### PR TITLE
fix: use correct agent_commands column names in workflow-executor (#177)

### DIFF
--- a/supabase/functions/workflow-executor/index.ts
+++ b/supabase/functions/workflow-executor/index.ts
@@ -116,13 +116,18 @@ async function executeStepInner(
       const { command, payload } = step.config as { command: string; payload?: unknown }
       if (!command) throw new Error('agent_command step requires "command" in config')
 
+      const content = typeof payload === 'string' ? payload : JSON.stringify(payload || {})
+
       const { data, error } = await supabase
         .from('agent_commands')
         .insert({
-          command,
-          payload: payload || {},
+          command_type: 'task',
+          content,
           status: 'pending',
-          agent_id: agentId,
+          user_id: agentId || 'system',
+          user_email: 'workflow@system',
+          session_id: crypto.randomUUID(),
+          metadata: { workflow_command: command },
         })
         .select('id')
         .single()


### PR DESCRIPTION
## Summary
- Fixed workflow-executor inserting into `agent_commands` with wrong column names
- `command` → `command_type` (set to `'task'` for workflow dispatches)
- `payload` → `content` (serialized as JSON string to match TEXT column)
- `agent_id` → `user_id`
- Added required `session_id` and `user_email` fields
- Original command name preserved in `metadata.workflow_command`

## Test plan
- [ ] Verify workflow-executor compiles without errors
- [ ] Test workflow with agent_command step inserts correctly into agent_commands table
- [ ] Confirm no Postgres column-not-found errors on workflow execution

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)