### PR TITLE
feat: workflow interface overhaul with templates and integration actions

### DIFF
--- a/src/components/admin/IntegrationActionForm.tsx
+++ b/src/components/admin/IntegrationActionForm.tsx
@@ -1,0 +1,201 @@
+import { useState, useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+import { useAuthenticatedSupabase } from '@/lib/supabase';
+import { getIntegrations, getIntegrationActions } from '@/lib/agent-platform-queries';
+import type { Integration, IntegrationAction } from '@/lib/schemas';
+
+interface IntegrationActionFormProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+  disabled?: boolean;
+}
+
+export default function IntegrationActionForm({
+  config,
+  onChange,
+  disabled,
+}: IntegrationActionFormProps) {
+  const { supabase } = useAuthenticatedSupabase();
+  const [integrations, setIntegrations] = useState<Integration[]>([]);
+  const [actions, setActions] = useState<IntegrationAction[]>([]);
+  const [selectedAction, setSelectedAction] = useState<IntegrationAction | null>(null);
+
+  useEffect(() => {
+    if (!supabase) return;
+    getIntegrations(supabase).then(setIntegrations);
+  }, [supabase]);
+
+  useEffect(() => {
+    if (!supabase || !config.integration_id) return;
+    getIntegrationActions(config.integration_id as string, supabase).then((data) => {
+      setActions(data);
+      const current = data.find((a) => a.action_name === config.action_name);
+      setSelectedAction(current || null);
+    });
+  }, [supabase, config.integration_id]);
+
+  const handleIntegrationChange = (integrationId: string) => {
+    onChange({
+      ...config,
+      integration_id: integrationId,
+      action_name: '',
+      parameters: {},
+    });
+    setSelectedAction(null);
+  };
+
+  const handleActionChange = (actionName: string) => {
+    const action = actions.find((a) => a.action_name === actionName);
+    setSelectedAction(action || null);
+    onChange({
+      ...config,
+      action_name: actionName,
+      parameters: action?.default_config || {},
+    });
+  };
+
+  const handleParamChange = (key: string, value: unknown) => {
+    const params = (config.parameters || {}) as Record<string, unknown>;
+    onChange({
+      ...config,
+      parameters: { ...params, [key]: value },
+    });
+  };
+
+  const params = (config.parameters || {}) as Record<string, unknown>;
+  const schema = selectedAction?.parameter_schema as Record<string, unknown> | undefined;
+  const properties = (schema?.properties || {}) as Record<
+    string,
+    { type?: string; enum?: string[]; description?: string }
+  >;
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-xs font-medium mb-1">Integration</label>
+        <select
+          value={(config.integration_id as string) || ''}
+          onChange={(e) => handleIntegrationChange(e.target.value)}
+          disabled={disabled}
+          className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm"
+        >
+          <option value="">Select integration...</option>
+          {integrations.map((i) => (
+            <option key={i.id} value={i.id}>
+              {i.display_name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {config.integration_id && (
+        <div>
+          <label className="block text-xs font-medium mb-1">Action</label>
+          <select
+            value={(config.action_name as string) || ''}
+            onChange={(e) => handleActionChange(e.target.value)}
+            disabled={disabled}
+            className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm"
+          >
+            <option value="">Select action...</option>
+            {actions.map((a) => (
+              <option key={a.action_name} value={a.action_name}>
+                {a.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {selectedAction && Object.keys(properties).length > 0 && (
+        <div className="space-y-2 border border-border rounded-md p-3 bg-muted/20">
+          <span className="text-xs font-medium text-muted-foreground">Parameters</span>
+          {Object.entries(properties).map(([key, prop]) => {
+            if (prop.enum) {
+              return (
+                <div key={key}>
+                  <label className="block text-xs font-medium mb-1">{key}</label>
+                  <select
+                    value={String(params[key] ?? '')}
+                    onChange={(e) => handleParamChange(key, e.target.value)}
+                    disabled={disabled}
+                    className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm"
+                  >
+                    <option value="">Select...</option>
+                    {prop.enum.map((v) => (
+                      <option key={v} value={v}>{v}</option>
+                    ))}
+                  </select>
+                </div>
+              );
+            }
+
+            if (prop.type === 'boolean') {
+              return (
+                <div key={key} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(params[key])}
+                    onChange={(e) => handleParamChange(key, e.target.checked)}
+                    disabled={disabled}
+                    className="rounded border-border"
+                  />
+                  <label className="text-xs font-medium">{key}</label>
+                </div>
+              );
+            }
+
+            if (prop.type === 'number') {
+              return (
+                <div key={key}>
+                  <label className="block text-xs font-medium mb-1">{key}</label>
+                  <Input
+                    type="number"
+                    value={String(params[key] ?? '')}
+                    onChange={(e) => handleParamChange(key, parseFloat(e.target.value))}
+                    disabled={disabled}
+                    placeholder={prop.description}
+                    className="text-sm"
+                  />
+                </div>
+              );
+            }
+
+            // Default: string input
+            return (
+              <div key={key}>
+                <label className="block text-xs font-medium mb-1">{key}</label>
+                <Input
+                  value={String(params[key] ?? '')}
+                  onChange={(e) => handleParamChange(key, e.target.value)}
+                  disabled={disabled}
+                  placeholder={prop.description || key}
+                  className="text-sm"
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {selectedAction && Object.keys(properties).length === 0 && (
+        <div>
+          <label className="block text-xs font-medium mb-1">Parameters (JSON)</label>
+          <textarea
+            value={JSON.stringify(params, null, 2)}
+            onChange={(e) => {
+              try {
+                onChange({ ...config, parameters: JSON.parse(e.target.value) });
+              } catch {
+                // Allow invalid JSON while typing
+              }
+            }}
+            disabled={disabled}
+            rows={4}
+            className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm font-mono resize-none"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/WorkflowCreatePanel.tsx
+++ b/src/components/admin/WorkflowCreatePanel.tsx
@@ -1,0 +1,293 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { X, Loader2, ChevronLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import WorkflowStepBuilder, { type WorkflowStep } from './WorkflowStepBuilder';
+import { WORKFLOW_TEMPLATES, TEMPLATE_CATEGORIES, type WorkflowTemplate } from '@/lib/workflow-templates';
+
+interface WorkflowCreatePanelProps {
+  onClose: () => void;
+  onCreate: (workflow: {
+    name: string;
+    description: string;
+    trigger_type: 'manual' | 'scheduled' | 'webhook' | 'event';
+    trigger_config: Record<string, unknown>;
+    steps: WorkflowStep[];
+  }) => Promise<void>;
+  isCreating: boolean;
+}
+
+export default function WorkflowCreatePanel({
+  onClose,
+  onCreate,
+  isCreating,
+}: WorkflowCreatePanelProps) {
+  const [selectedTemplate, setSelectedTemplate] = useState<WorkflowTemplate | null>(null);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [triggerType, setTriggerType] = useState<'manual' | 'scheduled' | 'webhook' | 'event'>('manual');
+  const [previewExpandedSteps, setPreviewExpandedSteps] = useState<Set<string>>(new Set());
+
+  const handleSelectTemplate = (template: WorkflowTemplate) => {
+    setSelectedTemplate(template);
+    setName(template.name);
+    setDescription(template.description);
+    setTriggerType(template.trigger_type);
+  };
+
+  const handleBack = () => {
+    setSelectedTemplate(null);
+    setName('');
+    setDescription('');
+    setTriggerType('manual');
+  };
+
+  const handleCreate = () => {
+    if (!name.trim()) return;
+
+    onCreate({
+      name,
+      description,
+      trigger_type: selectedTemplate?.trigger_type || triggerType,
+      trigger_config: selectedTemplate?.trigger_config || {},
+      steps: selectedTemplate
+        ? selectedTemplate.steps.map((s) => ({ ...s, id: crypto.randomUUID() }))
+        : [],
+    });
+  };
+
+  const togglePreviewExpand = (stepId: string) => {
+    setPreviewExpandedSteps((prev) => {
+      const next = new Set(prev);
+      if (next.has(stepId)) next.delete(stepId);
+      else next.add(stepId);
+      return next;
+    });
+  };
+
+  return (
+    <motion.div
+      initial={{ x: 20, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      exit={{ x: 20, opacity: 0 }}
+      className="flex-none w-full md:w-[45%] bg-card border-l border-border overflow-y-auto max-h-[calc(100vh-8rem)]"
+    >
+      {/* Sticky Header */}
+      <div className="sticky top-0 bg-card border-b border-border px-5 py-4 z-10 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {selectedTemplate && (
+            <button
+              onClick={handleBack}
+              className="p-1 hover:bg-muted rounded transition-colors"
+              aria-label="Back to templates"
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+          )}
+          <h3 className="font-semibold text-foreground text-lg">
+            {selectedTemplate ? 'Configure Workflow' : 'New Workflow'}
+          </h3>
+        </div>
+        <button
+          onClick={onClose}
+          disabled={isCreating}
+          className="p-1 hover:bg-muted rounded transition-colors"
+          aria-label="Close panel"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      <div className="p-5 space-y-5">
+        {selectedTemplate ? (
+          /* Template selected — show config form */
+          <>
+            <div className="flex items-center gap-2">
+              <Badge className="bg-primary/10 text-primary text-xs">
+                {selectedTemplate.category}
+              </Badge>
+              <Badge variant="outline" className="text-xs">
+                {selectedTemplate.trigger_type}
+              </Badge>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">Name</label>
+                <Input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Workflow name"
+                  disabled={isCreating}
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">
+                  Description
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  disabled={isCreating}
+                  rows={2}
+                  className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-2">
+                  Pre-configured Steps ({selectedTemplate.steps.length})
+                </label>
+                <WorkflowStepBuilder
+                  steps={selectedTemplate.steps}
+                  onStepsChange={() => {}}
+                  expandedSteps={previewExpandedSteps}
+                  onToggleExpand={togglePreviewExpand}
+                  readOnly
+                />
+              </div>
+            </div>
+
+            <Button
+              onClick={handleCreate}
+              disabled={isCreating || !name.trim()}
+              className="w-full"
+            >
+              {isCreating ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                `Create from "${selectedTemplate.name}"`
+              )}
+            </Button>
+          </>
+        ) : (
+          /* No template selected — show tabs */
+          <Tabs defaultValue="templates">
+            <TabsList className="w-full">
+              <TabsTrigger value="templates" className="flex-1">
+                Templates
+              </TabsTrigger>
+              <TabsTrigger value="scratch" className="flex-1">
+                From Scratch
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="templates" className="space-y-4 mt-4">
+              {TEMPLATE_CATEGORIES.map((cat) => {
+                const templates = WORKFLOW_TEMPLATES.filter((t) => t.category === cat.id);
+                return (
+                  <div key={cat.id}>
+                    <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+                      {cat.label}
+                    </h4>
+                    <div className="grid grid-cols-1 gap-2">
+                      {templates.map((template) => {
+                        const Icon = template.icon;
+                        return (
+                          <button
+                            key={template.id}
+                            onClick={() => handleSelectTemplate(template)}
+                            className="w-full text-left p-3 rounded-lg border border-border hover:border-primary/50 hover:bg-muted/50 transition-colors group"
+                          >
+                            <div className="flex items-start gap-3">
+                              <div className="p-2 rounded-md bg-primary/10 text-primary">
+                                <Icon className="w-4 h-4" />
+                              </div>
+                              <div className="flex-1 min-w-0">
+                                <div className="font-medium text-sm text-foreground group-hover:text-primary transition-colors">
+                                  {template.name}
+                                </div>
+                                <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                                  {template.description}
+                                </p>
+                                <div className="flex items-center gap-2 mt-1.5">
+                                  <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                                    {template.trigger_type}
+                                  </Badge>
+                                  <span className="text-[10px] text-muted-foreground">
+                                    {template.steps.length} steps
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </TabsContent>
+
+            <TabsContent value="scratch" className="space-y-4 mt-4">
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">Name</label>
+                <Input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="My Workflow"
+                  disabled={isCreating}
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">
+                  Description (optional)
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  disabled={isCreating}
+                  placeholder="What does this workflow do?"
+                  rows={3}
+                  className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-foreground mb-1">
+                  Trigger Type
+                </label>
+                <select
+                  value={triggerType}
+                  onChange={(e) =>
+                    setTriggerType(e.target.value as typeof triggerType)
+                  }
+                  disabled={isCreating}
+                  className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50"
+                >
+                  <option value="manual">Manual</option>
+                  <option value="scheduled">Scheduled</option>
+                  <option value="webhook">Webhook</option>
+                  <option value="event">Event</option>
+                </select>
+              </div>
+
+              <Button
+                onClick={handleCreate}
+                disabled={isCreating || !name.trim()}
+                className="w-full"
+              >
+                {isCreating ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    Creating...
+                  </>
+                ) : (
+                  'Create Workflow'
+                )}
+              </Button>
+            </TabsContent>
+          </Tabs>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/admin/WorkflowStepBuilder.tsx
+++ b/src/components/admin/WorkflowStepBuilder.tsx
@@ -1,0 +1,287 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { Plus, Trash2, ChevronDown, ChevronRight, GripVertical } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import IntegrationActionForm from './IntegrationActionForm';
+
+export interface WorkflowStep {
+  id: string;
+  type: 'agent_command' | 'wait' | 'condition' | 'integration_action';
+  config: Record<string, unknown>;
+  timeout_ms: number;
+  retries: number;
+  on_failure: 'continue' | 'stop' | 'skip';
+}
+
+interface WorkflowStepBuilderProps {
+  steps: WorkflowStep[];
+  onStepsChange: (steps: WorkflowStep[]) => void;
+  expandedSteps: Set<string>;
+  onToggleExpand: (stepId: string) => void;
+  readOnly?: boolean;
+}
+
+const STEP_TYPE_LABELS: Record<WorkflowStep['type'], string> = {
+  agent_command: 'Agent Command',
+  wait: 'Wait',
+  condition: 'Condition',
+  integration_action: 'Integration Action',
+};
+
+export default function WorkflowStepBuilder({
+  steps,
+  onStepsChange,
+  expandedSteps,
+  onToggleExpand,
+  readOnly = false,
+}: WorkflowStepBuilderProps) {
+  const addStep = () => {
+    const newStep: WorkflowStep = {
+      id: crypto.randomUUID(),
+      type: 'agent_command',
+      config: {},
+      timeout_ms: 30000,
+      retries: 0,
+      on_failure: 'stop',
+    };
+    onStepsChange([...steps, newStep]);
+    onToggleExpand(newStep.id);
+  };
+
+  const updateStep = (stepId: string, updates: Partial<WorkflowStep>) => {
+    onStepsChange(
+      steps.map((step) => (step.id === stepId ? { ...step, ...updates } : step))
+    );
+  };
+
+  const deleteStep = (stepId: string) => {
+    onStepsChange(steps.filter((step) => step.id !== stepId));
+  };
+
+  return (
+    <div className="space-y-3">
+      {steps.length === 0 ? (
+        <div className="text-center py-8 text-muted-foreground text-sm">
+          {readOnly ? 'No steps defined.' : 'No steps yet. Click "Add Step" to get started.'}
+        </div>
+      ) : (
+        <AnimatePresence>
+          {steps.map((step, index) => (
+            <motion.div
+              key={step.id}
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+            >
+              <Card className="p-4 space-y-3 bg-muted/20">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    {!readOnly && (
+                      <GripVertical className="w-4 h-4 text-muted-foreground cursor-grab" />
+                    )}
+                    <span className="font-semibold text-sm">Step {index + 1}</span>
+                    <Badge variant="outline" className="text-xs">
+                      {STEP_TYPE_LABELS[step.type]}
+                    </Badge>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onToggleExpand(step.id)}
+                    >
+                      {expandedSteps.has(step.id) ? (
+                        <ChevronDown className="w-4 h-4" />
+                      ) : (
+                        <ChevronRight className="w-4 h-4" />
+                      )}
+                    </Button>
+                    {!readOnly && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => deleteStep(step.id)}
+                      >
+                        <Trash2 className="w-4 h-4 text-red-500" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+
+                <AnimatePresence>
+                  {expandedSteps.has(step.id) && (
+                    <motion.div
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0 }}
+                      className="space-y-3 pt-3 border-t border-border"
+                    >
+                      {!readOnly && (
+                        <div className="grid grid-cols-2 gap-3">
+                          <div>
+                            <label className="block text-xs font-medium mb-1">Type</label>
+                            <select
+                              value={step.type}
+                              onChange={(e) =>
+                                updateStep(step.id, {
+                                  type: e.target.value as WorkflowStep['type'],
+                                  config: {},
+                                })
+                              }
+                              className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm"
+                            >
+                              <option value="agent_command">Agent Command</option>
+                              <option value="wait">Wait</option>
+                              <option value="condition">Condition</option>
+                              <option value="integration_action">Integration Action</option>
+                            </select>
+                          </div>
+
+                          <div>
+                            <label className="block text-xs font-medium mb-1">On Failure</label>
+                            <select
+                              value={step.on_failure}
+                              onChange={(e) =>
+                                updateStep(step.id, {
+                                  on_failure: e.target.value as WorkflowStep['on_failure'],
+                                })
+                              }
+                              className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm"
+                            >
+                              <option value="continue">Continue</option>
+                              <option value="stop">Stop</option>
+                              <option value="skip">Skip</option>
+                            </select>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Type-specific fields */}
+                      {step.type === 'agent_command' && (
+                        <div className="grid grid-cols-2 gap-3">
+                          <div>
+                            <label className="block text-xs font-medium mb-1">Command</label>
+                            <Input
+                              value={String(step.config.command || '')}
+                              onChange={(e) =>
+                                updateStep(step.id, {
+                                  config: { ...step.config, command: e.target.value },
+                                })
+                              }
+                              readOnly={readOnly}
+                              placeholder="agent.run"
+                              className="text-sm"
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs font-medium mb-1">Agent ID</label>
+                            <Input
+                              value={String(step.config.agent_id || '')}
+                              onChange={(e) =>
+                                updateStep(step.id, {
+                                  config: { ...step.config, agent_id: e.target.value },
+                                })
+                              }
+                              readOnly={readOnly}
+                              placeholder="agent-uuid"
+                              className="text-sm"
+                            />
+                          </div>
+                        </div>
+                      )}
+
+                      {step.type === 'wait' && (
+                        <div>
+                          <label className="block text-xs font-medium mb-1">Duration (ms)</label>
+                          <Input
+                            type="number"
+                            value={String(step.config.delay_ms || step.config.duration_ms || 0)}
+                            onChange={(e) =>
+                              updateStep(step.id, {
+                                config: { ...step.config, delay_ms: parseInt(e.target.value) },
+                              })
+                            }
+                            readOnly={readOnly}
+                            placeholder="5000"
+                            className="text-sm"
+                          />
+                        </div>
+                      )}
+
+                      {step.type === 'condition' && (
+                        <div>
+                          <label className="block text-xs font-medium mb-1">Expression</label>
+                          <Input
+                            value={String(step.config.expression || '')}
+                            onChange={(e) =>
+                              updateStep(step.id, {
+                                config: { ...step.config, expression: e.target.value },
+                              })
+                            }
+                            readOnly={readOnly}
+                            placeholder="result.success === true"
+                            className="text-sm"
+                          />
+                        </div>
+                      )}
+
+                      {step.type === 'integration_action' && (
+                        <IntegrationActionForm
+                          config={step.config}
+                          onChange={(newConfig) =>
+                            updateStep(step.id, { config: newConfig })
+                          }
+                          disabled={readOnly}
+                        />
+                      )}
+
+                      {!readOnly && (
+                        <div className="grid grid-cols-2 gap-3">
+                          <div>
+                            <label className="block text-xs font-medium mb-1">Timeout (ms)</label>
+                            <Input
+                              type="number"
+                              value={step.timeout_ms}
+                              onChange={(e) =>
+                                updateStep(step.id, { timeout_ms: parseInt(e.target.value) })
+                              }
+                              placeholder="30000"
+                              className="text-sm"
+                            />
+                          </div>
+                          <div>
+                            <label className="block text-xs font-medium mb-1">Retries</label>
+                            <Input
+                              type="number"
+                              value={step.retries}
+                              onChange={(e) =>
+                                updateStep(step.id, { retries: parseInt(e.target.value) })
+                              }
+                              placeholder="0"
+                              className="text-sm"
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </Card>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+      )}
+
+      {!readOnly && (
+        <Button type="button" variant="outline" size="sm" onClick={addStep} className="w-full">
+          <Plus className="w-4 h-4 mr-2" />
+          Add Step
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/lib/agent-platform-queries.ts
+++ b/src/lib/agent-platform-queries.ts
@@ -14,6 +14,8 @@ import {
   type EventType,
   type EventSubscription,
   type Event,
+  type IntegrationAction,
+  type StepTemplate,
 } from './schemas';
 
 // ============================================
@@ -686,4 +688,104 @@ export async function getEvents(
     returnFallback: true,
     fallback: [] as Event[],
   });
+}
+
+// ============================================
+// INTEGRATION ACTIONS
+// ============================================
+
+export async function getIntegrationActions(
+  integrationId?: string,
+  client: SupabaseClient = getSupabase()
+) {
+  let query = client
+    .from('integration_actions')
+    .select('*')
+    .eq('is_active', true)
+    .order('category, display_name');
+
+  if (integrationId) {
+    query = query.eq('integration_id', integrationId);
+  }
+
+  const { data, error } = await query;
+
+  return handleQueryResult(data, error, {
+    operation: 'getIntegrationActions',
+    returnFallback: true,
+    fallback: [] as IntegrationAction[],
+  });
+}
+
+export async function createIntegrationAction(
+  action: Omit<IntegrationAction, 'id' | 'created_at' | 'updated_at'>,
+  client: SupabaseClient = supabase
+) {
+  const { data, error } = await client
+    .from('integration_actions')
+    .insert(action)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as IntegrationAction;
+}
+
+export async function deleteIntegrationAction(id: string, client: SupabaseClient = getSupabase()) {
+  const { error } = await client
+    .from('integration_actions')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
+}
+
+// ============================================
+// STEP TEMPLATES
+// ============================================
+
+export async function getStepTemplates(
+  category?: string,
+  client: SupabaseClient = getSupabase()
+) {
+  let query = client
+    .from('step_templates')
+    .select('*')
+    .eq('is_active', true)
+    .order('category, name');
+
+  if (category) {
+    query = query.eq('category', category);
+  }
+
+  const { data, error } = await query;
+
+  return handleQueryResult(data, error, {
+    operation: 'getStepTemplates',
+    returnFallback: true,
+    fallback: [] as StepTemplate[],
+  });
+}
+
+export async function createStepTemplate(
+  template: Omit<StepTemplate, 'id' | 'created_at' | 'updated_at'>,
+  client: SupabaseClient = supabase
+) {
+  const { data, error } = await client
+    .from('step_templates')
+    .insert(template)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as StepTemplate;
+}
+
+export async function deleteStepTemplate(id: string, client: SupabaseClient = getSupabase()) {
+  const { error } = await client
+    .from('step_templates')
+    .delete()
+    .eq('id', id);
+
+  if (error) throw error;
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1526,3 +1526,38 @@ export const EventSchema = z.object({
   created_at: z.string(),
 });
 export type Event = z.infer<typeof EventSchema>;
+
+// Integration Actions
+export const IntegrationActionSchema = z.object({
+  id: z.string().uuid(),
+  integration_id: z.string().uuid(),
+  action_name: z.string(),
+  display_name: z.string(),
+  description: z.string().nullable(),
+  category: z.string(),
+  parameter_schema: z.record(z.unknown()),
+  default_config: z.record(z.unknown()),
+  requires_auth: z.boolean(),
+  is_active: z.boolean(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type IntegrationAction = z.infer<typeof IntegrationActionSchema>;
+
+// Step Templates
+export const StepTemplateSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable(),
+  category: z.string(),
+  step_type: z.enum(['agent_command', 'wait', 'condition', 'integration_action']),
+  config: z.record(z.unknown()),
+  timeout_ms: z.number(),
+  retries: z.number(),
+  on_failure: z.enum(['continue', 'stop', 'skip']),
+  integration_action_id: z.string().uuid().nullable(),
+  is_active: z.boolean(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type StepTemplate = z.infer<typeof StepTemplateSchema>;

--- a/src/lib/workflow-templates.ts
+++ b/src/lib/workflow-templates.ts
@@ -1,0 +1,385 @@
+import {
+  Link,
+  Activity,
+  ArrowUpRight,
+  Users,
+  Webhook,
+  MessageSquare,
+  RefreshCw,
+  Database,
+} from 'lucide-react';
+
+interface WorkflowTemplateStep {
+  id: string;
+  type: 'agent_command' | 'wait' | 'condition' | 'integration_action';
+  config: Record<string, unknown>;
+  timeout_ms: number;
+  retries: number;
+  on_failure: 'continue' | 'stop' | 'skip';
+}
+
+export interface WorkflowTemplate {
+  id: string;
+  name: string;
+  description: string;
+  category: 'agent' | 'integration';
+  icon: typeof Link;
+  trigger_type: 'manual' | 'scheduled' | 'webhook' | 'event';
+  trigger_config: Record<string, unknown>;
+  steps: WorkflowTemplateStep[];
+}
+
+export const WORKFLOW_TEMPLATES: WorkflowTemplate[] = [
+  // ===== Agent-Centric Templates =====
+  {
+    id: 'chain-agents',
+    name: 'Chain Agents',
+    description: 'Execute a sequence of agent commands, passing results between steps with failure handling.',
+    category: 'agent',
+    icon: Link,
+    trigger_type: 'manual',
+    trigger_config: {},
+    steps: [
+      {
+        id: 'step-1',
+        type: 'agent_command',
+        config: {
+          command: 'analyze',
+          payload: { task: 'Analyze input data' },
+        },
+        timeout_ms: 60000,
+        retries: 1,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-2',
+        type: 'condition',
+        config: {
+          expression: 'step-1.status == completed',
+          then_step: 'step-3',
+          else_step: undefined,
+        },
+        timeout_ms: 5000,
+        retries: 0,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-3',
+        type: 'agent_command',
+        config: {
+          command: 'process',
+          payload: { task: 'Process analysis results' },
+        },
+        timeout_ms: 60000,
+        retries: 1,
+        on_failure: 'stop',
+      },
+    ],
+  },
+  {
+    id: 'agent-health-monitor',
+    name: 'Agent Health Monitor',
+    description: 'Periodically check agent health and trigger alerts on failures.',
+    category: 'agent',
+    icon: Activity,
+    trigger_type: 'scheduled',
+    trigger_config: { cron: '*/5 * * * *' },
+    steps: [
+      {
+        id: 'step-1',
+        type: 'agent_command',
+        config: {
+          command: 'health_check',
+          payload: { check_type: 'full' },
+        },
+        timeout_ms: 15000,
+        retries: 2,
+        on_failure: 'continue',
+      },
+      {
+        id: 'step-2',
+        type: 'condition',
+        config: {
+          expression: 'step-1.status != completed',
+          then_step: 'step-3',
+        },
+        timeout_ms: 5000,
+        retries: 0,
+        on_failure: 'continue',
+      },
+      {
+        id: 'step-3',
+        type: 'agent_command',
+        config: {
+          command: 'notify',
+          payload: { message: 'Agent health check failed', severity: 'warning' },
+        },
+        timeout_ms: 10000,
+        retries: 1,
+        on_failure: 'continue',
+      },
+    ],
+  },
+  {
+    id: 'auto-escalation',
+    name: 'Auto-Escalation',
+    description: 'Wait for a task to complete, then escalate to a human or senior agent if it times out.',
+    category: 'agent',
+    icon: ArrowUpRight,
+    trigger_type: 'event',
+    trigger_config: { event_type: 'task.created' },
+    steps: [
+      {
+        id: 'step-1',
+        type: 'agent_command',
+        config: {
+          command: 'execute_task',
+          payload: { priority: 'normal' },
+        },
+        timeout_ms: 120000,
+        retries: 0,
+        on_failure: 'continue',
+      },
+      {
+        id: 'step-2',
+        type: 'condition',
+        config: {
+          expression: 'step-1.status == failed',
+          then_step: 'step-3',
+        },
+        timeout_ms: 5000,
+        retries: 0,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-3',
+        type: 'agent_command',
+        config: {
+          command: 'escalate',
+          payload: { reason: 'Task timed out or failed', escalate_to: 'admin' },
+        },
+        timeout_ms: 30000,
+        retries: 1,
+        on_failure: 'stop',
+      },
+    ],
+  },
+  {
+    id: 'smart-delegation',
+    name: 'Smart Delegation',
+    description: 'Route tasks to the best-fit agent based on capability matching.',
+    category: 'agent',
+    icon: Users,
+    trigger_type: 'manual',
+    trigger_config: {},
+    steps: [
+      {
+        id: 'step-1',
+        type: 'agent_command',
+        config: {
+          command: 'find_best_agent',
+          payload: { capability: 'code_review', min_proficiency: 0.7 },
+        },
+        timeout_ms: 15000,
+        retries: 1,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-2',
+        type: 'agent_command',
+        config: {
+          command: 'delegate_task',
+          payload: { task: 'Review pull request' },
+        },
+        timeout_ms: 60000,
+        retries: 0,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-3',
+        type: 'wait',
+        config: { delay_ms: 5000 },
+        timeout_ms: 10000,
+        retries: 0,
+        on_failure: 'continue',
+      },
+      {
+        id: 'step-4',
+        type: 'agent_command',
+        config: {
+          command: 'check_delegation_status',
+          payload: {},
+        },
+        timeout_ms: 15000,
+        retries: 0,
+        on_failure: 'continue',
+      },
+    ],
+  },
+
+  // ===== Integration-Driven Templates =====
+  {
+    id: 'webhook-pipeline',
+    name: 'Webhook Pipeline',
+    description: 'Receive webhook data, validate it, and dispatch to an integration action.',
+    category: 'integration',
+    icon: Webhook,
+    trigger_type: 'webhook',
+    trigger_config: { path: '/incoming' },
+    steps: [
+      {
+        id: 'step-1',
+        type: 'agent_command',
+        config: {
+          command: 'validate_payload',
+          payload: { schema: 'webhook_input' },
+        },
+        timeout_ms: 10000,
+        retries: 0,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-2',
+        type: 'integration_action',
+        config: {
+          integration_id: '',
+          action_name: '',
+          parameters: {},
+        },
+        timeout_ms: 30000,
+        retries: 1,
+        on_failure: 'stop',
+      },
+    ],
+  },
+  {
+    id: 'slack-notifications',
+    name: 'Slack Notifications',
+    description: 'Send formatted notifications to Slack channels based on events.',
+    category: 'integration',
+    icon: MessageSquare,
+    trigger_type: 'event',
+    trigger_config: { event_type: 'notification.send' },
+    steps: [
+      {
+        id: 'step-1',
+        type: 'agent_command',
+        config: {
+          command: 'format_message',
+          payload: { template: 'slack_notification' },
+        },
+        timeout_ms: 10000,
+        retries: 0,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-2',
+        type: 'integration_action',
+        config: {
+          integration_id: '',
+          action_name: 'send_message',
+          parameters: { channel: '#general', text: '' },
+        },
+        timeout_ms: 15000,
+        retries: 2,
+        on_failure: 'continue',
+      },
+    ],
+  },
+  {
+    id: 'api-polling',
+    name: 'API Polling',
+    description: 'Periodically poll an external API and process new data.',
+    category: 'integration',
+    icon: RefreshCw,
+    trigger_type: 'scheduled',
+    trigger_config: { cron: '0 * * * *' },
+    steps: [
+      {
+        id: 'step-1',
+        type: 'integration_action',
+        config: {
+          integration_id: '',
+          action_name: 'fetch_data',
+          parameters: { endpoint: '/api/updates', since: 'last_run' },
+        },
+        timeout_ms: 30000,
+        retries: 2,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-2',
+        type: 'condition',
+        config: {
+          expression: 'step-1.status == completed',
+          then_step: 'step-3',
+        },
+        timeout_ms: 5000,
+        retries: 0,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-3',
+        type: 'agent_command',
+        config: {
+          command: 'process_updates',
+          payload: {},
+        },
+        timeout_ms: 60000,
+        retries: 1,
+        on_failure: 'continue',
+      },
+    ],
+  },
+  {
+    id: 'data-sync',
+    name: 'Data Sync',
+    description: 'Synchronize data between two integrations on a schedule.',
+    category: 'integration',
+    icon: Database,
+    trigger_type: 'scheduled',
+    trigger_config: { cron: '0 */6 * * *' },
+    steps: [
+      {
+        id: 'step-1',
+        type: 'integration_action',
+        config: {
+          integration_id: '',
+          action_name: 'export_data',
+          parameters: { format: 'json' },
+        },
+        timeout_ms: 60000,
+        retries: 1,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-2',
+        type: 'agent_command',
+        config: {
+          command: 'transform_data',
+          payload: { mapping: 'default' },
+        },
+        timeout_ms: 30000,
+        retries: 0,
+        on_failure: 'stop',
+      },
+      {
+        id: 'step-3',
+        type: 'integration_action',
+        config: {
+          integration_id: '',
+          action_name: 'import_data',
+          parameters: { format: 'json', upsert: true },
+        },
+        timeout_ms: 60000,
+        retries: 1,
+        on_failure: 'stop',
+      },
+    ],
+  },
+];
+
+export const TEMPLATE_CATEGORIES = [
+  { id: 'agent', label: 'Agent' },
+  { id: 'integration', label: 'Integration' },
+] as const;

--- a/src/pages/admin/Workflows.tsx
+++ b/src/pages/admin/Workflows.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { GitBranch, Plus, Search, Play, Pause, Loader2, X } from 'lucide-react';
+import { GitBranch, Plus, Search, Play, Pause, Loader2 } from 'lucide-react';
 import AdminLayout from '@/components/AdminLayout';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
+import WorkflowCreatePanel from '@/components/admin/WorkflowCreatePanel';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
@@ -36,15 +37,8 @@ const Workflows = () => {
   const [workflows, setWorkflows] = useState<Workflow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
-  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showCreatePanel, setShowCreatePanel] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
-
-  // Create modal form state
-  const [newWorkflow, setNewWorkflow] = useState({
-    name: '',
-    description: '',
-    trigger_type: 'manual' as const,
-  });
 
   useEffect(() => {
     async function fetchWorkflows() {
@@ -85,19 +79,24 @@ const Workflows = () => {
     }
   };
 
-  const handleCreateWorkflow = async () => {
+  const handleCreateWorkflow = async (data: {
+    name: string;
+    description: string;
+    trigger_type: 'manual' | 'scheduled' | 'webhook' | 'event';
+    trigger_config: Record<string, unknown>;
+    steps: { id: string; type: string; config: Record<string, unknown>; timeout_ms: number; retries: number; on_failure: string }[];
+  }) => {
     if (!supabase) return;
-    if (!newWorkflow.name.trim()) return;
 
     setIsCreating(true);
     try {
       const created = await createWorkflow(
         {
-          name: newWorkflow.name,
-          description: newWorkflow.description || null,
-          trigger_type: newWorkflow.trigger_type,
-          trigger_config: null,
-          steps: [],
+          name: data.name,
+          description: data.description || null,
+          trigger_type: data.trigger_type,
+          trigger_config: Object.keys(data.trigger_config).length > 0 ? data.trigger_config : null,
+          steps: data.steps,
           is_active: false,
           created_by: null,
         },
@@ -105,10 +104,7 @@ const Workflows = () => {
       );
 
       setWorkflows(prev => [created, ...prev]);
-      setShowCreateModal(false);
-      setNewWorkflow({ name: '', description: '', trigger_type: 'manual' });
-
-      // Navigate to the new workflow's editor
+      setShowCreatePanel(false);
       navigate(`/admin/workflows/${created.id}`);
     } catch (error) {
       captureException(
@@ -120,7 +116,6 @@ const Workflows = () => {
     }
   };
 
-  // Filter workflows by search query
   const filteredWorkflows = workflows.filter(workflow =>
     workflow.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
     (workflow.description && workflow.description.toLowerCase().includes(searchQuery.toLowerCase()))
@@ -137,7 +132,7 @@ const Workflows = () => {
               Automate tasks with multi-step workflows
             </p>
           </div>
-          <Button onClick={() => setShowCreateModal(true)}>
+          <Button onClick={() => setShowCreatePanel(!showCreatePanel)}>
             <Plus className="w-4 h-4 mr-2" />
             New Workflow
           </Button>
@@ -155,223 +150,123 @@ const Workflows = () => {
           />
         </div>
 
-        {/* Loading State */}
-        {isLoading && (
-          <div className="flex items-center justify-center py-12">
-            <Loader2 className="w-8 h-8 animate-spin text-primary" />
-          </div>
-        )}
-
-        {/* Empty State */}
-        {!isLoading && filteredWorkflows.length === 0 && !searchQuery && (
+        {/* Main Content: List + Panel */}
+        <div className="flex gap-0">
           <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="text-center py-12"
+            animate={{ flex: showCreatePanel ? '0 0 55%' : '1 1 100%' }}
+            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            className="min-w-0"
           >
-            <GitBranch className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold text-foreground mb-2">No workflows yet</h3>
-            <p className="text-muted-foreground mb-4">
-              Create your first workflow to automate tasks
-            </p>
-            <Button onClick={() => setShowCreateModal(true)}>
-              <Plus className="w-4 h-4 mr-2" />
-              Create Workflow
-            </Button>
-          </motion.div>
-        )}
+            {/* Loading State */}
+            {isLoading && (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 className="w-8 h-8 animate-spin text-primary" />
+              </div>
+            )}
 
-        {/* No Search Results */}
-        {!isLoading && filteredWorkflows.length === 0 && searchQuery && (
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="text-center py-12"
-          >
-            <Search className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold text-foreground mb-2">No workflows found</h3>
-            <p className="text-muted-foreground">
-              Try adjusting your search query
-            </p>
-          </motion.div>
-        )}
-
-        {/* Workflows Grid */}
-        {!isLoading && filteredWorkflows.length > 0 && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredWorkflows.map((workflow, index) => (
+            {/* Empty State */}
+            {!isLoading && filteredWorkflows.length === 0 && !searchQuery && (
               <motion.div
-                key={workflow.id}
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.05 }}
+                className="text-center py-12"
               >
-                <Card className="p-6 hover:border-primary/50 transition-colors cursor-pointer group relative">
-                  <Link to={`/admin/workflows/${workflow.id}`} className="absolute inset-0" />
+                <GitBranch className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
+                <h3 className="text-lg font-semibold text-foreground mb-2">No workflows yet</h3>
+                <p className="text-muted-foreground mb-4">
+                  Create your first workflow to automate tasks
+                </p>
+                <Button onClick={() => setShowCreatePanel(true)}>
+                  <Plus className="w-4 h-4 mr-2" />
+                  Create Workflow
+                </Button>
+              </motion.div>
+            )}
 
-                  <div className="space-y-4">
-                    {/* Header */}
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-semibold text-foreground group-hover:text-primary transition-colors truncate">
-                          {workflow.name}
-                        </h3>
-                        {workflow.description && (
-                          <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
-                            {workflow.description}
-                          </p>
-                        )}
+            {/* No Search Results */}
+            {!isLoading && filteredWorkflows.length === 0 && searchQuery && (
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="text-center py-12"
+              >
+                <Search className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
+                <h3 className="text-lg font-semibold text-foreground mb-2">No workflows found</h3>
+                <p className="text-muted-foreground">
+                  Try adjusting your search query
+                </p>
+              </motion.div>
+            )}
+
+            {/* Workflows Grid */}
+            {!isLoading && filteredWorkflows.length > 0 && (
+              <div className="grid gap-6" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))' }}>
+                {filteredWorkflows.map((workflow, index) => (
+                  <motion.div
+                    key={workflow.id}
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.05 }}
+                  >
+                    <Card className="p-6 hover:border-primary/50 transition-colors cursor-pointer group relative">
+                      <Link to={`/admin/workflows/${workflow.id}`} className="absolute inset-0" />
+
+                      <div className="space-y-4">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex-1 min-w-0">
+                            <h3 className="font-semibold text-foreground group-hover:text-primary transition-colors truncate">
+                              {workflow.name}
+                            </h3>
+                            {workflow.description && (
+                              <p className="text-sm text-muted-foreground mt-1 line-clamp-2">
+                                {workflow.description}
+                              </p>
+                            )}
+                          </div>
+
+                          <button
+                            onClick={(e) => {
+                              e.preventDefault();
+                              handleToggleActive(workflow);
+                            }}
+                            className="relative z-10 p-1.5 rounded hover:bg-muted transition-colors"
+                            aria-label={workflow.is_active ? 'Pause workflow' : 'Activate workflow'}
+                          >
+                            {workflow.is_active ? (
+                              <Pause className="w-4 h-4 text-green-500" />
+                            ) : (
+                              <Play className="w-4 h-4 text-muted-foreground" />
+                            )}
+                          </button>
+                        </div>
+
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <Badge className={getTriggerBadgeStyles(workflow.trigger_type)}>
+                            {workflow.trigger_type}
+                          </Badge>
+                          <span className="text-xs text-muted-foreground">
+                            {workflow.steps?.length || 0} steps
+                          </span>
+                        </div>
                       </div>
+                    </Card>
+                  </motion.div>
+                ))}
+              </div>
+            )}
+          </motion.div>
 
-                      {/* Active Toggle */}
-                      <button
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handleToggleActive(workflow);
-                        }}
-                        className="relative z-10 p-1.5 rounded hover:bg-muted transition-colors"
-                        aria-label={workflow.is_active ? 'Pause workflow' : 'Activate workflow'}
-                      >
-                        {workflow.is_active ? (
-                          <Pause className="w-4 h-4 text-green-500" />
-                        ) : (
-                          <Play className="w-4 h-4 text-muted-foreground" />
-                        )}
-                      </button>
-                    </div>
-
-                    {/* Metadata */}
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <Badge className={getTriggerBadgeStyles(workflow.trigger_type)}>
-                        {workflow.trigger_type}
-                      </Badge>
-                      <span className="text-xs text-muted-foreground">
-                        {workflow.steps?.length || 0} steps
-                      </span>
-                    </div>
-                  </div>
-                </Card>
-              </motion.div>
-            ))}
-          </div>
-        )}
-
-        {/* Create Modal */}
-        <AnimatePresence>
-          {showCreateModal && (
-            <>
-              {/* Backdrop */}
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                onClick={() => !isCreating && setShowCreateModal(false)}
-                className="fixed inset-0 bg-black/50 z-50"
+          {/* Create Panel */}
+          <AnimatePresence>
+            {showCreatePanel && (
+              <WorkflowCreatePanel
+                onClose={() => setShowCreatePanel(false)}
+                onCreate={handleCreateWorkflow}
+                isCreating={isCreating}
               />
-
-              {/* Modal */}
-              <motion.div
-                initial={{ opacity: 0, scale: 0.95 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.95 }}
-                className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md bg-card border border-border rounded-lg shadow-lg z-50 p-6"
-              >
-                <div className="space-y-4">
-                  {/* Modal Header */}
-                  <div className="flex items-center justify-between">
-                    <h2 className="text-xl font-semibold text-foreground">Create Workflow</h2>
-                    <button
-                      onClick={() => !isCreating && setShowCreateModal(false)}
-                      disabled={isCreating}
-                      className="p-1 hover:bg-muted rounded transition-colors"
-                      aria-label="Close modal"
-                    >
-                      <X className="w-5 h-5" />
-                    </button>
-                  </div>
-
-                  {/* Form */}
-                  <div className="space-y-4">
-                    <div>
-                      <label htmlFor="workflow-name" className="block text-sm font-medium text-foreground mb-1">
-                        Name
-                      </label>
-                      <Input
-                        id="workflow-name"
-                        type="text"
-                        placeholder="My Workflow"
-                        value={newWorkflow.name}
-                        onChange={(e) => setNewWorkflow(prev => ({ ...prev, name: e.target.value }))}
-                        disabled={isCreating}
-                      />
-                    </div>
-
-                    <div>
-                      <label htmlFor="workflow-description" className="block text-sm font-medium text-foreground mb-1">
-                        Description (optional)
-                      </label>
-                      <textarea
-                        id="workflow-description"
-                        placeholder="What does this workflow do?"
-                        value={newWorkflow.description}
-                        onChange={(e) => setNewWorkflow(prev => ({ ...prev, description: e.target.value }))}
-                        disabled={isCreating}
-                        className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm resize-none focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50"
-                        rows={3}
-                      />
-                    </div>
-
-                    <div>
-                      <label htmlFor="workflow-trigger" className="block text-sm font-medium text-foreground mb-1">
-                        Trigger Type
-                      </label>
-                      <select
-                        id="workflow-trigger"
-                        value={newWorkflow.trigger_type}
-                        onChange={(e) => setNewWorkflow(prev => ({
-                          ...prev,
-                          trigger_type: e.target.value as 'manual' | 'scheduled' | 'webhook' | 'event'
-                        }))}
-                        disabled={isCreating}
-                        className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50"
-                      >
-                        <option value="manual">Manual</option>
-                        <option value="scheduled">Scheduled</option>
-                        <option value="webhook">Webhook</option>
-                        <option value="event">Event</option>
-                      </select>
-                    </div>
-                  </div>
-
-                  {/* Actions */}
-                  <div className="flex items-center gap-3 pt-2">
-                    <Button
-                      onClick={handleCreateWorkflow}
-                      disabled={isCreating || !newWorkflow.name.trim()}
-                      className="flex-1"
-                    >
-                      {isCreating ? (
-                        <>
-                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                          Creating...
-                        </>
-                      ) : (
-                        'Create Workflow'
-                      )}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      onClick={() => setShowCreateModal(false)}
-                      disabled={isCreating}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              </motion.div>
-            </>
-          )}
-        </AnimatePresence>
+            )}
+          </AnimatePresence>
+        </div>
       </div>
     </AdminLayout>
   );

--- a/supabase/migrations/20240601000008_workflow_connectors.sql
+++ b/supabase/migrations/20240601000008_workflow_connectors.sql
@@ -1,0 +1,103 @@
+-- Migration: Workflow Connectors
+-- Adds integration_actions and step_templates tables for the workflow overhaul.
+-- integration_actions defines per-integration actions (e.g., Slack "send_message").
+-- step_templates provides reusable pre-built step configurations.
+
+-- Prerequisite check: integrations table must exist
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'integrations') THEN
+    RAISE EXCEPTION 'Missing prerequisite: integrations table. Run 20240601000004_agent_platform.sql first.';
+  END IF;
+END
+$$;
+
+-- ============================================
+-- INTEGRATION ACTIONS
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS integration_actions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  integration_id UUID NOT NULL REFERENCES integrations(id) ON DELETE CASCADE,
+  action_name TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  description TEXT,
+  category TEXT NOT NULL DEFAULT 'general',
+  parameter_schema JSONB NOT NULL DEFAULT '{}'::jsonb,
+  default_config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  requires_auth BOOLEAN NOT NULL DEFAULT true,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(integration_id, action_name)
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_integration_actions_integration_id
+  ON integration_actions (integration_id);
+CREATE INDEX IF NOT EXISTS idx_integration_actions_category
+  ON integration_actions (category);
+CREATE INDEX IF NOT EXISTS idx_integration_actions_active
+  ON integration_actions (is_active) WHERE is_active = true;
+
+-- updated_at trigger
+CREATE OR REPLACE TRIGGER set_integration_actions_updated_at
+  BEFORE UPDATE ON integration_actions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- RLS
+ALTER TABLE integration_actions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admin full access on integration_actions"
+  ON integration_actions FOR ALL
+  USING (auth.jwt() ->> 'role' = 'admin')
+  WITH CHECK (auth.jwt() ->> 'role' = 'admin');
+
+CREATE POLICY "Agents can read active integration_actions"
+  ON integration_actions FOR SELECT
+  USING (is_active = true);
+
+-- ============================================
+-- STEP TEMPLATES
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS step_templates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  description TEXT,
+  category TEXT NOT NULL DEFAULT 'general',
+  step_type TEXT NOT NULL CHECK (step_type IN ('agent_command', 'wait', 'condition', 'integration_action')),
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+  timeout_ms INTEGER NOT NULL DEFAULT 30000,
+  retries INTEGER NOT NULL DEFAULT 0,
+  on_failure TEXT NOT NULL DEFAULT 'stop' CHECK (on_failure IN ('continue', 'stop', 'skip')),
+  integration_action_id UUID REFERENCES integration_actions(id) ON DELETE SET NULL,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_step_templates_category
+  ON step_templates (category);
+CREATE INDEX IF NOT EXISTS idx_step_templates_step_type
+  ON step_templates (step_type);
+CREATE INDEX IF NOT EXISTS idx_step_templates_integration_action_id
+  ON step_templates (integration_action_id) WHERE integration_action_id IS NOT NULL;
+
+-- updated_at trigger
+CREATE OR REPLACE TRIGGER set_step_templates_updated_at
+  BEFORE UPDATE ON step_templates
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- RLS
+ALTER TABLE step_templates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Admin full access on step_templates"
+  ON step_templates FOR ALL
+  USING (auth.jwt() ->> 'role' = 'admin')
+  WITH CHECK (auth.jwt() ->> 'role' = 'admin');
+
+CREATE POLICY "Authenticated users can read active step_templates"
+  ON step_templates FOR SELECT
+  USING (is_active = true);


### PR DESCRIPTION
## Summary
- Replace popup modal workflow creation with an inline slide-in panel featuring Radix Tabs (Templates / From Scratch)
- Add 8 pre-configured workflow templates (4 agent-centric, 4 integration-driven) for one-click workflow creation
- Introduce `integration_action` step type backed by new `integration_actions` and `step_templates` DB tables
- Add dynamic form rendering from JSON Schema for integration action parameters
- Replace all `alert()`/`confirm()` calls in WorkflowEditor with inline feedback UI

## Changes
| File | Action |
|------|--------|
| `supabase/migrations/20240601000008_workflow_connectors.sql` | New migration |
| `src/lib/schemas.ts` | Add IntegrationAction + StepTemplate Zod schemas |
| `src/lib/agent-platform-queries.ts` | Add 6 CRUD functions |
| `src/lib/workflow-templates.ts` | 8 workflow templates |
| `src/components/admin/IntegrationActionForm.tsx` | Dynamic form renderer |
| `src/components/admin/WorkflowStepBuilder.tsx` | Shared step list component |
| `src/components/admin/WorkflowCreatePanel.tsx` | Slide-in creation panel |
| `src/pages/admin/Workflows.tsx` | Replace modal with flex master-detail layout |
| `src/pages/admin/WorkflowEditor.tsx` | Add integration_action + inline feedback |
| `supabase/functions/workflow-executor/index.ts` | Add integration_action executor |

## Test plan
- [ ] Open `/admin/workflows` — verify "New Workflow" opens slide-in panel (not popup)
- [ ] Verify workflow list shrinks smoothly when panel opens
- [ ] Verify template cards are visible, grouped by category, and clickable
- [ ] Create a workflow from a template — verify steps are pre-populated
- [ ] Create a workflow from scratch — verify it still works
- [ ] Open workflow editor — verify "Integration Action" in step type dropdown
- [ ] Verify selecting Integration Action shows integration/action dropdowns
- [ ] Save a workflow — verify inline success message (no alert)
- [ ] Delete a workflow — verify inline confirmation (no confirm dialog)
- [ ] Run `npx supabase migration list` — verify new migration is recognized
- [ ] Run `npm run build` — passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)