### PR TITLE
fix: add pg_cron and pg_net extension verification (#179)

### DIFF
--- a/supabase/migrations/20240601000005_scheduler.sql
+++ b/supabase/migrations/20240601000005_scheduler.sql
@@ -27,6 +27,17 @@ END $$;
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 CREATE EXTENSION IF NOT EXISTS pg_net;
 
+-- Verify extensions were actually created (they may be unavailable on some Postgres instances)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    RAISE EXCEPTION 'pg_cron extension could not be created. Ensure it is available on your Postgres instance (required for scheduled workflows).';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_net') THEN
+    RAISE EXCEPTION 'pg_net extension could not be created. Ensure it is available on your Postgres instance (required for HTTP dispatch to edge functions).';
+  END IF;
+END $$;
+
 -- ============================================
 -- SCHEDULED_WORKFLOW_RUNS TRACKING TABLE
 -- ============================================

--- a/supabase/migrations/20240601000006_phase4.sql
+++ b/supabase/migrations/20240601000006_phase4.sql
@@ -21,6 +21,12 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'audit_log') THEN
     RAISE EXCEPTION 'Missing prerequisite: audit_log table. Run agent platform migrations first.';
   END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    RAISE EXCEPTION 'Missing prerequisite: pg_cron extension. Run 20240601000005_scheduler.sql first.';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_net') THEN
+    RAISE EXCEPTION 'Missing prerequisite: pg_net extension. Run 20240601000005_scheduler.sql first.';
+  END IF;
 END $$;
 
 -- ============================================


### PR DESCRIPTION
## Summary
- Added post-creation verification in scheduler migration (`_000005`) to confirm pg_cron and pg_net extensions were actually installed
- Added prerequisite checks in phase4 migration (`_000006`) to verify pg_cron and pg_net exist before using `cron.schedule()` and `net.http_post()`
- All checks use `pg_extension` catalog with clear error messages pointing to the required migration

## Test plan
- [ ] Run scheduler migration on fresh database — verify pg_cron/pg_net verification passes
- [ ] Run phase4 migration after scheduler — verify prerequisite checks pass
- [ ] Confirm `emit_event()` function works with pg_net available
- [ ] Confirm `cron.schedule()` calls succeed in phase4

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)