### PR TITLE
fix: destructure useAuthenticatedSupabase in AgentRegistry

### DIFF
--- a/src/pages/admin/AgentRegistry.tsx
+++ b/src/pages/admin/AgentRegistry.tsx
@@ -73,7 +73,7 @@ function StatusBadge({ status }: { status: PlatformAgentStatus }) {
 export default function AgentRegistry() {
   useSEO({ title: 'Agent Registry', noIndex: true });
 
-  const supabase = useAuthenticatedSupabase();
+  const { supabase } = useAuthenticatedSupabase();
   const [agents, setAgents] = useState<AgentPlatform[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');


### PR DESCRIPTION
## Summary
- Fixed runtime crash on the Agent Registry admin page caused by missing destructuring on the `useAuthenticatedSupabase()` hook return value
- The wrapper object `{ supabase, isLoading }` was being passed directly to Supabase query functions instead of the `SupabaseClient`, causing `.from()` calls to fail at runtime

## Test plan
- [ ] Navigate to `/admin/agents` and verify the page loads without errors
- [ ] Verify agent list renders correctly
- [ ] Test create, edit, and delete agent operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)