### PR TITLE
fix: use correct column name in integration-health (#176)

### DIFF
--- a/supabase/functions/integration-health/index.ts
+++ b/supabase/functions/integration-health/index.ts
@@ -102,12 +102,12 @@ async function checkIntegration(
         try {
           const { data: credRow } = await supabase
             .from('integration_credentials')
-            .select('credentials_encrypted')
+            .select('encrypted_data')
             .eq('integration_id', integration.id)
             .single()
 
-          if (credRow?.credentials_encrypted) {
-            const decrypted = await decrypt(credRow.credentials_encrypted as EncryptedPayload)
+          if (credRow?.encrypted_data) {
+            const decrypted = await decrypt(credRow.encrypted_data as EncryptedPayload)
             token = (decrypted.access_token as string) || ''
           }
         } catch {
@@ -138,12 +138,12 @@ async function checkIntegration(
         try {
           const { data: credRow } = await supabase
             .from('integration_credentials')
-            .select('credentials_encrypted')
+            .select('encrypted_data')
             .eq('integration_id', integration.id)
             .single()
 
-          if (credRow?.credentials_encrypted) {
-            const decrypted = await decrypt(credRow.credentials_encrypted as EncryptedPayload)
+          if (credRow?.encrypted_data) {
+            const decrypted = await decrypt(credRow.encrypted_data as EncryptedPayload)
             apiKey = (decrypted.api_key as string) || ''
           }
         } catch {


### PR DESCRIPTION
## Summary
- Fixed `integration-health` edge function querying wrong column name `credentials_encrypted` instead of `encrypted_data`
- Affects both `oauth2` and `api_key` health check paths (lines 105 and 141)
- Without this fix, all credential-based health checks fail silently

## Test plan
- [ ] Verify integration-health function compiles without errors
- [ ] Test oauth2 integration health check returns valid credentials
- [ ] Test api_key integration health check returns valid credentials

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)