### PR TITLE
fix: replace wildcard CORS with env-based origin (#180)

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared CORS origin for all edge functions.
+ *
+ * Set ALLOWED_ORIGIN env var to override (e.g., "http://localhost:5173" for dev).
+ * Defaults to production domain.
+ */
+export const CORS_ORIGIN = Deno.env.get('ALLOWED_ORIGIN') || 'https://mejohnc.org'

--- a/supabase/functions/agent-auth/index.ts
+++ b/supabase/functions/agent-auth/index.ts
@@ -5,9 +5,10 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
 import { authenticateAgent, extractApiKey } from '../_shared/agent-auth.ts'
 import { Logger } from '../_shared/logger.ts'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type, x-agent-key',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',

--- a/supabase/functions/api-gateway/index.ts
+++ b/supabase/functions/api-gateway/index.ts
@@ -17,9 +17,10 @@ import { canPerformAction, resolveRoute, ACTION_CAPABILITY_MAP } from '../_share
 import { verifySignature } from '../_shared/command-signing.ts'
 import { Logger } from '../_shared/logger.ts'
 import { validateInput, validateFields } from '../_shared/input-validator.ts'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type, x-agent-key, x-scheduler-secret, x-signature',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',

--- a/supabase/functions/fetch-news/index.ts
+++ b/supabase/functions/fetch-news/index.ts
@@ -4,10 +4,11 @@
 // Set up cron: Use Supabase Dashboard > Database > Extensions > pg_cron
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 // CORS headers for browser requests
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 

--- a/supabase/functions/health-check/index.ts
+++ b/supabase/functions/health-check/index.ts
@@ -3,10 +3,11 @@
 // Invoke: GET /functions/v1/health-check
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 // CORS headers
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
 }

--- a/supabase/functions/integration-auth/index.ts
+++ b/supabase/functions/integration-auth/index.ts
@@ -12,9 +12,10 @@ import { authenticateAgent } from '../_shared/agent-auth.ts'
 import { Logger } from '../_shared/logger.ts'
 import { validateInput, validateFields } from '../_shared/input-validator.ts'
 import { encrypt, decrypt, EncryptedPayload } from '../_shared/encryption.ts'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type, x-agent-key',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',

--- a/supabase/functions/integration-credentials/index.ts
+++ b/supabase/functions/integration-credentials/index.ts
@@ -13,9 +13,10 @@ import { authenticateAgent } from '../_shared/agent-auth.ts'
 import { Logger } from '../_shared/logger.ts'
 import { validateInput, validateFields } from '../_shared/input-validator.ts'
 import { encrypt, decrypt, EncryptedPayload } from '../_shared/encryption.ts'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type, x-agent-key',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',

--- a/supabase/functions/integration-health/index.ts
+++ b/supabase/functions/integration-health/index.ts
@@ -16,9 +16,10 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
 import { decrypt, EncryptedPayload } from '../_shared/encryption.ts'
 import { Logger } from '../_shared/logger.ts'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type, x-scheduler-secret',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',

--- a/supabase/functions/metrics-sync/index.ts
+++ b/supabase/functions/metrics-sync/index.ts
@@ -4,10 +4,11 @@
 // Set up cron with pg_cron for automatic syncing
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 // CORS headers for browser requests
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
 }

--- a/supabase/functions/metrics-webhook/index.ts
+++ b/supabase/functions/metrics-webhook/index.ts
@@ -3,10 +3,11 @@
 // Invoke: POST /functions/v1/metrics-webhook with JSON body
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 // CORS headers for browser requests
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-webhook-secret',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
 }

--- a/supabase/functions/webhook-receiver/index.ts
+++ b/supabase/functions/webhook-receiver/index.ts
@@ -17,9 +17,10 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
 import { Logger } from '../_shared/logger.ts'
 import { validateInput } from '../_shared/input-validator.ts'
 import { createRateLimiter, getClientId } from '../_shared/rate-limiter.ts'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type, x-webhook-signature, stripe-signature, x-hub-signature-256',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',

--- a/supabase/functions/workflow-executor/index.ts
+++ b/supabase/functions/workflow-executor/index.ts
@@ -11,9 +11,10 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
 import { authenticateAgent, AgentAuthResult } from '../_shared/agent-auth.ts'
 import { Logger } from '../_shared/logger.ts'
 import { validateInput, validateFields } from '../_shared/input-validator.ts'
+import { CORS_ORIGIN } from '../_shared/cors.ts'
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': CORS_ORIGIN,
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type, x-agent-key, x-scheduler-secret',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',


### PR DESCRIPTION
## Summary
- Created `_shared/cors.ts` with `CORS_ORIGIN` constant (defaults to `https://mejohnc.org`, configurable via `ALLOWED_ORIGIN` env var)
- Replaced `'Access-Control-Allow-Origin': '*'` in all 11 edge functions:
  - api-gateway, agent-auth, webhook-receiver, integration-auth, integration-credentials, workflow-executor, integration-health, health-check, fetch-news, metrics-sync, metrics-webhook
- Set `ALLOWED_ORIGIN=http://localhost:5173` in dev environment for local development

## Test plan
- [ ] Verify production requests from mejohnc.org get correct CORS headers
- [ ] Verify cross-origin requests from other domains are blocked
- [ ] Set `ALLOWED_ORIGIN` env var in Supabase dashboard for production
- [ ] Test local dev with `ALLOWED_ORIGIN=http://localhost:5173`

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)