### PR TITLE
feat: add Personal Infrastructure Command Center

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,12 @@ const AdminApiRegistry = lazy(() => import('./pages/admin/ApiRegistry'));
 // Prompt Library admin page
 const AdminPromptLibrary = lazy(() => import('./pages/admin/PromptLibrary'));
 
+// Command Center admin pages
+const AdminSkillsRegistry = lazy(() => import('./pages/admin/SkillsRegistry'));
+const AdminInfrastructureMap = lazy(() => import('./pages/admin/InfrastructureMap'));
+const AdminConfigVault = lazy(() => import('./pages/admin/ConfigVault'));
+const AdminRunbooks = lazy(() => import('./pages/admin/Runbooks'));
+
 // Site Builder admin pages (will be migrated to feature module)
 const SiteBuilderIndex = lazy(() => import('./pages/admin/site-builder/index'));
 const SiteBuilderEditor = lazy(() => import('./pages/admin/site-builder/editor'));
@@ -351,6 +357,11 @@ function AdminRoutes() {
           <Route path="/admin/apis" element={<AdminApiRegistry />} />
           {/* Prompt Library route */}
           <Route path="/admin/prompts" element={<AdminPromptLibrary />} />
+          {/* Command Center routes */}
+          <Route path="/admin/skills" element={<AdminSkillsRegistry />} />
+          <Route path="/admin/infrastructure" element={<AdminInfrastructureMap />} />
+          <Route path="/admin/configs" element={<AdminConfigVault />} />
+          <Route path="/admin/runbooks" element={<AdminRunbooks />} />
           {/* Marketing routes (legacy - will be migrated to feature module) */}
           <Route path="/admin/marketing" element={<AdminMarketing />} />
           <Route path="/admin/marketing/subscribers" element={<AdminMarketingSubscribers />} />

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -23,6 +23,10 @@ import {
   Sparkles,
   Cable,
   BookText,
+  Wrench,
+  Server,
+  FileCode2,
+  BookOpen,
 } from 'lucide-react';
 import { useAuth } from '@/lib/auth';
 import { UserButton } from '@clerk/clerk-react';
@@ -47,6 +51,10 @@ const sidebarItems = [
   { label: 'Metrics', path: '/admin/metrics', icon: BarChart3 },
   { label: 'Style Guide', path: '/admin/style', icon: Palette },
   { label: 'Prompts', path: '/admin/prompts', icon: BookText },
+  { label: 'Skills', path: '/admin/skills', icon: Wrench },
+  { label: 'Infrastructure', path: '/admin/infrastructure', icon: Server },
+  { label: 'Configs', path: '/admin/configs', icon: FileCode2 },
+  { label: 'Runbooks', path: '/admin/runbooks', icon: BookOpen },
   { label: 'APIs', path: '/admin/apis', icon: Cable },
   { label: 'Apps', path: '/admin/apps', icon: AppWindow },
   { label: 'Projects', path: '/admin/projects', icon: FolderKanban },

--- a/src/lib/configs-queries.ts
+++ b/src/lib/configs-queries.ts
@@ -1,0 +1,132 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabase } from './supabase';
+import { handleQueryResult } from './errors';
+import type {
+  Config,
+  ConfigCreate,
+  ConfigUpdate,
+  ConfigQueryOptions,
+} from './configs-schemas';
+
+export type {
+  Config,
+  ConfigCreate,
+  ConfigUpdate,
+  ConfigQueryOptions,
+};
+
+// ============================================
+// CONFIGS
+// ============================================
+
+export async function getConfigs(
+  options: ConfigQueryOptions = {},
+  client: SupabaseClient = getSupabase()
+) {
+  let query = client
+    .from('configs')
+    .select('*')
+    .order('updated_at', { ascending: false });
+
+  if (options.type) {
+    query = query.eq('type', options.type);
+  }
+
+  if (options.format) {
+    query = query.eq('format', options.format);
+  }
+
+  if (options.category) {
+    query = query.eq('category', options.category);
+  }
+
+  if (options.isActive !== undefined) {
+    query = query.eq('is_active', options.isActive);
+  }
+
+  if (options.tags && options.tags.length > 0) {
+    query = query.overlaps('tags', options.tags);
+  }
+
+  if (options.search) {
+    query = query.or(`name.ilike.%${options.search}%,description.ilike.%${options.search}%,source_path.ilike.%${options.search}%`);
+  }
+
+  if (options.limit) {
+    query = query.limit(options.limit);
+  }
+
+  if (options.offset) {
+    query = query.range(options.offset, options.offset + (options.limit || 50) - 1);
+  }
+
+  const { data, error } = await query;
+
+  return handleQueryResult(data, error, {
+    operation: 'getConfigs',
+    returnFallback: true,
+    fallback: [] as Config[],
+  });
+}
+
+export async function getConfigById(id: string, client: SupabaseClient = getSupabase()) {
+  const { data, error } = await client
+    .from('configs')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) throw error;
+  return data as Config;
+}
+
+export async function createConfig(
+  config: ConfigCreate,
+  client: SupabaseClient = getSupabase()
+) {
+  const { data, error } = await client
+    .from('configs')
+    .insert(config)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Config;
+}
+
+export async function updateConfig(
+  id: string,
+  updates: ConfigUpdate,
+  client: SupabaseClient = getSupabase()
+) {
+  const { data, error } = await client
+    .from('configs')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Config;
+}
+
+export async function deleteConfig(id: string, client: SupabaseClient = getSupabase()) {
+  const { error } = await client
+    .from('configs')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+}
+
+// ============================================
+// UTILITIES
+// ============================================
+
+export function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}

--- a/src/lib/configs-schemas.ts
+++ b/src/lib/configs-schemas.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+// ============================================
+// CONFIGS SCHEMAS
+// ============================================
+
+export const CONFIG_TYPES = ['file', 'snippet', 'setting', 'template'] as const;
+export const CONFIG_FORMATS = ['json', 'yaml', 'toml', 'javascript', 'typescript', 'markdown', 'text', 'env'] as const;
+export const CONFIG_CATEGORIES = ['build', 'lint', 'deploy', 'auth', 'database', 'styling', 'testing', 'other'] as const;
+
+export const ConfigSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  type: z.string(),
+  source_path: z.string().nullable(),
+  content: z.string().nullable(),
+  format: z.string(),
+  category: z.string(),
+  version: z.string().nullable(),
+  is_active: z.boolean(),
+  tags: z.array(z.string()).nullable().transform(v => v ?? []),
+  notes: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type Config = z.infer<typeof ConfigSchema>;
+
+export type ConfigCreate = Omit<Config, 'id' | 'created_at' | 'updated_at'>;
+
+export type ConfigUpdate = Partial<Omit<Config, 'id' | 'created_at'>>;
+
+// ============================================
+// QUERY OPTIONS
+// ============================================
+
+export interface ConfigQueryOptions {
+  type?: string;
+  format?: string;
+  category?: string;
+  isActive?: boolean;
+  search?: string;
+  tags?: string[];
+  limit?: number;
+  offset?: number;
+}

--- a/src/lib/infrastructure-queries.ts
+++ b/src/lib/infrastructure-queries.ts
@@ -1,0 +1,132 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabase } from './supabase';
+import { handleQueryResult } from './errors';
+import type {
+  InfraNode,
+  InfraNodeCreate,
+  InfraNodeUpdate,
+  InfraQueryOptions,
+} from './infrastructure-schemas';
+
+export type {
+  InfraNode,
+  InfraNodeCreate,
+  InfraNodeUpdate,
+  InfraQueryOptions,
+};
+
+// ============================================
+// INFRASTRUCTURE NODES
+// ============================================
+
+export async function getInfraNodes(
+  options: InfraQueryOptions = {},
+  client: SupabaseClient = getSupabase()
+) {
+  let query = client
+    .from('infrastructure_nodes')
+    .select('*')
+    .order('updated_at', { ascending: false });
+
+  if (options.type) {
+    query = query.eq('type', options.type);
+  }
+
+  if (options.provider) {
+    query = query.eq('provider', options.provider);
+  }
+
+  if (options.status) {
+    query = query.eq('status', options.status);
+  }
+
+  if (options.environment) {
+    query = query.eq('environment', options.environment);
+  }
+
+  if (options.tags && options.tags.length > 0) {
+    query = query.overlaps('tags', options.tags);
+  }
+
+  if (options.search) {
+    query = query.or(`name.ilike.%${options.search}%,description.ilike.%${options.search}%`);
+  }
+
+  if (options.limit) {
+    query = query.limit(options.limit);
+  }
+
+  if (options.offset) {
+    query = query.range(options.offset, options.offset + (options.limit || 50) - 1);
+  }
+
+  const { data, error } = await query;
+
+  return handleQueryResult(data, error, {
+    operation: 'getInfraNodes',
+    returnFallback: true,
+    fallback: [] as InfraNode[],
+  });
+}
+
+export async function getInfraNodeById(id: string, client: SupabaseClient = getSupabase()) {
+  const { data, error } = await client
+    .from('infrastructure_nodes')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) throw error;
+  return data as InfraNode;
+}
+
+export async function createInfraNode(
+  node: InfraNodeCreate,
+  client: SupabaseClient = getSupabase()
+) {
+  const { data, error } = await client
+    .from('infrastructure_nodes')
+    .insert(node)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as InfraNode;
+}
+
+export async function updateInfraNode(
+  id: string,
+  updates: InfraNodeUpdate,
+  client: SupabaseClient = getSupabase()
+) {
+  const { data, error } = await client
+    .from('infrastructure_nodes')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as InfraNode;
+}
+
+export async function deleteInfraNode(id: string, client: SupabaseClient = getSupabase()) {
+  const { error } = await client
+    .from('infrastructure_nodes')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+}
+
+// ============================================
+// UTILITIES
+// ============================================
+
+export function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}

--- a/src/lib/infrastructure-schemas.ts
+++ b/src/lib/infrastructure-schemas.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+// ============================================
+// INFRASTRUCTURE SCHEMAS
+// ============================================
+
+export const INFRA_TYPES = ['service', 'server', 'database', 'cdn', 'dns', 'domain', 'repository', 'ci-cd', 'monitoring'] as const;
+export const INFRA_PROVIDERS = ['netlify', 'supabase', 'github', 'cloudflare', 'sentry', 'clerk', 'ghost', 'vercel', 'aws', 'other'] as const;
+export const INFRA_STATUSES = ['active', 'degraded', 'inactive'] as const;
+export const INFRA_ENVIRONMENTS = ['production', 'staging', 'development'] as const;
+
+export const InfraNodeSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  type: z.string(),
+  provider: z.string(),
+  url: z.string().nullable(),
+  status: z.string(),
+  tier: z.string().nullable(),
+  region: z.string().nullable(),
+  config_notes: z.string().nullable(),
+  environment: z.string(),
+  connected_to: z.array(z.string()).nullable().transform(v => v ?? []),
+  monthly_cost: z.union([z.number(), z.string()]).nullable().transform(v => v !== null ? Number(v) : null),
+  tags: z.array(z.string()).nullable().transform(v => v ?? []),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type InfraNode = z.infer<typeof InfraNodeSchema>;
+
+export type InfraNodeCreate = Omit<InfraNode, 'id' | 'created_at' | 'updated_at'>;
+
+export type InfraNodeUpdate = Partial<Omit<InfraNode, 'id' | 'created_at'>>;
+
+// ============================================
+// QUERY OPTIONS
+// ============================================
+
+export interface InfraQueryOptions {
+  type?: string;
+  provider?: string;
+  status?: string;
+  environment?: string;
+  search?: string;
+  tags?: string[];
+  limit?: number;
+  offset?: number;
+}

--- a/src/lib/runbooks-queries.ts
+++ b/src/lib/runbooks-queries.ts
@@ -1,0 +1,139 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabase } from './supabase';
+import { handleQueryResult } from './errors';
+import type {
+  Runbook,
+  RunbookCreate,
+  RunbookUpdate,
+  RunbookQueryOptions,
+} from './runbooks-schemas';
+
+export type {
+  Runbook,
+  RunbookCreate,
+  RunbookUpdate,
+  RunbookQueryOptions,
+};
+
+// ============================================
+// RUNBOOKS
+// ============================================
+
+export async function getRunbooks(
+  options: RunbookQueryOptions = {},
+  client: SupabaseClient = getSupabase()
+) {
+  let query = client
+    .from('runbooks')
+    .select('*')
+    .order('updated_at', { ascending: false });
+
+  if (options.category) {
+    query = query.eq('category', options.category);
+  }
+
+  if (options.type) {
+    query = query.eq('type', options.type);
+  }
+
+  if (options.status) {
+    query = query.eq('status', options.status);
+  }
+
+  if (options.priority) {
+    query = query.eq('priority', options.priority);
+  }
+
+  if (options.tags && options.tags.length > 0) {
+    query = query.overlaps('tags', options.tags);
+  }
+
+  if (options.search) {
+    query = query.or(`title.ilike.%${options.search}%,content.ilike.%${options.search}%`);
+  }
+
+  if (options.limit) {
+    query = query.limit(options.limit);
+  }
+
+  if (options.offset) {
+    query = query.range(options.offset, options.offset + (options.limit || 50) - 1);
+  }
+
+  const { data, error } = await query;
+
+  return handleQueryResult(data, error, {
+    operation: 'getRunbooks',
+    returnFallback: true,
+    fallback: [] as Runbook[],
+  });
+}
+
+export async function getRunbookById(id: string, client: SupabaseClient = getSupabase()) {
+  const { data, error } = await client
+    .from('runbooks')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) throw error;
+  return data as Runbook;
+}
+
+export async function createRunbook(
+  runbook: RunbookCreate,
+  client: SupabaseClient = getSupabase()
+) {
+  const { data, error } = await client
+    .from('runbooks')
+    .insert(runbook)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Runbook;
+}
+
+export async function updateRunbook(
+  id: string,
+  updates: RunbookUpdate,
+  client: SupabaseClient = getSupabase()
+) {
+  const { data, error } = await client
+    .from('runbooks')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Runbook;
+}
+
+export async function deleteRunbook(id: string, client: SupabaseClient = getSupabase()) {
+  const { error } = await client
+    .from('runbooks')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+}
+
+// ============================================
+// UTILITIES
+// ============================================
+
+export function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+export function markAsReviewed(
+  id: string,
+  client: SupabaseClient = getSupabase()
+) {
+  return updateRunbook(id, { last_reviewed_at: new Date().toISOString() }, client);
+}

--- a/src/lib/runbooks-schemas.ts
+++ b/src/lib/runbooks-schemas.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+// ============================================
+// RUNBOOKS SCHEMAS
+// ============================================
+
+export const RUNBOOK_CATEGORIES = ['deployment', 'troubleshooting', 'onboarding', 'security', 'maintenance', 'architecture', 'api', 'other'] as const;
+export const RUNBOOK_TYPES = ['runbook', 'guide', 'reference', 'decision-record'] as const;
+export const RUNBOOK_STATUSES = ['current', 'outdated', 'draft'] as const;
+export const RUNBOOK_PRIORITIES = ['critical', 'high', 'normal', 'low'] as const;
+
+export const RunbookSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  slug: z.string(),
+  content: z.string().nullable(),
+  category: z.string(),
+  type: z.string(),
+  status: z.string(),
+  priority: z.string(),
+  related_skills: z.array(z.string()).nullable().transform(v => v ?? []),
+  related_infra: z.array(z.string()).nullable().transform(v => v ?? []),
+  tags: z.array(z.string()).nullable().transform(v => v ?? []),
+  last_reviewed_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type Runbook = z.infer<typeof RunbookSchema>;
+
+export type RunbookCreate = Omit<Runbook, 'id' | 'created_at' | 'updated_at'>;
+
+export type RunbookUpdate = Partial<Omit<Runbook, 'id' | 'created_at'>>;
+
+// ============================================
+// QUERY OPTIONS
+// ============================================
+
+export interface RunbookQueryOptions {
+  category?: string;
+  type?: string;
+  status?: string;
+  priority?: string;
+  search?: string;
+  tags?: string[];
+  limit?: number;
+  offset?: number;
+}

--- a/src/lib/skills-queries.ts
+++ b/src/lib/skills-queries.ts
@@ -1,0 +1,128 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabase } from './supabase';
+import { handleQueryResult } from './errors';
+import type {
+  Skill,
+  SkillCreate,
+  SkillUpdate,
+  SkillQueryOptions,
+} from './skills-schemas';
+
+export type {
+  Skill,
+  SkillCreate,
+  SkillUpdate,
+  SkillQueryOptions,
+};
+
+// ============================================
+// SKILLS
+// ============================================
+
+export async function getSkills(
+  options: SkillQueryOptions = {},
+  client: SupabaseClient = getSupabase()
+) {
+  let query = client
+    .from('skills')
+    .select('*')
+    .order('updated_at', { ascending: false });
+
+  if (options.type) {
+    query = query.eq('type', options.type);
+  }
+
+  if (options.category) {
+    query = query.eq('category', options.category);
+  }
+
+  if (options.status) {
+    query = query.eq('status', options.status);
+  }
+
+  if (options.tags && options.tags.length > 0) {
+    query = query.overlaps('tags', options.tags);
+  }
+
+  if (options.search) {
+    query = query.or(`name.ilike.%${options.search}%,description.ilike.%${options.search}%,invocation.ilike.%${options.search}%`);
+  }
+
+  if (options.limit) {
+    query = query.limit(options.limit);
+  }
+
+  if (options.offset) {
+    query = query.range(options.offset, options.offset + (options.limit || 50) - 1);
+  }
+
+  const { data, error } = await query;
+
+  return handleQueryResult(data, error, {
+    operation: 'getSkills',
+    returnFallback: true,
+    fallback: [] as Skill[],
+  });
+}
+
+export async function getSkillById(id: string, client: SupabaseClient = getSupabase()) {
+  const { data, error } = await client
+    .from('skills')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) throw error;
+  return data as Skill;
+}
+
+export async function createSkill(
+  skill: SkillCreate,
+  client: SupabaseClient = getSupabase()
+) {
+  const { data, error } = await client
+    .from('skills')
+    .insert(skill)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Skill;
+}
+
+export async function updateSkill(
+  id: string,
+  updates: SkillUpdate,
+  client: SupabaseClient = getSupabase()
+) {
+  const { data, error } = await client
+    .from('skills')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Skill;
+}
+
+export async function deleteSkill(id: string, client: SupabaseClient = getSupabase()) {
+  const { error } = await client
+    .from('skills')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+}
+
+// ============================================
+// UTILITIES
+// ============================================
+
+export function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}

--- a/src/lib/skills-schemas.ts
+++ b/src/lib/skills-schemas.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+// ============================================
+// SKILLS SCHEMAS
+// ============================================
+
+export const SKILL_TYPES = ['skill', 'agent', 'mcp-server', 'script', 'automation'] as const;
+export const SKILL_CATEGORIES = ['development', 'deployment', 'testing', 'content', 'data', 'other'] as const;
+export const SKILL_STATUSES = ['active', 'inactive', 'draft'] as const;
+
+export const SkillSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullable(),
+  type: z.string(),
+  source: z.string().nullable(),
+  invocation: z.string().nullable(),
+  category: z.string(),
+  dependencies: z.array(z.string()).nullable().transform(v => v ?? []),
+  status: z.string(),
+  tags: z.array(z.string()).nullable().transform(v => v ?? []),
+  notes: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type Skill = z.infer<typeof SkillSchema>;
+
+export type SkillCreate = Omit<Skill, 'id' | 'created_at' | 'updated_at'>;
+
+export type SkillUpdate = Partial<Omit<Skill, 'id' | 'created_at'>>;
+
+// ============================================
+// QUERY OPTIONS
+// ============================================
+
+export interface SkillQueryOptions {
+  type?: string;
+  category?: string;
+  status?: string;
+  search?: string;
+  tags?: string[];
+  limit?: number;
+  offset?: number;
+}

--- a/src/pages/admin/ConfigVault.tsx
+++ b/src/pages/admin/ConfigVault.tsx
@@ -1,0 +1,500 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  FileCode2,
+  Plus,
+  Search,
+  Trash2,
+  X,
+  Pencil,
+  Loader2,
+  FileText,
+  Code2,
+  CheckCircle2,
+  XCircle,
+} from 'lucide-react';
+import AdminLayout from '@/components/AdminLayout';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useSEO } from '@/lib/seo';
+import { useAuthenticatedSupabase } from '@/lib/supabase';
+import {
+  getConfigs,
+  createConfig,
+  updateConfig,
+  deleteConfig,
+  generateSlug,
+} from '@/lib/configs-queries';
+import type { Config, ConfigCreate, ConfigQueryOptions } from '@/lib/configs-schemas';
+import { CONFIG_TYPES, CONFIG_FORMATS, CONFIG_CATEGORIES } from '@/lib/configs-schemas';
+
+// ============================================
+// MODAL COMPONENT
+// ============================================
+
+interface ConfigModalProps {
+  config: Config | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: ConfigCreate | { id: string } & Partial<Config>) => Promise<void>;
+  onDelete?: (id: string) => Promise<void>;
+}
+
+function ConfigModal({ config, isOpen, onClose, onSave, onDelete }: ConfigModalProps) {
+  const isEdit = !!config;
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [description, setDescription] = useState('');
+  const [type, setType] = useState<string>('file');
+  const [sourcePath, setSourcePath] = useState('');
+  const [content, setContent] = useState('');
+  const [format, setFormat] = useState<string>('text');
+  const [category, setCategory] = useState<string>('other');
+  const [version, setVersion] = useState('');
+  const [isActive, setIsActive] = useState(true);
+  const [tagsInput, setTagsInput] = useState('');
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  useEffect(() => {
+    if (config) {
+      setName(config.name);
+      setSlug(config.slug);
+      setDescription(config.description ?? '');
+      setType(config.type);
+      setSourcePath(config.source_path ?? '');
+      setContent(config.content ?? '');
+      setFormat(config.format);
+      setCategory(config.category);
+      setVersion(config.version ?? '');
+      setIsActive(config.is_active);
+      setTagsInput((config.tags ?? []).join(', '));
+      setNotes(config.notes ?? '');
+    } else {
+      setName('');
+      setSlug('');
+      setDescription('');
+      setType('file');
+      setSourcePath('');
+      setContent('');
+      setFormat('text');
+      setCategory('other');
+      setVersion('');
+      setIsActive(true);
+      setTagsInput('');
+      setNotes('');
+    }
+    setConfirmDelete(false);
+  }, [config, isOpen]);
+
+  const handleNameChange = (val: string) => {
+    setName(val);
+    if (!isEdit) {
+      setSlug(generateSlug(val));
+    }
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      const tags = tagsInput.split(',').map(t => t.trim()).filter(Boolean);
+      const data = {
+        name: name.trim(),
+        slug: slug.trim() || generateSlug(name),
+        description: description.trim() || null,
+        type,
+        source_path: sourcePath.trim() || null,
+        content: content || null,
+        format,
+        category,
+        version: version.trim() || null,
+        is_active: isActive,
+        tags,
+        notes: notes.trim() || null,
+      };
+      if (isEdit && config) {
+        await onSave({ id: config.id, ...data });
+      } else {
+        await onSave(data as ConfigCreate);
+      }
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!config || !onDelete) return;
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setDeleting(true);
+    try {
+      await onDelete(config.id);
+      onClose();
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center p-4 pt-20 overflow-y-auto"
+        onClick={(e) => e.target === e.currentTarget && onClose()}
+      >
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          className="bg-card border border-border rounded-xl w-full max-w-2xl shadow-lg mb-8"
+        >
+          <div className="flex items-center justify-between p-6 border-b border-border">
+            <h2 className="text-lg font-semibold text-foreground">
+              {isEdit ? 'Edit Config' : 'New Config'}
+            </h2>
+            <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+
+          <div className="p-6 space-y-4">
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Name</label>
+              <Input value={name} onChange={e => handleNameChange(e.target.value)} placeholder="ESLint Config" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Slug</label>
+              <Input value={slug} onChange={e => setSlug(e.target.value)} placeholder="eslint-config" className="font-mono text-sm" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Description</label>
+              <Input value={description} onChange={e => setDescription(e.target.value)} placeholder="What this config is for" />
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Type</label>
+                <select value={type} onChange={e => setType(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {CONFIG_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Format</label>
+                <select value={format} onChange={e => setFormat(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {CONFIG_FORMATS.map(f => <option key={f} value={f}>{f}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Category</label>
+                <select value={category} onChange={e => setCategory(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {CONFIG_CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Source Path</label>
+                <Input value={sourcePath} onChange={e => setSourcePath(e.target.value)} placeholder="e.g., eslint.config.js" className="font-mono text-sm" />
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Version</label>
+                <Input value={version} onChange={e => setVersion(e.target.value)} placeholder="e.g., 1.0.0" />
+              </div>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Content</label>
+              <textarea
+                value={content}
+                onChange={e => setContent(e.target.value)}
+                placeholder="Paste config content here..."
+                rows={8}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+              />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Tags (comma-separated)</label>
+              <Input value={tagsInput} onChange={e => setTagsInput(e.target.value)} placeholder="eslint, linting, code-quality" />
+            </div>
+
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input type="checkbox" checked={isActive} onChange={e => setIsActive(e.target.checked)} className="rounded border-input" />
+              <span className="text-sm text-foreground">Active</span>
+            </label>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Notes (markdown)</label>
+              <textarea
+                value={notes}
+                onChange={e => setNotes(e.target.value)}
+                placeholder="Additional notes..."
+                rows={3}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between p-6 border-t border-border">
+            <div>
+              {isEdit && onDelete && (
+                <Button
+                  variant="ghost"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className={confirmDelete ? 'text-destructive hover:text-destructive' : 'text-muted-foreground'}
+                >
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  {deleting ? 'Deleting...' : confirmDelete ? 'Confirm Delete' : 'Delete'}
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="ghost" onClick={onClose}>Cancel</Button>
+              <Button onClick={handleSave} disabled={saving || !name.trim()}>
+                {saving ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : null}
+                {isEdit ? 'Save Changes' : 'Create Config'}
+              </Button>
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+// ============================================
+// MAIN PAGE
+// ============================================
+
+function ConfigVault() {
+  useSEO({ title: 'Config Vault', noIndex: true });
+
+  const { supabase, isLoading: authLoading } = useAuthenticatedSupabase();
+  const [configs, setConfigs] = useState<Config[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [formatFilter, setFormatFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [activeFilter, setActiveFilter] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingConfig, setEditingConfig] = useState<Config | null>(null);
+
+  const fetchConfigs = useCallback(async () => {
+    if (!supabase) return;
+    setLoading(true);
+    try {
+      const options: ConfigQueryOptions = {};
+      if (search) options.search = search;
+      if (typeFilter) options.type = typeFilter;
+      if (formatFilter) options.format = formatFilter;
+      if (categoryFilter) options.category = categoryFilter;
+      if (activeFilter) options.isActive = true;
+      const data = await getConfigs(options, supabase);
+      setConfigs(data);
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase, search, typeFilter, formatFilter, categoryFilter, activeFilter]);
+
+  useEffect(() => {
+    if (!authLoading && supabase) {
+      fetchConfigs();
+    }
+  }, [authLoading, supabase, fetchConfigs]);
+
+  const handleSave = async (data: ConfigCreate | ({ id: string } & Partial<Config>)) => {
+    if (!supabase) return;
+    if ('id' in data) {
+      const { id, ...updates } = data;
+      await updateConfig(id, updates, supabase);
+    } else {
+      await createConfig(data, supabase);
+    }
+    await fetchConfigs();
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!supabase) return;
+    await deleteConfig(id, supabase);
+    await fetchConfigs();
+  };
+
+  const openNew = () => { setEditingConfig(null); setModalOpen(true); };
+  const openEdit = (config: Config) => { setEditingConfig(config); setModalOpen(true); };
+
+  const stats = useMemo(() => ({
+    total: configs.length,
+    active: configs.filter(c => c.is_active).length,
+    files: configs.filter(c => c.type === 'file').length,
+    snippets: configs.filter(c => c.type === 'snippet').length,
+  }), [configs]);
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  };
+
+  if (authLoading) {
+    return (
+      <AdminLayout>
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <div className="max-w-6xl mx-auto space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <FileCode2 className="w-6 h-6 text-primary" />
+            <h1 className="text-2xl font-bold text-foreground">Config Vault</h1>
+          </div>
+          <Button onClick={openNew}>
+            <Plus className="w-4 h-4 mr-1" /> New Config
+          </Button>
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          {[
+            { label: 'Total', value: stats.total, icon: FileCode2 },
+            { label: 'Active', value: stats.active, icon: CheckCircle2 },
+            { label: 'Files', value: stats.files, icon: FileText },
+            { label: 'Snippets', value: stats.snippets, icon: Code2 },
+          ].map(({ label, value, icon: Icon }) => (
+            <div key={label} className="bg-card border border-border rounded-lg p-4 flex items-center gap-3">
+              <Icon className="w-5 h-5 text-muted-foreground" />
+              <div>
+                <div className="text-2xl font-bold text-foreground">{value}</div>
+                <div className="text-xs text-muted-foreground">{label}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search configs..." className="pl-9" />
+          </div>
+          <select value={typeFilter} onChange={e => setTypeFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Types</option>
+            {CONFIG_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+          <select value={formatFilter} onChange={e => setFormatFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Formats</option>
+            {CONFIG_FORMATS.map(f => <option key={f} value={f}>{f}</option>)}
+          </select>
+          <select value={categoryFilter} onChange={e => setCategoryFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Categories</option>
+            {CONFIG_CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+          </select>
+          <Button
+            variant={activeFilter ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setActiveFilter(prev => !prev)}
+            className="h-9"
+          >
+            <CheckCircle2 className="w-4 h-4 mr-1" />
+            Active Only
+          </Button>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-6 h-6 animate-spin text-primary" />
+          </div>
+        ) : configs.length === 0 ? (
+          <div className="text-center py-20">
+            <FileCode2 className="w-12 h-12 mx-auto text-muted-foreground/40 mb-4" />
+            <h3 className="text-lg font-medium text-foreground mb-1">No configs yet</h3>
+            <p className="text-muted-foreground mb-4">Store your first configuration to get started.</p>
+            <Button onClick={openNew}>
+              <Plus className="w-4 h-4 mr-1" /> Create Config
+            </Button>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {configs.map((config, index) => (
+              <motion.div
+                key={config.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.03 }}
+                className="bg-card border border-border rounded-lg p-5 hover:border-primary/30 transition-colors group"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      {config.is_active ? (
+                        <CheckCircle2 className="w-4 h-4 text-green-400 flex-shrink-0" />
+                      ) : (
+                        <XCircle className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+                      )}
+                      <button onClick={() => openEdit(config)} className="text-foreground font-semibold hover:text-primary transition-colors text-left truncate">
+                        {config.name}
+                      </button>
+                      <Badge variant="secondary" className="text-[10px]">{config.format}</Badge>
+                      <Badge variant="outline" className="text-[10px]">{config.category}</Badge>
+                      <Badge className="text-[10px] bg-purple-500/10 text-purple-400 border-purple-500/20">{config.type}</Badge>
+                    </div>
+
+                    {config.description && (
+                      <p className="text-sm text-muted-foreground mb-2 line-clamp-1">{config.description}</p>
+                    )}
+
+                    <div className="flex items-center gap-2 flex-wrap">
+                      {config.source_path && (
+                        <span className="text-[10px] font-mono text-primary/70">{config.source_path}</span>
+                      )}
+                      {config.version && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400 border border-blue-500/20">v{config.version}</span>
+                      )}
+                      {(config.tags ?? []).slice(0, 5).map(tag => (
+                        <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{tag}</span>
+                      ))}
+                      <span className="text-[10px] text-muted-foreground">{formatDate(config.updated_at)}</span>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button onClick={() => openEdit(config)} className="p-1.5 rounded hover:bg-muted transition-colors" title="Edit">
+                      <Pencil className="w-4 h-4 text-muted-foreground" />
+                    </button>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <ConfigModal
+        config={editingConfig}
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSave={handleSave}
+        onDelete={handleDelete}
+      />
+    </AdminLayout>
+  );
+}
+
+export default ConfigVault;

--- a/src/pages/admin/InfrastructureMap.tsx
+++ b/src/pages/admin/InfrastructureMap.tsx
@@ -1,0 +1,563 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Server,
+  Plus,
+  Search,
+  Trash2,
+  X,
+  Pencil,
+  Loader2,
+  Activity,
+  DollarSign,
+  Link2,
+  ExternalLink,
+} from 'lucide-react';
+import AdminLayout from '@/components/AdminLayout';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useSEO } from '@/lib/seo';
+import { useAuthenticatedSupabase } from '@/lib/supabase';
+import {
+  getInfraNodes,
+  createInfraNode,
+  updateInfraNode,
+  deleteInfraNode,
+  generateSlug,
+} from '@/lib/infrastructure-queries';
+import type { InfraNode, InfraNodeCreate, InfraQueryOptions } from '@/lib/infrastructure-schemas';
+import { INFRA_TYPES, INFRA_PROVIDERS, INFRA_STATUSES, INFRA_ENVIRONMENTS } from '@/lib/infrastructure-schemas';
+
+// ============================================
+// STATUS HELPERS
+// ============================================
+
+const statusColors: Record<string, string> = {
+  active: 'bg-green-500/10 text-green-400 border-green-500/20',
+  degraded: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  inactive: 'bg-red-500/10 text-red-400 border-red-500/20',
+};
+
+// ============================================
+// MODAL COMPONENT
+// ============================================
+
+interface InfraModalProps {
+  node: InfraNode | null;
+  allNodes: InfraNode[];
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: InfraNodeCreate | { id: string } & Partial<InfraNode>) => Promise<void>;
+  onDelete?: (id: string) => Promise<void>;
+}
+
+function InfraModal({ node, allNodes, isOpen, onClose, onSave, onDelete }: InfraModalProps) {
+  const isEdit = !!node;
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [description, setDescription] = useState('');
+  const [type, setType] = useState<string>('service');
+  const [provider, setProvider] = useState<string>('other');
+  const [url, setUrl] = useState('');
+  const [status, setStatus] = useState<string>('active');
+  const [tier, setTier] = useState('');
+  const [region, setRegion] = useState('');
+  const [configNotes, setConfigNotes] = useState('');
+  const [environment, setEnvironment] = useState<string>('production');
+  const [connectedTo, setConnectedTo] = useState<string[]>([]);
+  const [monthlyCost, setMonthlyCost] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  useEffect(() => {
+    if (node) {
+      setName(node.name);
+      setSlug(node.slug);
+      setDescription(node.description ?? '');
+      setType(node.type);
+      setProvider(node.provider);
+      setUrl(node.url ?? '');
+      setStatus(node.status);
+      setTier(node.tier ?? '');
+      setRegion(node.region ?? '');
+      setConfigNotes(node.config_notes ?? '');
+      setEnvironment(node.environment);
+      setConnectedTo(node.connected_to ?? []);
+      setMonthlyCost(node.monthly_cost !== null ? String(node.monthly_cost) : '');
+      setTagsInput((node.tags ?? []).join(', '));
+    } else {
+      setName('');
+      setSlug('');
+      setDescription('');
+      setType('service');
+      setProvider('other');
+      setUrl('');
+      setStatus('active');
+      setTier('');
+      setRegion('');
+      setConfigNotes('');
+      setEnvironment('production');
+      setConnectedTo([]);
+      setMonthlyCost('');
+      setTagsInput('');
+    }
+    setConfirmDelete(false);
+  }, [node, isOpen]);
+
+  const handleNameChange = (val: string) => {
+    setName(val);
+    if (!isEdit) {
+      setSlug(generateSlug(val));
+    }
+  };
+
+  const toggleConnection = (id: string) => {
+    setConnectedTo(prev =>
+      prev.includes(id) ? prev.filter(c => c !== id) : [...prev, id]
+    );
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      const tags = tagsInput.split(',').map(t => t.trim()).filter(Boolean);
+      const data = {
+        name: name.trim(),
+        slug: slug.trim() || generateSlug(name),
+        description: description.trim() || null,
+        type,
+        provider,
+        url: url.trim() || null,
+        status,
+        tier: tier.trim() || null,
+        region: region.trim() || null,
+        config_notes: configNotes.trim() || null,
+        environment,
+        connected_to: connectedTo,
+        monthly_cost: monthlyCost ? parseFloat(monthlyCost) : null,
+        tags,
+      };
+      if (isEdit && node) {
+        await onSave({ id: node.id, ...data });
+      } else {
+        await onSave(data as InfraNodeCreate);
+      }
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!node || !onDelete) return;
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setDeleting(true);
+    try {
+      await onDelete(node.id);
+      onClose();
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  // Available nodes for connections (exclude self)
+  const availableNodes = allNodes.filter(n => n.id !== node?.id);
+
+  if (!isOpen) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center p-4 pt-20 overflow-y-auto"
+        onClick={(e) => e.target === e.currentTarget && onClose()}
+      >
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          className="bg-card border border-border rounded-xl w-full max-w-2xl shadow-lg mb-8"
+        >
+          <div className="flex items-center justify-between p-6 border-b border-border">
+            <h2 className="text-lg font-semibold text-foreground">
+              {isEdit ? 'Edit Infrastructure Node' : 'New Infrastructure Node'}
+            </h2>
+            <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+
+          <div className="p-6 space-y-4">
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Name</label>
+              <Input value={name} onChange={e => handleNameChange(e.target.value)} placeholder="Netlify Production" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Slug</label>
+              <Input value={slug} onChange={e => setSlug(e.target.value)} placeholder="netlify-production" className="font-mono text-sm" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Description</label>
+              <Input value={description} onChange={e => setDescription(e.target.value)} placeholder="Production hosting for mejohnc.org" />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Type</label>
+                <select value={type} onChange={e => setType(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {INFRA_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Provider</label>
+                <select value={provider} onChange={e => setProvider(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {INFRA_PROVIDERS.map(p => <option key={p} value={p}>{p}</option>)}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Status</label>
+                <select value={status} onChange={e => setStatus(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {INFRA_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Environment</label>
+                <select value={environment} onChange={e => setEnvironment(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {INFRA_ENVIRONMENTS.map(e => <option key={e} value={e}>{e}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Monthly Cost ($)</label>
+                <Input value={monthlyCost} onChange={e => setMonthlyCost(e.target.value)} placeholder="0.00" type="number" step="0.01" />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Tier</label>
+                <Input value={tier} onChange={e => setTier(e.target.value)} placeholder="e.g., Free, Pro, Enterprise" />
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Region</label>
+                <Input value={region} onChange={e => setRegion(e.target.value)} placeholder="e.g., us-east-1" />
+              </div>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">URL</label>
+              <Input value={url} onChange={e => setUrl(e.target.value)} placeholder="https://..." className="font-mono text-sm" />
+            </div>
+
+            {availableNodes.length > 0 && (
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Connected To</label>
+                <div className="flex flex-wrap gap-2 p-3 border border-border rounded-lg max-h-32 overflow-y-auto">
+                  {availableNodes.map(n => (
+                    <button
+                      key={n.id}
+                      type="button"
+                      onClick={() => toggleConnection(n.id)}
+                      className={`text-xs px-2 py-1 rounded-full border transition-colors ${
+                        connectedTo.includes(n.id)
+                          ? 'bg-primary/10 text-primary border-primary/30'
+                          : 'bg-muted text-muted-foreground border-border hover:border-primary/30'
+                      }`}
+                    >
+                      {n.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Tags (comma-separated)</label>
+              <Input value={tagsInput} onChange={e => setTagsInput(e.target.value)} placeholder="hosting, production, cdn" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Config Notes (markdown)</label>
+              <textarea
+                value={configNotes}
+                onChange={e => setConfigNotes(e.target.value)}
+                placeholder="Configuration notes..."
+                rows={4}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between p-6 border-t border-border">
+            <div>
+              {isEdit && onDelete && (
+                <Button
+                  variant="ghost"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className={confirmDelete ? 'text-destructive hover:text-destructive' : 'text-muted-foreground'}
+                >
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  {deleting ? 'Deleting...' : confirmDelete ? 'Confirm Delete' : 'Delete'}
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="ghost" onClick={onClose}>Cancel</Button>
+              <Button onClick={handleSave} disabled={saving || !name.trim()}>
+                {saving ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : null}
+                {isEdit ? 'Save Changes' : 'Create Node'}
+              </Button>
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+// ============================================
+// MAIN PAGE
+// ============================================
+
+function InfrastructureMap() {
+  useSEO({ title: 'Infrastructure Map', noIndex: true });
+
+  const { supabase, isLoading: authLoading } = useAuthenticatedSupabase();
+  const [nodes, setNodes] = useState<InfraNode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [providerFilter, setProviderFilter] = useState('');
+  const [envFilter, setEnvFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingNode, setEditingNode] = useState<InfraNode | null>(null);
+
+  const fetchNodes = useCallback(async () => {
+    if (!supabase) return;
+    setLoading(true);
+    try {
+      const options: InfraQueryOptions = {};
+      if (search) options.search = search;
+      if (typeFilter) options.type = typeFilter;
+      if (providerFilter) options.provider = providerFilter;
+      if (envFilter) options.environment = envFilter;
+      if (statusFilter) options.status = statusFilter;
+      const data = await getInfraNodes(options, supabase);
+      setNodes(data);
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase, search, typeFilter, providerFilter, envFilter, statusFilter]);
+
+  useEffect(() => {
+    if (!authLoading && supabase) {
+      fetchNodes();
+    }
+  }, [authLoading, supabase, fetchNodes]);
+
+  const handleSave = async (data: InfraNodeCreate | ({ id: string } & Partial<InfraNode>)) => {
+    if (!supabase) return;
+    if ('id' in data) {
+      const { id, ...updates } = data;
+      await updateInfraNode(id, updates, supabase);
+    } else {
+      await createInfraNode(data, supabase);
+    }
+    await fetchNodes();
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!supabase) return;
+    await deleteInfraNode(id, supabase);
+    await fetchNodes();
+  };
+
+  const openNew = () => { setEditingNode(null); setModalOpen(true); };
+  const openEdit = (node: InfraNode) => { setEditingNode(node); setModalOpen(true); };
+
+  const stats = useMemo(() => {
+    const totalCost = nodes.reduce((sum, n) => sum + (n.monthly_cost ?? 0), 0);
+    const uniqueProviders = new Set(nodes.map(n => n.provider));
+    return {
+      total: nodes.length,
+      active: nodes.filter(n => n.status === 'active').length,
+      monthlyCost: totalCost,
+      providers: uniqueProviders.size,
+    };
+  }, [nodes]);
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  };
+
+  const getNodeName = (id: string) => {
+    return nodes.find(n => n.id === id)?.name ?? 'Unknown';
+  };
+
+  if (authLoading) {
+    return (
+      <AdminLayout>
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <div className="max-w-6xl mx-auto space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Server className="w-6 h-6 text-primary" />
+            <h1 className="text-2xl font-bold text-foreground">Infrastructure Map</h1>
+          </div>
+          <Button onClick={openNew}>
+            <Plus className="w-4 h-4 mr-1" /> New Node
+          </Button>
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          {[
+            { label: 'Total Nodes', value: stats.total, icon: Server },
+            { label: 'Active', value: stats.active, icon: Activity },
+            { label: 'Monthly Cost', value: `$${stats.monthlyCost.toFixed(2)}`, icon: DollarSign },
+            { label: 'Providers', value: stats.providers, icon: Link2 },
+          ].map(({ label, value, icon: Icon }) => (
+            <div key={label} className="bg-card border border-border rounded-lg p-4 flex items-center gap-3">
+              <Icon className="w-5 h-5 text-muted-foreground" />
+              <div>
+                <div className="text-2xl font-bold text-foreground">{value}</div>
+                <div className="text-xs text-muted-foreground">{label}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search infrastructure..." className="pl-9" />
+          </div>
+          <select value={typeFilter} onChange={e => setTypeFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Types</option>
+            {INFRA_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+          <select value={providerFilter} onChange={e => setProviderFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Providers</option>
+            {INFRA_PROVIDERS.map(p => <option key={p} value={p}>{p}</option>)}
+          </select>
+          <select value={envFilter} onChange={e => setEnvFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Environments</option>
+            {INFRA_ENVIRONMENTS.map(e => <option key={e} value={e}>{e}</option>)}
+          </select>
+          <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Statuses</option>
+            {INFRA_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-6 h-6 animate-spin text-primary" />
+          </div>
+        ) : nodes.length === 0 ? (
+          <div className="text-center py-20">
+            <Server className="w-12 h-12 mx-auto text-muted-foreground/40 mb-4" />
+            <h3 className="text-lg font-medium text-foreground mb-1">No infrastructure nodes yet</h3>
+            <p className="text-muted-foreground mb-4">Map your first infrastructure node to get started.</p>
+            <Button onClick={openNew}>
+              <Plus className="w-4 h-4 mr-1" /> Create Node
+            </Button>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {nodes.map((node, index) => (
+              <motion.div
+                key={node.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.03 }}
+                className="bg-card border border-border rounded-lg p-5 hover:border-primary/30 transition-colors group"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <button onClick={() => openEdit(node)} className="text-foreground font-semibold hover:text-primary transition-colors text-left truncate">
+                        {node.name}
+                      </button>
+                      <Badge variant="secondary" className="text-[10px]">{node.provider}</Badge>
+                      <Badge variant="outline" className="text-[10px]">{node.type}</Badge>
+                      <Badge className={`text-[10px] ${statusColors[node.status] ?? ''}`}>{node.status}</Badge>
+                      <Badge className="text-[10px] bg-purple-500/10 text-purple-400 border-purple-500/20">{node.environment}</Badge>
+                    </div>
+
+                    {node.description && (
+                      <p className="text-sm text-muted-foreground mb-2 line-clamp-1">{node.description}</p>
+                    )}
+
+                    <div className="flex items-center gap-2 flex-wrap">
+                      {node.tier && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400 border border-blue-500/20">{node.tier}</span>
+                      )}
+                      {node.monthly_cost !== null && node.monthly_cost > 0 && (
+                        <span className="text-[10px] text-muted-foreground">${node.monthly_cost}/mo</span>
+                      )}
+                      {(node.connected_to ?? []).length > 0 && (
+                        <span className="text-[10px] text-muted-foreground">
+                          <Link2 className="w-3 h-3 inline mr-0.5" />
+                          {(node.connected_to ?? []).map(id => getNodeName(id)).join(', ')}
+                        </span>
+                      )}
+                      {node.url && (
+                        <a href={node.url} target="_blank" rel="noopener noreferrer" className="text-[10px] text-primary hover:underline inline-flex items-center gap-0.5">
+                          <ExternalLink className="w-3 h-3" /> Link
+                        </a>
+                      )}
+                      {(node.tags ?? []).slice(0, 3).map(tag => (
+                        <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{tag}</span>
+                      ))}
+                      <span className="text-[10px] text-muted-foreground">{formatDate(node.updated_at)}</span>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button onClick={() => openEdit(node)} className="p-1.5 rounded hover:bg-muted transition-colors" title="Edit">
+                      <Pencil className="w-4 h-4 text-muted-foreground" />
+                    </button>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <InfraModal
+        node={editingNode}
+        allNodes={nodes}
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSave={handleSave}
+        onDelete={handleDelete}
+      />
+    </AdminLayout>
+  );
+}
+
+export default InfrastructureMap;

--- a/src/pages/admin/Runbooks.tsx
+++ b/src/pages/admin/Runbooks.tsx
@@ -1,0 +1,605 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import ReactMarkdown from 'react-markdown';
+import {
+  BookOpen,
+  Plus,
+  Search,
+  Trash2,
+  X,
+  Pencil,
+  Loader2,
+  AlertTriangle,
+  Clock,
+  CheckCircle2,
+  Eye,
+  Edit3,
+} from 'lucide-react';
+import AdminLayout from '@/components/AdminLayout';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useSEO } from '@/lib/seo';
+import { useAuthenticatedSupabase } from '@/lib/supabase';
+import {
+  getRunbooks,
+  createRunbook,
+  updateRunbook,
+  deleteRunbook,
+  generateSlug,
+} from '@/lib/runbooks-queries';
+import type { Runbook, RunbookCreate, RunbookQueryOptions } from '@/lib/runbooks-schemas';
+import { RUNBOOK_CATEGORIES, RUNBOOK_TYPES, RUNBOOK_STATUSES, RUNBOOK_PRIORITIES } from '@/lib/runbooks-schemas';
+import { getSkills } from '@/lib/skills-queries';
+import type { Skill } from '@/lib/skills-schemas';
+import { getInfraNodes } from '@/lib/infrastructure-queries';
+import type { InfraNode } from '@/lib/infrastructure-schemas';
+
+// ============================================
+// STATUS/PRIORITY HELPERS
+// ============================================
+
+const statusColors: Record<string, string> = {
+  current: 'bg-green-500/10 text-green-400 border-green-500/20',
+  outdated: 'bg-red-500/10 text-red-400 border-red-500/20',
+  draft: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+};
+
+const priorityColors: Record<string, string> = {
+  critical: 'bg-red-500/10 text-red-400 border-red-500/20',
+  high: 'bg-orange-500/10 text-orange-400 border-orange-500/20',
+  normal: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  low: 'bg-gray-500/10 text-gray-400 border-gray-500/20',
+};
+
+// ============================================
+// MODAL COMPONENT
+// ============================================
+
+interface RunbookModalProps {
+  runbook: Runbook | null;
+  skills: Skill[];
+  infraNodes: InfraNode[];
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: RunbookCreate | { id: string } & Partial<Runbook>) => Promise<void>;
+  onDelete?: (id: string) => Promise<void>;
+}
+
+function RunbookModal({ runbook, skills, infraNodes, isOpen, onClose, onSave, onDelete }: RunbookModalProps) {
+  const isEdit = !!runbook;
+  const [title, setTitle] = useState('');
+  const [slug, setSlug] = useState('');
+  const [content, setContent] = useState('');
+  const [category, setCategory] = useState<string>('other');
+  const [type, setType] = useState<string>('runbook');
+  const [status, setStatus] = useState<string>('draft');
+  const [priority, setPriority] = useState<string>('normal');
+  const [relatedSkills, setRelatedSkills] = useState<string[]>([]);
+  const [relatedInfra, setRelatedInfra] = useState<string[]>([]);
+  const [tagsInput, setTagsInput] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [activeTab, setActiveTab] = useState<'edit' | 'preview'>('edit');
+
+  useEffect(() => {
+    if (runbook) {
+      setTitle(runbook.title);
+      setSlug(runbook.slug);
+      setContent(runbook.content ?? '');
+      setCategory(runbook.category);
+      setType(runbook.type);
+      setStatus(runbook.status);
+      setPriority(runbook.priority);
+      setRelatedSkills(runbook.related_skills ?? []);
+      setRelatedInfra(runbook.related_infra ?? []);
+      setTagsInput((runbook.tags ?? []).join(', '));
+    } else {
+      setTitle('');
+      setSlug('');
+      setContent('');
+      setCategory('other');
+      setType('runbook');
+      setStatus('draft');
+      setPriority('normal');
+      setRelatedSkills([]);
+      setRelatedInfra([]);
+      setTagsInput('');
+    }
+    setConfirmDelete(false);
+    setActiveTab('edit');
+  }, [runbook, isOpen]);
+
+  const handleTitleChange = (val: string) => {
+    setTitle(val);
+    if (!isEdit) {
+      setSlug(generateSlug(val));
+    }
+  };
+
+  const toggleSkill = (id: string) => {
+    setRelatedSkills(prev =>
+      prev.includes(id) ? prev.filter(s => s !== id) : [...prev, id]
+    );
+  };
+
+  const toggleInfra = (id: string) => {
+    setRelatedInfra(prev =>
+      prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id]
+    );
+  };
+
+  const handleSave = async () => {
+    if (!title.trim()) return;
+    setSaving(true);
+    try {
+      const tags = tagsInput.split(',').map(t => t.trim()).filter(Boolean);
+      const data = {
+        title: title.trim(),
+        slug: slug.trim() || generateSlug(title),
+        content: content || null,
+        category,
+        type,
+        status,
+        priority,
+        related_skills: relatedSkills,
+        related_infra: relatedInfra,
+        tags,
+        last_reviewed_at: runbook?.last_reviewed_at ?? null,
+      };
+      if (isEdit && runbook) {
+        await onSave({ id: runbook.id, ...data });
+      } else {
+        await onSave(data as RunbookCreate);
+      }
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!runbook || !onDelete) return;
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setDeleting(true);
+    try {
+      await onDelete(runbook.id);
+      onClose();
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center p-4 pt-10 overflow-y-auto"
+        onClick={(e) => e.target === e.currentTarget && onClose()}
+      >
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          className="bg-card border border-border rounded-xl w-full max-w-4xl shadow-lg mb-8"
+        >
+          <div className="flex items-center justify-between p-6 border-b border-border">
+            <h2 className="text-lg font-semibold text-foreground">
+              {isEdit ? 'Edit Runbook' : 'New Runbook'}
+            </h2>
+            <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+
+          <div className="p-6 space-y-4">
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Title</label>
+              <Input value={title} onChange={e => handleTitleChange(e.target.value)} placeholder="Deployment Runbook" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Slug</label>
+              <Input value={slug} onChange={e => setSlug(e.target.value)} placeholder="deployment-runbook" className="font-mono text-sm" />
+            </div>
+
+            <div className="grid grid-cols-4 gap-4">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Category</label>
+                <select value={category} onChange={e => setCategory(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {RUNBOOK_CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Type</label>
+                <select value={type} onChange={e => setType(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {RUNBOOK_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Status</label>
+                <select value={status} onChange={e => setStatus(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {RUNBOOK_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Priority</label>
+                <select value={priority} onChange={e => setPriority(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {RUNBOOK_PRIORITIES.map(p => <option key={p} value={p}>{p}</option>)}
+                </select>
+              </div>
+            </div>
+
+            {/* Tabbed content editor */}
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <label className="text-sm font-medium text-foreground">Content (markdown)</label>
+                <div className="flex gap-1 ml-auto">
+                  <button
+                    onClick={() => setActiveTab('edit')}
+                    className={`px-3 py-1 text-xs rounded-md transition-colors ${
+                      activeTab === 'edit' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    <Edit3 className="w-3 h-3 inline mr-1" />Edit
+                  </button>
+                  <button
+                    onClick={() => setActiveTab('preview')}
+                    className={`px-3 py-1 text-xs rounded-md transition-colors ${
+                      activeTab === 'preview' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    <Eye className="w-3 h-3 inline mr-1" />Preview
+                  </button>
+                </div>
+              </div>
+              {activeTab === 'edit' ? (
+                <textarea
+                  value={content}
+                  onChange={e => setContent(e.target.value)}
+                  placeholder="# Runbook Title&#10;&#10;## Prerequisites&#10;&#10;## Steps&#10;&#10;1. ..."
+                  rows={14}
+                  className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+                />
+              ) : (
+                <div className="min-h-[280px] max-h-[400px] overflow-y-auto rounded-md border border-input p-4 prose prose-sm prose-invert max-w-none">
+                  {content ? (
+                    <ReactMarkdown>{content}</ReactMarkdown>
+                  ) : (
+                    <p className="text-muted-foreground italic">Nothing to preview</p>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Related Skills */}
+            {skills.length > 0 && (
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Related Skills</label>
+                <div className="flex flex-wrap gap-2 p-3 border border-border rounded-lg max-h-28 overflow-y-auto">
+                  {skills.map(s => (
+                    <button
+                      key={s.id}
+                      type="button"
+                      onClick={() => toggleSkill(s.id)}
+                      className={`text-xs px-2 py-1 rounded-full border transition-colors ${
+                        relatedSkills.includes(s.id)
+                          ? 'bg-primary/10 text-primary border-primary/30'
+                          : 'bg-muted text-muted-foreground border-border hover:border-primary/30'
+                      }`}
+                    >
+                      {s.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Related Infrastructure */}
+            {infraNodes.length > 0 && (
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Related Infrastructure</label>
+                <div className="flex flex-wrap gap-2 p-3 border border-border rounded-lg max-h-28 overflow-y-auto">
+                  {infraNodes.map(n => (
+                    <button
+                      key={n.id}
+                      type="button"
+                      onClick={() => toggleInfra(n.id)}
+                      className={`text-xs px-2 py-1 rounded-full border transition-colors ${
+                        relatedInfra.includes(n.id)
+                          ? 'bg-primary/10 text-primary border-primary/30'
+                          : 'bg-muted text-muted-foreground border-border hover:border-primary/30'
+                      }`}
+                    >
+                      {n.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Tags (comma-separated)</label>
+              <Input value={tagsInput} onChange={e => setTagsInput(e.target.value)} placeholder="deployment, production, critical" />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between p-6 border-t border-border">
+            <div>
+              {isEdit && onDelete && (
+                <Button
+                  variant="ghost"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className={confirmDelete ? 'text-destructive hover:text-destructive' : 'text-muted-foreground'}
+                >
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  {deleting ? 'Deleting...' : confirmDelete ? 'Confirm Delete' : 'Delete'}
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="ghost" onClick={onClose}>Cancel</Button>
+              <Button onClick={handleSave} disabled={saving || !title.trim()}>
+                {saving ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : null}
+                {isEdit ? 'Save Changes' : 'Create Runbook'}
+              </Button>
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+// ============================================
+// MAIN PAGE
+// ============================================
+
+function RunbooksPage() {
+  useSEO({ title: 'Runbooks', noIndex: true });
+
+  const { supabase, isLoading: authLoading } = useAuthenticatedSupabase();
+  const [runbooks, setRunbooks] = useState<Runbook[]>([]);
+  const [allSkills, setAllSkills] = useState<Skill[]>([]);
+  const [allInfra, setAllInfra] = useState<InfraNode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [priorityFilter, setPriorityFilter] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingRunbook, setEditingRunbook] = useState<Runbook | null>(null);
+
+  const fetchRunbooks = useCallback(async () => {
+    if (!supabase) return;
+    setLoading(true);
+    try {
+      const options: RunbookQueryOptions = {};
+      if (search) options.search = search;
+      if (categoryFilter) options.category = categoryFilter;
+      if (typeFilter) options.type = typeFilter;
+      if (statusFilter) options.status = statusFilter;
+      if (priorityFilter) options.priority = priorityFilter;
+      const data = await getRunbooks(options, supabase);
+      setRunbooks(data);
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase, search, categoryFilter, typeFilter, statusFilter, priorityFilter]);
+
+  const fetchRelated = useCallback(async () => {
+    if (!supabase) return;
+    const [skills, infra] = await Promise.all([
+      getSkills({}, supabase),
+      getInfraNodes({}, supabase),
+    ]);
+    setAllSkills(skills);
+    setAllInfra(infra);
+  }, [supabase]);
+
+  useEffect(() => {
+    if (!authLoading && supabase) {
+      fetchRunbooks();
+      fetchRelated();
+    }
+  }, [authLoading, supabase, fetchRunbooks, fetchRelated]);
+
+  const handleSave = async (data: RunbookCreate | ({ id: string } & Partial<Runbook>)) => {
+    if (!supabase) return;
+    if ('id' in data) {
+      const { id, ...updates } = data;
+      await updateRunbook(id, updates, supabase);
+    } else {
+      await createRunbook(data, supabase);
+    }
+    await fetchRunbooks();
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!supabase) return;
+    await deleteRunbook(id, supabase);
+    await fetchRunbooks();
+  };
+
+  const openNew = () => { setEditingRunbook(null); setModalOpen(true); };
+  const openEdit = (runbook: Runbook) => { setEditingRunbook(runbook); setModalOpen(true); };
+
+  const stats = useMemo(() => {
+    const ninetyDaysAgo = new Date();
+    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+    const needsReview = runbooks.filter(r => {
+      if (r.status !== 'current') return false;
+      if (!r.last_reviewed_at) return true;
+      return new Date(r.last_reviewed_at) < ninetyDaysAgo;
+    }).length;
+
+    return {
+      total: runbooks.length,
+      current: runbooks.filter(r => r.status === 'current').length,
+      critical: runbooks.filter(r => r.priority === 'critical').length,
+      needsReview,
+    };
+  }, [runbooks]);
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  };
+
+  if (authLoading) {
+    return (
+      <AdminLayout>
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <div className="max-w-6xl mx-auto space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <BookOpen className="w-6 h-6 text-primary" />
+            <h1 className="text-2xl font-bold text-foreground">Runbooks</h1>
+          </div>
+          <Button onClick={openNew}>
+            <Plus className="w-4 h-4 mr-1" /> New Runbook
+          </Button>
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          {[
+            { label: 'Total', value: stats.total, icon: BookOpen },
+            { label: 'Current', value: stats.current, icon: CheckCircle2 },
+            { label: 'Critical', value: stats.critical, icon: AlertTriangle },
+            { label: 'Needs Review', value: stats.needsReview, icon: Clock },
+          ].map(({ label, value, icon: Icon }) => (
+            <div key={label} className="bg-card border border-border rounded-lg p-4 flex items-center gap-3">
+              <Icon className="w-5 h-5 text-muted-foreground" />
+              <div>
+                <div className="text-2xl font-bold text-foreground">{value}</div>
+                <div className="text-xs text-muted-foreground">{label}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search runbooks..." className="pl-9" />
+          </div>
+          <select value={categoryFilter} onChange={e => setCategoryFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Categories</option>
+            {RUNBOOK_CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+          </select>
+          <select value={typeFilter} onChange={e => setTypeFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Types</option>
+            {RUNBOOK_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+          <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Statuses</option>
+            {RUNBOOK_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+          <select value={priorityFilter} onChange={e => setPriorityFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Priorities</option>
+            {RUNBOOK_PRIORITIES.map(p => <option key={p} value={p}>{p}</option>)}
+          </select>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-6 h-6 animate-spin text-primary" />
+          </div>
+        ) : runbooks.length === 0 ? (
+          <div className="text-center py-20">
+            <BookOpen className="w-12 h-12 mx-auto text-muted-foreground/40 mb-4" />
+            <h3 className="text-lg font-medium text-foreground mb-1">No runbooks yet</h3>
+            <p className="text-muted-foreground mb-4">Create your first runbook to get started.</p>
+            <Button onClick={openNew}>
+              <Plus className="w-4 h-4 mr-1" /> Create Runbook
+            </Button>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {runbooks.map((runbook, index) => (
+              <motion.div
+                key={runbook.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.03 }}
+                className="bg-card border border-border rounded-lg p-5 hover:border-primary/30 transition-colors group"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <button onClick={() => openEdit(runbook)} className="text-foreground font-semibold hover:text-primary transition-colors text-left truncate">
+                        {runbook.title}
+                      </button>
+                      <Badge variant="outline" className="text-[10px]">{runbook.type}</Badge>
+                      <Badge className={`text-[10px] ${statusColors[runbook.status] ?? ''}`}>{runbook.status}</Badge>
+                      <Badge className={`text-[10px] ${priorityColors[runbook.priority] ?? ''}`}>{runbook.priority}</Badge>
+                      <Badge variant="secondary" className="text-[10px]">{runbook.category}</Badge>
+                    </div>
+
+                    <div className="flex items-center gap-2 flex-wrap mt-2">
+                      {runbook.last_reviewed_at && (
+                        <span className="text-[10px] text-muted-foreground">
+                          <Clock className="w-3 h-3 inline mr-0.5" />
+                          Reviewed {formatDate(runbook.last_reviewed_at)}
+                        </span>
+                      )}
+                      {(runbook.related_skills ?? []).length > 0 && (
+                        <span className="text-[10px] text-muted-foreground">
+                          {(runbook.related_skills ?? []).length} skill{(runbook.related_skills ?? []).length !== 1 ? 's' : ''}
+                        </span>
+                      )}
+                      {(runbook.related_infra ?? []).length > 0 && (
+                        <span className="text-[10px] text-muted-foreground">
+                          {(runbook.related_infra ?? []).length} infra node{(runbook.related_infra ?? []).length !== 1 ? 's' : ''}
+                        </span>
+                      )}
+                      {(runbook.tags ?? []).slice(0, 5).map(tag => (
+                        <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{tag}</span>
+                      ))}
+                      <span className="text-[10px] text-muted-foreground">{formatDate(runbook.updated_at)}</span>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button onClick={() => openEdit(runbook)} className="p-1.5 rounded hover:bg-muted transition-colors" title="Edit">
+                      <Pencil className="w-4 h-4 text-muted-foreground" />
+                    </button>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <RunbookModal
+        runbook={editingRunbook}
+        skills={allSkills}
+        infraNodes={allInfra}
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSave={handleSave}
+        onDelete={handleDelete}
+      />
+    </AdminLayout>
+  );
+}
+
+export default RunbooksPage;

--- a/src/pages/admin/SkillsRegistry.tsx
+++ b/src/pages/admin/SkillsRegistry.tsx
@@ -1,0 +1,492 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Wrench,
+  Plus,
+  Search,
+  Trash2,
+  X,
+  Pencil,
+  Loader2,
+  Zap,
+  Bot,
+  Terminal,
+  FileCode,
+} from 'lucide-react';
+import AdminLayout from '@/components/AdminLayout';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useSEO } from '@/lib/seo';
+import { useAuthenticatedSupabase } from '@/lib/supabase';
+import {
+  getSkills,
+  createSkill,
+  updateSkill,
+  deleteSkill,
+  generateSlug,
+} from '@/lib/skills-queries';
+import type { Skill, SkillCreate, SkillQueryOptions } from '@/lib/skills-schemas';
+import { SKILL_TYPES, SKILL_CATEGORIES, SKILL_STATUSES } from '@/lib/skills-schemas';
+
+// ============================================
+// MODAL COMPONENT
+// ============================================
+
+interface SkillModalProps {
+  skill: Skill | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: SkillCreate | { id: string } & Partial<Skill>) => Promise<void>;
+  onDelete?: (id: string) => Promise<void>;
+}
+
+function SkillModal({ skill, isOpen, onClose, onSave, onDelete }: SkillModalProps) {
+  const isEdit = !!skill;
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [description, setDescription] = useState('');
+  const [type, setType] = useState<string>('skill');
+  const [source, setSource] = useState('');
+  const [invocation, setInvocation] = useState('');
+  const [category, setCategory] = useState<string>('other');
+  const [depsInput, setDepsInput] = useState('');
+  const [status, setStatus] = useState<string>('active');
+  const [tagsInput, setTagsInput] = useState('');
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  useEffect(() => {
+    if (skill) {
+      setName(skill.name);
+      setSlug(skill.slug);
+      setDescription(skill.description ?? '');
+      setType(skill.type);
+      setSource(skill.source ?? '');
+      setInvocation(skill.invocation ?? '');
+      setCategory(skill.category);
+      setDepsInput((skill.dependencies ?? []).join(', '));
+      setStatus(skill.status);
+      setTagsInput((skill.tags ?? []).join(', '));
+      setNotes(skill.notes ?? '');
+    } else {
+      setName('');
+      setSlug('');
+      setDescription('');
+      setType('skill');
+      setSource('');
+      setInvocation('');
+      setCategory('other');
+      setDepsInput('');
+      setStatus('active');
+      setTagsInput('');
+      setNotes('');
+    }
+    setConfirmDelete(false);
+  }, [skill, isOpen]);
+
+  const handleNameChange = (val: string) => {
+    setName(val);
+    if (!isEdit) {
+      setSlug(generateSlug(val));
+    }
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      const tags = tagsInput.split(',').map(t => t.trim()).filter(Boolean);
+      const dependencies = depsInput.split(',').map(t => t.trim()).filter(Boolean);
+      const data = {
+        name: name.trim(),
+        slug: slug.trim() || generateSlug(name),
+        description: description.trim() || null,
+        type,
+        source: source.trim() || null,
+        invocation: invocation.trim() || null,
+        category,
+        dependencies,
+        status,
+        tags,
+        notes: notes.trim() || null,
+      };
+      if (isEdit && skill) {
+        await onSave({ id: skill.id, ...data });
+      } else {
+        await onSave(data as SkillCreate);
+      }
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!skill || !onDelete) return;
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    setDeleting(true);
+    try {
+      await onDelete(skill.id);
+      onClose();
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 bg-black/50 z-50 flex items-start justify-center p-4 pt-20 overflow-y-auto"
+        onClick={(e) => e.target === e.currentTarget && onClose()}
+      >
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          className="bg-card border border-border rounded-xl w-full max-w-2xl shadow-lg mb-8"
+        >
+          <div className="flex items-center justify-between p-6 border-b border-border">
+            <h2 className="text-lg font-semibold text-foreground">
+              {isEdit ? 'Edit Skill' : 'New Skill'}
+            </h2>
+            <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+
+          <div className="p-6 space-y-4">
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Name</label>
+              <Input value={name} onChange={e => handleNameChange(e.target.value)} placeholder="My Skill" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Slug</label>
+              <Input value={slug} onChange={e => setSlug(e.target.value)} placeholder="my-skill" className="font-mono text-sm" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Description</label>
+              <Input value={description} onChange={e => setDescription(e.target.value)} placeholder="What this skill does" />
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Type</label>
+                <select value={type} onChange={e => setType(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {SKILL_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Category</label>
+                <select value={category} onChange={e => setCategory(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {SKILL_CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-1">Status</label>
+                <select value={status} onChange={e => setStatus(e.target.value)} className="w-full h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+                  {SKILL_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Source</label>
+              <Input value={source} onChange={e => setSource(e.target.value)} placeholder="e.g., .claude/skills/commit.md" className="font-mono text-sm" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Invocation</label>
+              <Input value={invocation} onChange={e => setInvocation(e.target.value)} placeholder="e.g., /commit or claude-code-guide" className="font-mono text-sm" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Dependencies (comma-separated)</label>
+              <Input value={depsInput} onChange={e => setDepsInput(e.target.value)} placeholder="node, npm, git" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Tags (comma-separated)</label>
+              <Input value={tagsInput} onChange={e => setTagsInput(e.target.value)} placeholder="cli, automation, ai" />
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-foreground block mb-1">Notes (markdown)</label>
+              <textarea
+                value={notes}
+                onChange={e => setNotes(e.target.value)}
+                placeholder="Additional notes..."
+                rows={4}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between p-6 border-t border-border">
+            <div>
+              {isEdit && onDelete && (
+                <Button
+                  variant="ghost"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className={confirmDelete ? 'text-destructive hover:text-destructive' : 'text-muted-foreground'}
+                >
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  {deleting ? 'Deleting...' : confirmDelete ? 'Confirm Delete' : 'Delete'}
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="ghost" onClick={onClose}>Cancel</Button>
+              <Button onClick={handleSave} disabled={saving || !name.trim()}>
+                {saving ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : null}
+                {isEdit ? 'Save Changes' : 'Create Skill'}
+              </Button>
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+// ============================================
+// MAIN PAGE
+// ============================================
+
+function SkillsRegistry() {
+  useSEO({ title: 'Skills Registry', noIndex: true });
+
+  const { supabase, isLoading: authLoading } = useAuthenticatedSupabase();
+  const [skills, setSkills] = useState<Skill[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
+
+  const fetchSkills = useCallback(async () => {
+    if (!supabase) return;
+    setLoading(true);
+    try {
+      const options: SkillQueryOptions = {};
+      if (search) options.search = search;
+      if (typeFilter) options.type = typeFilter;
+      if (categoryFilter) options.category = categoryFilter;
+      if (statusFilter) options.status = statusFilter;
+      const data = await getSkills(options, supabase);
+      setSkills(data);
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase, search, typeFilter, categoryFilter, statusFilter]);
+
+  useEffect(() => {
+    if (!authLoading && supabase) {
+      fetchSkills();
+    }
+  }, [authLoading, supabase, fetchSkills]);
+
+  const handleSave = async (data: SkillCreate | ({ id: string } & Partial<Skill>)) => {
+    if (!supabase) return;
+    if ('id' in data) {
+      const { id, ...updates } = data;
+      await updateSkill(id, updates, supabase);
+    } else {
+      await createSkill(data, supabase);
+    }
+    await fetchSkills();
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!supabase) return;
+    await deleteSkill(id, supabase);
+    await fetchSkills();
+  };
+
+  const openNew = () => { setEditingSkill(null); setModalOpen(true); };
+  const openEdit = (skill: Skill) => { setEditingSkill(skill); setModalOpen(true); };
+
+  const stats = useMemo(() => ({
+    total: skills.length,
+    active: skills.filter(s => s.status === 'active').length,
+    agents: skills.filter(s => s.type === 'agent').length,
+    scripts: skills.filter(s => s.type === 'script').length,
+  }), [skills]);
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  };
+
+  const typeIcon = (type: string) => {
+    switch (type) {
+      case 'agent': return Bot;
+      case 'script': return Terminal;
+      case 'mcp-server': return FileCode;
+      case 'automation': return Zap;
+      default: return Wrench;
+    }
+  };
+
+  if (authLoading) {
+    return (
+      <AdminLayout>
+        <div className="flex items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <div className="max-w-6xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Wrench className="w-6 h-6 text-primary" />
+            <h1 className="text-2xl font-bold text-foreground">Skills Registry</h1>
+          </div>
+          <Button onClick={openNew}>
+            <Plus className="w-4 h-4 mr-1" /> New Skill
+          </Button>
+        </div>
+
+        {/* Stats Row */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          {[
+            { label: 'Total', value: stats.total, icon: Wrench },
+            { label: 'Active', value: stats.active, icon: Zap },
+            { label: 'Agents', value: stats.agents, icon: Bot },
+            { label: 'Scripts', value: stats.scripts, icon: Terminal },
+          ].map(({ label, value, icon: Icon }) => (
+            <div key={label} className="bg-card border border-border rounded-lg p-4 flex items-center gap-3">
+              <Icon className="w-5 h-5 text-muted-foreground" />
+              <div>
+                <div className="text-2xl font-bold text-foreground">{value}</div>
+                <div className="text-xs text-muted-foreground">{label}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Search + Filters */}
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search skills..." className="pl-9" />
+          </div>
+          <select value={typeFilter} onChange={e => setTypeFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Types</option>
+            {SKILL_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+          <select value={categoryFilter} onChange={e => setCategoryFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Categories</option>
+            {SKILL_CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+          </select>
+          <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)} className="h-9 rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+            <option value="">All Statuses</option>
+            {SKILL_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </div>
+
+        {/* Skill Cards */}
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-6 h-6 animate-spin text-primary" />
+          </div>
+        ) : skills.length === 0 ? (
+          <div className="text-center py-20">
+            <Wrench className="w-12 h-12 mx-auto text-muted-foreground/40 mb-4" />
+            <h3 className="text-lg font-medium text-foreground mb-1">No skills yet</h3>
+            <p className="text-muted-foreground mb-4">Register your first skill to get started.</p>
+            <Button onClick={openNew}>
+              <Plus className="w-4 h-4 mr-1" /> Create Skill
+            </Button>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {skills.map((skill, index) => {
+              const TypeIcon = typeIcon(skill.type);
+              return (
+                <motion.div
+                  key={skill.id}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: index * 0.03 }}
+                  className="bg-card border border-border rounded-lg p-5 hover:border-primary/30 transition-colors group"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <TypeIcon className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+                        <button onClick={() => openEdit(skill)} className="text-foreground font-semibold hover:text-primary transition-colors text-left truncate">
+                          {skill.name}
+                        </button>
+                        <Badge variant="secondary" className="text-[10px]">{skill.type}</Badge>
+                        <Badge variant="outline" className="text-[10px]">{skill.category}</Badge>
+                        {skill.status !== 'active' && (
+                          <Badge className={`text-[10px] ${skill.status === 'inactive' ? 'bg-red-500/10 text-red-400 border-red-500/20' : 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20'}`}>
+                            {skill.status}
+                          </Badge>
+                        )}
+                      </div>
+
+                      {skill.description && (
+                        <p className="text-sm text-muted-foreground mb-2 line-clamp-1">{skill.description}</p>
+                      )}
+
+                      {skill.invocation && (
+                        <p className="text-xs font-mono text-primary/70 mb-2">{skill.invocation}</p>
+                      )}
+
+                      <div className="flex items-center gap-2 flex-wrap">
+                        {(skill.dependencies ?? []).slice(0, 5).map(dep => (
+                          <span key={dep} className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400 border border-blue-500/20">{dep}</span>
+                        ))}
+                        {(skill.tags ?? []).slice(0, 5).map(tag => (
+                          <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{tag}</span>
+                        ))}
+                        <span className="text-[10px] text-muted-foreground">{formatDate(skill.updated_at)}</span>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button onClick={() => openEdit(skill)} className="p-1.5 rounded hover:bg-muted transition-colors" title="Edit">
+                        <Pencil className="w-4 h-4 text-muted-foreground" />
+                      </button>
+                    </div>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <SkillModal
+        skill={editingSkill}
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSave={handleSave}
+        onDelete={handleDelete}
+      />
+    </AdminLayout>
+  );
+}
+
+export default SkillsRegistry;

--- a/supabase/migrations/007_command_center.sql
+++ b/supabase/migrations/007_command_center.sql
@@ -1,0 +1,203 @@
+-- Command Center Migration
+-- Prerequisites: schema.sql must be applied first (is_admin, update_updated_at_column)
+-- This migration is idempotent and safe to re-run
+-- Tables: skills, infrastructure_nodes, configs, runbooks
+
+-- ============================================
+-- VERIFY PREREQUISITES
+-- ============================================
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'is_admin') THEN
+    RAISE EXCEPTION 'Missing prerequisite: is_admin() function. Run schema.sql first.';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'update_updated_at_column') THEN
+    RAISE EXCEPTION 'Missing prerequisite: update_updated_at_column() function. Run schema.sql first.';
+  END IF;
+END $$;
+
+-- ============================================
+-- SKILLS TABLE
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS skills (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  description TEXT,
+  type TEXT NOT NULL DEFAULT 'skill',
+  source TEXT,
+  invocation TEXT,
+  category TEXT NOT NULL DEFAULT 'other',
+  dependencies TEXT[] DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'active',
+  tags TEXT[] DEFAULT '{}',
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT skills_type_check CHECK (type IN ('skill', 'agent', 'mcp-server', 'script', 'automation')),
+  CONSTRAINT skills_category_check CHECK (category IN ('development', 'deployment', 'testing', 'content', 'data', 'other')),
+  CONSTRAINT skills_status_check CHECK (status IN ('active', 'inactive', 'draft'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_skills_slug ON skills(slug);
+CREATE INDEX IF NOT EXISTS idx_skills_type ON skills(type);
+CREATE INDEX IF NOT EXISTS idx_skills_category ON skills(category);
+CREATE INDEX IF NOT EXISTS idx_skills_status ON skills(status) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_skills_tags ON skills USING GIN(tags);
+
+DROP TRIGGER IF EXISTS skills_updated_at ON skills;
+CREATE TRIGGER skills_updated_at
+  BEFORE UPDATE ON skills
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE skills ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS skills_admin_all ON skills;
+CREATE POLICY skills_admin_all ON skills
+  FOR ALL USING (is_admin());
+
+-- ============================================
+-- INFRASTRUCTURE_NODES TABLE
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS infrastructure_nodes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  description TEXT,
+  type TEXT NOT NULL DEFAULT 'service',
+  provider TEXT NOT NULL DEFAULT 'other',
+  url TEXT,
+  status TEXT NOT NULL DEFAULT 'active',
+  tier TEXT,
+  region TEXT,
+  config_notes TEXT,
+  environment TEXT NOT NULL DEFAULT 'production',
+  connected_to UUID[] DEFAULT '{}',
+  monthly_cost DECIMAL(10,2),
+  tags TEXT[] DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT infra_type_check CHECK (type IN ('service', 'server', 'database', 'cdn', 'dns', 'domain', 'repository', 'ci-cd', 'monitoring')),
+  CONSTRAINT infra_provider_check CHECK (provider IN ('netlify', 'supabase', 'github', 'cloudflare', 'sentry', 'clerk', 'ghost', 'vercel', 'aws', 'other')),
+  CONSTRAINT infra_status_check CHECK (status IN ('active', 'degraded', 'inactive')),
+  CONSTRAINT infra_environment_check CHECK (environment IN ('production', 'staging', 'development'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_infra_slug ON infrastructure_nodes(slug);
+CREATE INDEX IF NOT EXISTS idx_infra_type ON infrastructure_nodes(type);
+CREATE INDEX IF NOT EXISTS idx_infra_provider ON infrastructure_nodes(provider);
+CREATE INDEX IF NOT EXISTS idx_infra_status ON infrastructure_nodes(status) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_infra_environment ON infrastructure_nodes(environment);
+CREATE INDEX IF NOT EXISTS idx_infra_tags ON infrastructure_nodes USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_infra_connected_to ON infrastructure_nodes USING GIN(connected_to);
+
+DROP TRIGGER IF EXISTS infra_updated_at ON infrastructure_nodes;
+CREATE TRIGGER infra_updated_at
+  BEFORE UPDATE ON infrastructure_nodes
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE infrastructure_nodes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS infra_admin_all ON infrastructure_nodes;
+CREATE POLICY infra_admin_all ON infrastructure_nodes
+  FOR ALL USING (is_admin());
+
+-- ============================================
+-- CONFIGS TABLE
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS configs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  description TEXT,
+  type TEXT NOT NULL DEFAULT 'file',
+  source_path TEXT,
+  content TEXT,
+  format TEXT NOT NULL DEFAULT 'text',
+  category TEXT NOT NULL DEFAULT 'other',
+  version TEXT,
+  is_active BOOLEAN DEFAULT true,
+  tags TEXT[] DEFAULT '{}',
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT configs_type_check CHECK (type IN ('file', 'snippet', 'setting', 'template')),
+  CONSTRAINT configs_format_check CHECK (format IN ('json', 'yaml', 'toml', 'javascript', 'typescript', 'markdown', 'text', 'env')),
+  CONSTRAINT configs_category_check CHECK (category IN ('build', 'lint', 'deploy', 'auth', 'database', 'styling', 'testing', 'other'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_configs_slug ON configs(slug);
+CREATE INDEX IF NOT EXISTS idx_configs_type ON configs(type);
+CREATE INDEX IF NOT EXISTS idx_configs_format ON configs(format);
+CREATE INDEX IF NOT EXISTS idx_configs_category ON configs(category);
+CREATE INDEX IF NOT EXISTS idx_configs_is_active ON configs(is_active) WHERE is_active = true;
+CREATE INDEX IF NOT EXISTS idx_configs_tags ON configs USING GIN(tags);
+
+DROP TRIGGER IF EXISTS configs_updated_at ON configs;
+CREATE TRIGGER configs_updated_at
+  BEFORE UPDATE ON configs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE configs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS configs_admin_all ON configs;
+CREATE POLICY configs_admin_all ON configs
+  FOR ALL USING (is_admin());
+
+-- ============================================
+-- RUNBOOKS TABLE
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS runbooks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  content TEXT,
+  category TEXT NOT NULL DEFAULT 'other',
+  type TEXT NOT NULL DEFAULT 'runbook',
+  status TEXT NOT NULL DEFAULT 'draft',
+  priority TEXT NOT NULL DEFAULT 'normal',
+  related_skills UUID[] DEFAULT '{}',
+  related_infra UUID[] DEFAULT '{}',
+  tags TEXT[] DEFAULT '{}',
+  last_reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT runbooks_category_check CHECK (category IN ('deployment', 'troubleshooting', 'onboarding', 'security', 'maintenance', 'architecture', 'api', 'other')),
+  CONSTRAINT runbooks_type_check CHECK (type IN ('runbook', 'guide', 'reference', 'decision-record')),
+  CONSTRAINT runbooks_status_check CHECK (status IN ('current', 'outdated', 'draft')),
+  CONSTRAINT runbooks_priority_check CHECK (priority IN ('critical', 'high', 'normal', 'low'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_runbooks_slug ON runbooks(slug);
+CREATE INDEX IF NOT EXISTS idx_runbooks_category ON runbooks(category);
+CREATE INDEX IF NOT EXISTS idx_runbooks_type ON runbooks(type);
+CREATE INDEX IF NOT EXISTS idx_runbooks_status ON runbooks(status) WHERE status = 'current';
+CREATE INDEX IF NOT EXISTS idx_runbooks_priority ON runbooks(priority);
+CREATE INDEX IF NOT EXISTS idx_runbooks_tags ON runbooks USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_runbooks_related_skills ON runbooks USING GIN(related_skills);
+CREATE INDEX IF NOT EXISTS idx_runbooks_related_infra ON runbooks USING GIN(related_infra);
+
+DROP TRIGGER IF EXISTS runbooks_updated_at ON runbooks;
+CREATE TRIGGER runbooks_updated_at
+  BEFORE UPDATE ON runbooks
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE runbooks ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS runbooks_admin_all ON runbooks;
+CREATE POLICY runbooks_admin_all ON runbooks
+  FOR ALL USING (is_admin());
+
+-- ============================================
+-- DONE
+-- ============================================
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Command Center migration completed successfully';
+  RAISE NOTICE 'Tables created: skills, infrastructure_nodes, configs, runbooks';
+END $$;

--- a/supabase/seed/configs.sql
+++ b/supabase/seed/configs.sql
@@ -1,0 +1,10 @@
+-- Seed data for configs table
+-- Run after 007_command_center.sql migration
+
+INSERT INTO configs (name, slug, description, type, source_path, format, category, is_active, tags) VALUES
+('ESLint Config', 'eslint-config', 'ESLint flat config with TypeScript and React rules', 'file', 'eslint.config.js', 'javascript', 'lint', true, '{"eslint", "linting", "typescript"}'),
+('Vite Config', 'vite-config', 'Vite build configuration with React and path aliases', 'file', 'vite.config.ts', 'typescript', 'build', true, '{"vite", "build", "react"}'),
+('Tailwind Config', 'tailwind-config', 'Tailwind CSS configuration with custom theme', 'file', 'tailwind.config.js', 'javascript', 'styling', true, '{"tailwind", "css", "theme"}'),
+('Netlify Config', 'netlify-config', 'Netlify deployment configuration with redirects and headers', 'file', 'netlify.toml', 'toml', 'deploy', true, '{"netlify", "deploy", "redirects"}'),
+('TypeScript Config', 'tsconfig', 'TypeScript compiler configuration', 'file', 'tsconfig.json', 'json', 'build', true, '{"typescript", "compiler", "build"}')
+ON CONFLICT (slug) DO NOTHING;

--- a/supabase/seed/infrastructure.sql
+++ b/supabase/seed/infrastructure.sql
@@ -1,0 +1,13 @@
+-- Seed data for infrastructure_nodes table
+-- Run after 007_command_center.sql migration
+
+INSERT INTO infrastructure_nodes (name, slug, description, type, provider, url, status, tier, environment, monthly_cost, tags) VALUES
+('Netlify Production', 'netlify-production', 'Production hosting for mejohnc.org SPA', 'service', 'netlify', 'https://app.netlify.com', 'active', 'Free', 'production', 0.00, '{"hosting", "cdn", "deploy"}'),
+('Supabase Production', 'supabase-production', 'Production PostgreSQL database and auth backend', 'database', 'supabase', 'https://supabase.com/dashboard', 'active', 'Free', 'production', 0.00, '{"database", "auth", "api"}'),
+('GitHub Repository', 'github-repo', 'Source code repository for MeJohnC.Org', 'repository', 'github', 'https://github.com/MeJohnC', 'active', 'Free', 'production', 0.00, '{"git", "source-code", "ci-cd"}'),
+('Clerk Auth', 'clerk-auth', 'Authentication and user management service', 'service', 'clerk', 'https://dashboard.clerk.com', 'active', 'Free', 'production', 0.00, '{"auth", "users", "sso"}'),
+('Ghost CMS', 'ghost-cms', 'Blog content management system', 'service', 'ghost', NULL, 'active', 'Self-hosted', 'production', 0.00, '{"blog", "cms", "content"}'),
+('Cloudflare DNS', 'cloudflare-dns', 'DNS management and CDN', 'dns', 'cloudflare', 'https://dash.cloudflare.com', 'active', 'Free', 'production', 0.00, '{"dns", "cdn", "security"}'),
+('Sentry Monitoring', 'sentry-monitoring', 'Error tracking and performance monitoring', 'monitoring', 'sentry', 'https://sentry.io', 'active', 'Developer', 'production', 0.00, '{"monitoring", "errors", "performance"}'),
+('GitHub Actions CI/CD', 'github-actions', 'Continuous integration and deployment pipelines', 'ci-cd', 'github', NULL, 'active', 'Free', 'production', 0.00, '{"ci-cd", "automation", "deploy"}')
+ON CONFLICT (slug) DO NOTHING;

--- a/supabase/seed/skills.sql
+++ b/supabase/seed/skills.sql
@@ -1,0 +1,15 @@
+-- Seed data for skills table
+-- Run after 007_command_center.sql migration
+
+INSERT INTO skills (name, slug, description, type, source, invocation, category, dependencies, status, tags) VALUES
+('Commit', 'commit', 'Claude Code skill for creating well-formatted git commits', 'skill', '.claude/skills/commit.md', '/commit', 'development', '{"git"}', 'active', '{"git", "automation", "claude-code"}'),
+('Review PR', 'review-pr', 'Claude Code skill for reviewing pull requests', 'skill', '.claude/skills/review-pr.md', '/review-pr', 'development', '{"git", "gh"}', 'active', '{"git", "code-review", "claude-code"}'),
+('PDF Toolkit', 'pdf', 'Comprehensive PDF manipulation toolkit', 'skill', '.claude/skills/pdf.md', '/pdf', 'content', '{}', 'active', '{"pdf", "documents", "claude-code"}'),
+('Claude Code Guide', 'claude-code-guide', 'Agent for answering questions about Claude Code features', 'agent', NULL, 'claude-code-guide', 'development', '{}', 'active', '{"claude-code", "documentation", "agent"}'),
+('Explore Agent', 'explore-agent', 'Fast agent for exploring codebases', 'agent', NULL, 'Explore', 'development', '{}', 'active', '{"codebase", "search", "agent"}'),
+('Tech Lead Agent', 'tech-lead', 'Architecture decisions and system design agent', 'agent', NULL, 'tech-lead', 'development', '{}', 'active', '{"architecture", "design", "agent"}'),
+('Code Reviewer Agent', 'code-reviewer', 'Code quality and TypeScript best practices agent', 'agent', NULL, 'code-reviewer', 'development', '{}', 'active', '{"code-review", "quality", "agent"}'),
+('Supabase MCP Server', 'supabase-mcp', 'MCP server for Supabase database operations', 'mcp-server', NULL, NULL, 'data', '{"supabase"}', 'active', '{"mcp", "supabase", "database"}'),
+('Build Script', 'build-script', 'npm run build - Vite production build', 'script', 'package.json', 'npm run build', 'deployment', '{"node", "npm", "vite"}', 'active', '{"build", "vite", "production"}'),
+('DB Push Script', 'db-push', 'Push Supabase migrations to remote database', 'script', 'package.json', 'npm run db:push', 'deployment', '{"supabase"}', 'active', '{"database", "migrations", "supabase"}')
+ON CONFLICT (slug) DO NOTHING;


### PR DESCRIPTION
## Summary
- **Skills Registry** (`/admin/skills`) - Catalog Claude Code skills, agents, MCP servers, scripts with type/category/status filters
- **Infrastructure Map** (`/admin/infrastructure`) - Document compute, services, and connections with cost tracking and connected_to multi-select
- **Config Vault** (`/admin/configs`) - Store and version non-secret configurations with format-aware display
- **Runbooks** (`/admin/runbooks`) - Operational docs with markdown preview, cross-references to skills and infra nodes

All 4 sections have full CRUD via Supabase with RLS, Zod schemas, query layers, and seed data. Migration adds 4 new tables with indexes, constraints, and triggers.

## Files Added (19)
- 1 SQL migration (`007_command_center.sql`)
- 8 schema + query files
- 4 admin page components
- 3 seed data files
- 2 modified files (App.tsx routing, AdminLayout.tsx sidebar)

## Test plan
- [ ] Run `npm run db:push` - 4 new tables appear in Supabase dashboard
- [ ] Navigate to `/admin/skills`, `/admin/infrastructure`, `/admin/configs`, `/admin/runbooks` - pages load with empty states
- [ ] Create an item in each section - modal works, item appears in list
- [ ] Edit and delete items - CRUD fully functional
- [ ] Search and filter - results update correctly
- [ ] Runbooks cross-references - can link to skills and infra nodes
- [ ] `npm run build` succeeds with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)