### PR TITLE
fix: extract metadata object to fix schema validation test

### DIFF
--- a/supabase/functions/workflow-executor/index.ts
+++ b/supabase/functions/workflow-executor/index.ts
@@ -195,6 +195,12 @@ async function executeStepInner(
       // Dispatch as an agent command with integration context in metadata
       const content = JSON.stringify(mergedParams)
 
+      const integrationMeta = {
+        workflow_integration_action: action_name,
+        integration_id: integration_id || null,
+        integration_action_id: actionDef?.id || null,
+      }
+
       const { data, error } = await supabase
         .from('agent_commands')
         .insert({
@@ -204,11 +210,7 @@ async function executeStepInner(
           user_id: agentId || 'system',
           user_email: 'workflow@system',
           session_id: crypto.randomUUID(),
-          metadata: {
-            workflow_integration_action: action_name,
-            integration_id: integration_id || null,
-            integration_action_id: actionDef?.id || null,
-          },
+          metadata: integrationMeta,
         })
         .select('id')
         .single()


### PR DESCRIPTION
## Summary
- Extract nested metadata object in workflow-executor's `integration_action` case to a variable
- Fixes schema validation test false positive where regex matched `integration_id` and `integration_action_id` as `agent_commands` columns

## Context
PR #192 merged without this fix due to a squash merge issue. The CI test on main is currently failing.

## Test plan
- [x] `npx vitest run tests/agent-platform/schema-validation.test.ts` — 13/13 pass
- [ ] CI Tests job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)