### PR TITLE
fix: remove misleading agent-command handler route (#178)

### DIFF
--- a/supabase/functions/_shared/capabilities.ts
+++ b/supabase/functions/_shared/capabilities.ts
@@ -133,7 +133,8 @@ export function resolveRoute(action: string): RouteTarget {
 
   switch (prefix) {
     case 'agent':
-      return { type: 'agent', handler: 'agent-command' }
+      // Handled inline by api-gateway (no separate edge function)
+      return { type: 'agent', handler: 'api-gateway' }
     case 'workflow':
       return { type: 'workflow', handler: 'workflow-executor' }
     case 'integration':

--- a/tests/agent-platform/gateway.test.ts
+++ b/tests/agent-platform/gateway.test.ts
@@ -45,7 +45,7 @@ interface RouteTarget {
 function resolveRoute(action: string): RouteTarget {
   const prefix = action.split('.')[0]
   switch (prefix) {
-    case 'agent': return { type: 'agent', handler: 'agent-command' }
+    case 'agent': return { type: 'agent', handler: 'api-gateway' }
     case 'workflow': return { type: 'workflow', handler: 'workflow-executor' }
     case 'integration': return { type: 'integration', handler: 'integration-credentials' }
     case 'query': return { type: 'query', handler: 'query-engine' }
@@ -110,7 +110,7 @@ describe('API Gateway', () => {
     // Agent action routes to agent handler
     const agentRoute = resolveRoute('agent.status')
     expect(agentRoute.type).toBe('agent')
-    expect(agentRoute.handler).toBe('agent-command')
+    expect(agentRoute.handler).toBe('api-gateway')
 
     // Integration action routes to integration handler
     const intRoute = resolveRoute('integration.status')


### PR DESCRIPTION
## Summary
- Changed `resolveRoute()` for `agent.*` actions from non-existent `agent-command` handler to `api-gateway` (reflecting that these are handled inline)
- Updated corresponding test assertion
- All 5 gateway tests pass

## Test plan
- [x] `gateway.test.ts` — 5/5 tests pass
- [ ] Verify no runtime references to `agent-command` function name

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)