### PR TITLE
feat: Phase 2 — Full Windowing (Drag, Resize, Snap)

### DIFF
--- a/src/hooks/useSnapZones.tsx
+++ b/src/hooks/useSnapZones.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useRef, useState } from 'react';
+
+const SNAP_THRESHOLD = 12;
+const MENU_BAR_HEIGHT = 28;
+const DOCK_HEIGHT = 64;
+
+export type SnapZone =
+  | 'left-half'
+  | 'right-half'
+  | 'full'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+  | null;
+
+/** Get the snap zone based on cursor position relative to viewport edges */
+function detectSnapZone(clientX: number, clientY: number): SnapZone {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  const nearLeft = clientX <= SNAP_THRESHOLD;
+  const nearRight = clientX >= vw - SNAP_THRESHOLD;
+  const nearTop = clientY <= MENU_BAR_HEIGHT + SNAP_THRESHOLD;
+  const nearBottom = clientY >= vh - DOCK_HEIGHT - SNAP_THRESHOLD;
+
+  // Corners take priority
+  if (nearTop && nearLeft) return 'top-left';
+  if (nearTop && nearRight) return 'top-right';
+  if (nearBottom && nearLeft) return 'bottom-left';
+  if (nearBottom && nearRight) return 'bottom-right';
+
+  // Full screen via top edge
+  if (nearTop) return 'full';
+
+  // Halves via left/right edges
+  if (nearLeft) return 'left-half';
+  if (nearRight) return 'right-half';
+
+  return null;
+}
+
+/** Get the target geometry for a snap zone */
+export function getSnapGeometry(zone: SnapZone): {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} | null {
+  if (!zone) return null;
+
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const usableHeight = vh - MENU_BAR_HEIGHT - DOCK_HEIGHT;
+  const halfW = Math.floor(vw / 2);
+  const halfH = Math.floor(usableHeight / 2);
+
+  switch (zone) {
+    case 'full':
+      return { x: 0, y: MENU_BAR_HEIGHT, width: vw, height: usableHeight };
+    case 'left-half':
+      return { x: 0, y: MENU_BAR_HEIGHT, width: halfW, height: usableHeight };
+    case 'right-half':
+      return { x: halfW, y: MENU_BAR_HEIGHT, width: vw - halfW, height: usableHeight };
+    case 'top-left':
+      return { x: 0, y: MENU_BAR_HEIGHT, width: halfW, height: halfH };
+    case 'top-right':
+      return { x: halfW, y: MENU_BAR_HEIGHT, width: vw - halfW, height: halfH };
+    case 'bottom-left':
+      return { x: 0, y: MENU_BAR_HEIGHT + halfH, width: halfW, height: usableHeight - halfH };
+    case 'bottom-right':
+      return { x: halfW, y: MENU_BAR_HEIGHT + halfH, width: vw - halfW, height: usableHeight - halfH };
+    default:
+      return null;
+  }
+}
+
+export function useSnapZones() {
+  const [activeZone, setActiveZone] = useState<SnapZone>(null);
+  const zoneRef = useRef<SnapZone>(null);
+
+  const updateSnapZone = useCallback((clientX: number, clientY: number) => {
+    const zone = detectSnapZone(clientX, clientY);
+    if (zone !== zoneRef.current) {
+      zoneRef.current = zone;
+      setActiveZone(zone);
+    }
+  }, []);
+
+  const clearSnapZone = useCallback(() => {
+    zoneRef.current = null;
+    setActiveZone(null);
+  }, []);
+
+  /** Returns snap geometry if active, or null if no snap */
+  const commitSnap = useCallback((): ReturnType<typeof getSnapGeometry> => {
+    const zone = zoneRef.current;
+    const geo = getSnapGeometry(zone);
+    zoneRef.current = null;
+    setActiveZone(null);
+    return geo;
+  }, []);
+
+  return { activeZone, updateSnapZone, clearSnapZone, commitSnap };
+}
+
+/** Semi-transparent blue snap preview overlay */
+export function SnapPreview({ zone }: { zone: SnapZone }) {
+  const geo = getSnapGeometry(zone);
+  if (!geo) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: geo.x,
+        top: geo.y,
+        width: geo.width,
+        height: geo.height,
+        zIndex: 9999,
+        pointerEvents: 'none',
+      }}
+      className="bg-blue-500/20 border-2 border-blue-500/40 rounded-lg transition-all duration-150"
+    />
+  );
+}

--- a/src/hooks/useWindowDrag.ts
+++ b/src/hooks/useWindowDrag.ts
@@ -1,0 +1,124 @@
+import { useCallback, useRef } from 'react';
+
+const MENU_BAR_HEIGHT = 28;
+const TITLE_BAR_MIN_VISIBLE = 48;
+
+export interface DragCallbacks {
+  onDragStart?: () => void;
+  onDragMove?: (x: number, y: number) => void;
+  onDragEnd?: (x: number, y: number) => void;
+}
+
+export interface UseWindowDragOptions {
+  windowRef: React.RefObject<HTMLDivElement | null>;
+  x: number;
+  y: number;
+  width: number;
+  maximized: boolean;
+  callbacks?: DragCallbacks;
+}
+
+export function useWindowDrag({
+  windowRef,
+  x,
+  y,
+  width,
+  maximized,
+  callbacks,
+}: UseWindowDragOptions) {
+  const dragStartRef = useRef<{
+    px: number;
+    py: number;
+    winX: number;
+    winY: number;
+  } | null>(null);
+  const isDraggingRef = useRef(false);
+
+  const handleTitleBarPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (maximized) return;
+      e.preventDefault();
+      const el = windowRef.current;
+      if (!el) return;
+
+      dragStartRef.current = { px: e.clientX, py: e.clientY, winX: x, winY: y };
+      isDraggingRef.current = false;
+      el.setPointerCapture(e.pointerId);
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        if (!dragStartRef.current) return;
+        const dx = moveEvent.clientX - dragStartRef.current.px;
+        const dy = moveEvent.clientY - dragStartRef.current.py;
+
+        if (!isDraggingRef.current && (Math.abs(dx) > 2 || Math.abs(dy) > 2)) {
+          isDraggingRef.current = true;
+          callbacks?.onDragStart?.();
+        }
+
+        if (!isDraggingRef.current) return;
+
+        const viewW = window.innerWidth;
+        const viewH = window.innerHeight;
+
+        // Boundary constraints
+        let newX = dragStartRef.current.winX + dx;
+        let newY = dragStartRef.current.winY + dy;
+        // Cannot go above menu bar
+        newY = Math.max(MENU_BAR_HEIGHT, newY);
+        // At least 48px of title bar visible horizontally
+        newX = Math.max(-width + TITLE_BAR_MIN_VISIBLE, newX);
+        newX = Math.min(viewW - TITLE_BAR_MIN_VISIBLE, newX);
+        // At least title bar visible vertically (don't go below viewport)
+        newY = Math.min(viewH - TITLE_BAR_MIN_VISIBLE, newY);
+
+        // GPU-accelerated movement via transform
+        if (windowRef.current) {
+          windowRef.current.style.transform = `translate(${newX}px, ${newY}px)`;
+          windowRef.current.style.left = '0';
+          windowRef.current.style.top = '0';
+        }
+
+        callbacks?.onDragMove?.(newX, newY);
+      };
+
+      const handleUp = (upEvent: PointerEvent) => {
+        el.removeEventListener('pointermove', handleMove);
+        el.removeEventListener('pointerup', handleUp);
+
+        if (!dragStartRef.current) return;
+        const dx = upEvent.clientX - dragStartRef.current.px;
+        const dy = upEvent.clientY - dragStartRef.current.py;
+
+        const viewW = window.innerWidth;
+        const viewH = window.innerHeight;
+
+        let newX = dragStartRef.current.winX + dx;
+        let newY = dragStartRef.current.winY + dy;
+        newY = Math.max(MENU_BAR_HEIGHT, newY);
+        newX = Math.max(-width + TITLE_BAR_MIN_VISIBLE, newX);
+        newX = Math.min(viewW - TITLE_BAR_MIN_VISIBLE, newX);
+        newY = Math.min(viewH - TITLE_BAR_MIN_VISIBLE, newY);
+
+        dragStartRef.current = null;
+
+        // Commit to DOM before state update
+        if (windowRef.current) {
+          windowRef.current.style.transform = '';
+          windowRef.current.style.left = `${newX}px`;
+          windowRef.current.style.top = `${newY}px`;
+        }
+
+        if (isDraggingRef.current) {
+          callbacks?.onDragEnd?.(newX, newY);
+        }
+        isDraggingRef.current = false;
+      };
+
+      el.addEventListener('pointermove', handleMove);
+      el.addEventListener('pointerup', handleUp);
+    },
+    [windowRef, x, y, width, maximized, callbacks]
+  );
+
+  return { handleTitleBarPointerDown, isDraggingRef };
+}

--- a/src/hooks/useWindowResize.tsx
+++ b/src/hooks/useWindowResize.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useRef } from 'react';
+
+const MENU_BAR_HEIGHT = 28;
+
+export type ResizeEdge = 'n' | 'e' | 's' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+
+export interface ResizeCallbacks {
+  onResizeEnd: (x: number, y: number, width: number, height: number) => void;
+}
+
+export interface UseWindowResizeOptions {
+  windowRef: React.RefObject<HTMLDivElement | null>;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  minWidth: number;
+  minHeight: number;
+  maximized: boolean;
+  callbacks: ResizeCallbacks;
+}
+
+interface ResizeStart {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Pure geometry calculation extracted for reuse between move and up handlers */
+function calcResize(
+  edge: ResizeEdge,
+  dx: number,
+  dy: number,
+  start: ResizeStart,
+  minW: number,
+  minH: number,
+) {
+  let { x: newX, y: newY, w: newW, h: newH } = start;
+
+  const hasEast = edge === 'e' || edge === 'ne' || edge === 'se';
+  const hasWest = edge === 'w' || edge === 'nw' || edge === 'sw';
+  const hasSouth = edge === 's' || edge === 'se' || edge === 'sw';
+  const hasNorth = edge === 'n' || edge === 'ne' || edge === 'nw';
+
+  if (hasEast) newW = Math.max(minW, start.w + dx);
+  if (hasWest) {
+    const dw = Math.min(dx, start.w - minW);
+    newW = start.w - dw;
+    newX = start.x + dw;
+  }
+  if (hasSouth) newH = Math.max(minH, start.h + dy);
+  if (hasNorth) {
+    const dh = Math.min(dy, start.h - minH);
+    newH = start.h - dh;
+    newY = Math.max(MENU_BAR_HEIGHT, start.y + dh);
+    if (newY === MENU_BAR_HEIGHT && start.y + dh < MENU_BAR_HEIGHT) {
+      newH = start.y + start.h - MENU_BAR_HEIGHT;
+    }
+  }
+
+  return { x: newX, y: newY, w: newW, h: newH };
+}
+
+export function useWindowResize({
+  windowRef,
+  x,
+  y,
+  width,
+  height,
+  minWidth,
+  minHeight,
+  maximized,
+  callbacks,
+}: UseWindowResizeOptions) {
+  const resizingRef = useRef(false);
+
+  const handleResizePointerDown = useCallback(
+    (edge: ResizeEdge, e: React.PointerEvent) => {
+      if (maximized) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      const el = windowRef.current;
+      if (!el) return;
+
+      resizingRef.current = true;
+
+      const startPx = e.clientX;
+      const startPy = e.clientY;
+      const start: ResizeStart = { x, y, w: width, h: height };
+
+      el.setPointerCapture(e.pointerId);
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        const r = calcResize(
+          edge,
+          moveEvent.clientX - startPx,
+          moveEvent.clientY - startPy,
+          start,
+          minWidth,
+          minHeight,
+        );
+        if (windowRef.current) {
+          windowRef.current.style.transform = `translate(${r.x}px, ${r.y}px)`;
+          windowRef.current.style.left = '0';
+          windowRef.current.style.top = '0';
+          windowRef.current.style.width = `${r.w}px`;
+          windowRef.current.style.height = `${r.h}px`;
+        }
+      };
+
+      const handleUp = (upEvent: PointerEvent) => {
+        el.removeEventListener('pointermove', handleMove);
+        el.removeEventListener('pointerup', handleUp);
+        resizingRef.current = false;
+
+        const r = calcResize(
+          edge,
+          upEvent.clientX - startPx,
+          upEvent.clientY - startPy,
+          start,
+          minWidth,
+          minHeight,
+        );
+        if (windowRef.current) {
+          windowRef.current.style.transform = '';
+          windowRef.current.style.left = `${r.x}px`;
+          windowRef.current.style.top = `${r.y}px`;
+          windowRef.current.style.width = `${r.w}px`;
+          windowRef.current.style.height = `${r.h}px`;
+        }
+        callbacks.onResizeEnd(r.x, r.y, r.w, r.h);
+      };
+
+      el.addEventListener('pointermove', handleMove);
+      el.addEventListener('pointerup', handleUp);
+    },
+    [windowRef, x, y, width, height, minWidth, minHeight, maximized, callbacks]
+  );
+
+  return { handleResizePointerDown, resizingRef };
+}
+
+/** Resize handles rendered inside the window frame */
+export function ResizeHandles({
+  onPointerDown,
+  maximized,
+}: {
+  onPointerDown: (edge: ResizeEdge, e: React.PointerEvent) => void;
+  maximized: boolean;
+}) {
+  if (maximized) return null;
+
+  const edges: { edge: ResizeEdge; style: React.CSSProperties }[] = [
+    { edge: 'n', style: { top: -2, left: 8, right: 8, height: 4, cursor: 'n-resize' } },
+    { edge: 's', style: { bottom: -2, left: 8, right: 8, height: 4, cursor: 's-resize' } },
+    { edge: 'e', style: { top: 8, right: -2, bottom: 8, width: 4, cursor: 'e-resize' } },
+    { edge: 'w', style: { top: 8, left: -2, bottom: 8, width: 4, cursor: 'w-resize' } },
+    { edge: 'nw', style: { top: -4, left: -4, width: 8, height: 8, cursor: 'nw-resize' } },
+    { edge: 'ne', style: { top: -4, right: -4, width: 8, height: 8, cursor: 'ne-resize' } },
+    { edge: 'sw', style: { bottom: -4, left: -4, width: 8, height: 8, cursor: 'sw-resize' } },
+    { edge: 'se', style: { bottom: -4, right: -4, width: 8, height: 8, cursor: 'se-resize' } },
+  ];
+
+  return (
+    <>
+      {edges.map(({ edge, style }) => (
+        <div
+          key={edge}
+          style={{ position: 'absolute', zIndex: 1, ...style }}
+          onPointerDown={(e) => onPointerDown(edge, e)}
+        />
+      ))}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract window drag logic into `useWindowDrag` hook with pointer capture, GPU-accelerated transforms during drag, and boundary constraints (menu bar min, 48px title bar always visible)
- Add `useWindowResize` hook with 8 resize handles (4 edges + 4 corners), correct CSS cursors, enforcing `minSize` from AppRegistry
- Add `useSnapZones` hook with 7 snap zones (left/right halves, full screen, 4 corners) triggered within 12px of viewport edges, with semi-transparent blue preview overlay

## Test plan
- [ ] Drag windows by title bar — smooth, GPU-accelerated
- [ ] Resize from all 8 edges/corners with correct cursors
- [ ] Snap to left/right half by dragging to viewport edge
- [ ] Snap preview overlay appears before committing
- [ ] Z-order updates correctly on window click
- [ ] Double-click title bar toggles maximize
- [ ] `npm run typecheck && npm run lint && npm run test:run` passes

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)