### PR TITLE
fix: persistent rate limiting for webhook-receiver (#181)

### DIFF
--- a/supabase/functions/_shared/rate-limiter.ts
+++ b/supabase/functions/_shared/rate-limiter.ts
@@ -17,45 +17,45 @@
  *   const result = await limiter.check(clientId)
  */
 
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
 
 export interface RateLimitConfig {
   /** Time window in milliseconds (default: 60000 = 1 minute) */
-  windowMs?: number
+  windowMs?: number;
   /** Maximum requests per window (default: 100) */
-  maxRequests?: number
+  maxRequests?: number;
   /** Key prefix for namespacing (default: 'rate') */
-  keyPrefix?: string
+  keyPrefix?: string;
   /** Skip rate limiting for these IPs (e.g., health checks) */
-  skipIps?: string[]
+  skipIps?: string[];
 }
 
 export interface RateLimitResult {
-  allowed: boolean
-  remaining: number
-  resetAt: number
-  retryAfter?: number
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+  retryAfter?: number;
 }
 
 interface RateLimitEntry {
-  count: number
-  windowStart: number
+  count: number;
+  windowStart: number;
 }
 
 export class RateLimiter {
-  private store = new Map<string, RateLimitEntry>()
-  private config: Required<RateLimitConfig>
+  private store = new Map<string, RateLimitEntry>();
+  private config: Required<RateLimitConfig>;
 
   constructor(config: RateLimitConfig = {}) {
     this.config = {
       windowMs: config.windowMs ?? 60000,
       maxRequests: config.maxRequests ?? 100,
-      keyPrefix: config.keyPrefix ?? 'rate',
-      skipIps: config.skipIps ?? ['127.0.0.1', '::1'],
-    }
+      keyPrefix: config.keyPrefix ?? "rate",
+      skipIps: config.skipIps ?? ["127.0.0.1", "::1"],
+    };
 
     // Clean up old entries periodically
-    setInterval(() => this.cleanup(), this.config.windowMs * 2)
+    setInterval(() => this.cleanup(), this.config.windowMs * 2);
   }
 
   /**
@@ -68,25 +68,25 @@ export class RateLimiter {
         allowed: true,
         remaining: this.config.maxRequests,
         resetAt: Date.now() + this.config.windowMs,
-      }
+      };
     }
 
-    const key = `${this.config.keyPrefix}:${clientId}`
-    const now = Date.now()
-    const entry = this.store.get(key)
+    const key = `${this.config.keyPrefix}:${clientId}`;
+    const now = Date.now();
+    const entry = this.store.get(key);
 
     // New client or window expired
     if (!entry || now - entry.windowStart >= this.config.windowMs) {
-      this.store.set(key, { count: 1, windowStart: now })
+      this.store.set(key, { count: 1, windowStart: now });
       return {
         allowed: true,
         remaining: this.config.maxRequests - 1,
         resetAt: now + this.config.windowMs,
-      }
+      };
     }
 
     // Window still active
-    const resetAt = entry.windowStart + this.config.windowMs
+    const resetAt = entry.windowStart + this.config.windowMs;
 
     if (entry.count >= this.config.maxRequests) {
       return {
@@ -94,15 +94,15 @@ export class RateLimiter {
         remaining: 0,
         resetAt,
         retryAfter: Math.ceil((resetAt - now) / 1000),
-      }
+      };
     }
 
-    entry.count++
+    entry.count++;
     return {
       allowed: true,
       remaining: this.config.maxRequests - entry.count,
       resetAt,
-    }
+    };
   }
 
   /**
@@ -110,34 +110,34 @@ export class RateLimiter {
    */
   getHeaders(result: RateLimitResult): Record<string, string> {
     const headers: Record<string, string> = {
-      'X-RateLimit-Limit': this.config.maxRequests.toString(),
-      'X-RateLimit-Remaining': result.remaining.toString(),
-      'X-RateLimit-Reset': Math.ceil(result.resetAt / 1000).toString(),
-    }
+      "X-RateLimit-Limit": this.config.maxRequests.toString(),
+      "X-RateLimit-Remaining": result.remaining.toString(),
+      "X-RateLimit-Reset": Math.ceil(result.resetAt / 1000).toString(),
+    };
 
     if (result.retryAfter !== undefined) {
-      headers['Retry-After'] = result.retryAfter.toString()
+      headers["Retry-After"] = result.retryAfter.toString();
     }
 
-    return headers
+    return headers;
   }
 
   /**
    * Reset rate limit for a client (e.g., after successful auth)
    */
   reset(clientId: string): void {
-    const key = `${this.config.keyPrefix}:${clientId}`
-    this.store.delete(key)
+    const key = `${this.config.keyPrefix}:${clientId}`;
+    this.store.delete(key);
   }
 
   /**
    * Clean up expired entries
    */
   private cleanup(): void {
-    const now = Date.now()
+    const now = Date.now();
     for (const [key, entry] of this.store.entries()) {
       if (now - entry.windowStart >= this.config.windowMs * 2) {
-        this.store.delete(key)
+        this.store.delete(key);
       }
     }
   }
@@ -146,7 +146,7 @@ export class RateLimiter {
    * Get current store size (for monitoring)
    */
   get size(): number {
-    return this.store.size
+    return this.store.size;
   }
 }
 
@@ -154,94 +154,165 @@ export class RateLimiter {
  * Create a rate limiter instance
  */
 export function createRateLimiter(config?: RateLimitConfig): RateLimiter {
-  return new RateLimiter(config)
+  return new RateLimiter(config);
 }
 
 /**
- * Default rate limiters for common use cases
+ * Lazy Supabase service client for persistent rate limiters.
+ * Created once on first use to avoid failures at module load time.
+ */
+let _serviceClient: ReturnType<typeof createClient> | null = null;
+
+function getServiceClient(): ReturnType<typeof createClient> {
+  if (!_serviceClient) {
+    const url = Deno.env.get("SUPABASE_URL");
+    const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!url || !key) {
+      throw new Error(
+        "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required for persistent rate limiting",
+      );
+    }
+    _serviceClient = createClient(url, key);
+  }
+  return _serviceClient;
+}
+
+/**
+ * Default persistent rate limiters for common use cases.
+ * Backed by Supabase rate_limit_buckets table — survives edge function cold starts.
+ * Falls back to in-memory if DB is unreachable.
+ */
+export function getPersistentRateLimiters(
+  supabase?: ReturnType<typeof createClient>,
+) {
+  const client = supabase ?? getServiceClient();
+  return {
+    /** Standard API rate limit: 100 req/min */
+    api: new PersistentRateLimiter(client, {
+      maxRequests: 100,
+      windowMs: 60000,
+      keyPrefix: "api",
+    }),
+
+    /** Strict rate limit for auth endpoints: 10 req/min */
+    auth: new PersistentRateLimiter(client, {
+      maxRequests: 10,
+      windowMs: 60000,
+      keyPrefix: "auth",
+    }),
+
+    /** Relaxed rate limit for read operations: 300 req/min */
+    read: new PersistentRateLimiter(client, {
+      maxRequests: 300,
+      windowMs: 60000,
+      keyPrefix: "read",
+    }),
+
+    /** Webhook rate limit: 100 req/min per source */
+    webhook: new PersistentRateLimiter(client, {
+      maxRequests: 100,
+      windowMs: 60000,
+      keyPrefix: "webhook",
+    }),
+  };
+}
+
+/**
+ * @deprecated Use getPersistentRateLimiters() for cold-start-safe rate limiting.
+ * Kept for backward compatibility — these reset on every edge function cold start.
  */
 export const rateLimiters = {
-  /** Standard API rate limit: 100 req/min */
-  api: createRateLimiter({ maxRequests: 100, windowMs: 60000, keyPrefix: 'api' }),
-
-  /** Strict rate limit for auth endpoints: 10 req/min */
-  auth: createRateLimiter({ maxRequests: 10, windowMs: 60000, keyPrefix: 'auth' }),
-
-  /** Relaxed rate limit for read operations: 300 req/min */
-  read: createRateLimiter({ maxRequests: 300, windowMs: 60000, keyPrefix: 'read' }),
-
-  /** Webhook rate limit: 100 req/min per source */
-  webhook: createRateLimiter({ maxRequests: 100, windowMs: 60000, keyPrefix: 'webhook' }),
-}
+  api: createRateLimiter({
+    maxRequests: 100,
+    windowMs: 60000,
+    keyPrefix: "api",
+  }),
+  auth: createRateLimiter({
+    maxRequests: 10,
+    windowMs: 60000,
+    keyPrefix: "auth",
+  }),
+  read: createRateLimiter({
+    maxRequests: 300,
+    windowMs: 60000,
+    keyPrefix: "read",
+  }),
+  webhook: createRateLimiter({
+    maxRequests: 100,
+    windowMs: 60000,
+    keyPrefix: "webhook",
+  }),
+};
 
 /**
  * Extract client identifier from request
  */
 export function getClientId(req: Request): string {
   // Prefer X-Forwarded-For for proxied requests
-  const forwarded = req.headers.get('x-forwarded-for')
+  const forwarded = req.headers.get("x-forwarded-for");
   if (forwarded) {
     // Take the first IP (original client)
-    return forwarded.split(',')[0].trim()
+    return forwarded.split(",")[0].trim();
   }
 
   // Fall back to X-Real-IP
-  const realIp = req.headers.get('x-real-ip')
+  const realIp = req.headers.get("x-real-ip");
   if (realIp) {
-    return realIp
+    return realIp;
   }
 
   // Use CF-Connecting-IP for Cloudflare
-  const cfIp = req.headers.get('cf-connecting-ip')
+  const cfIp = req.headers.get("cf-connecting-ip");
   if (cfIp) {
-    return cfIp
+    return cfIp;
   }
 
-  return 'unknown'
+  return "unknown";
 }
 
 /**
- * Middleware helper for rate limiting
+ * Middleware helper for rate limiting.
+ * Accepts either a sync RateLimiter or async PersistentRateLimiter.
  */
 export function withRateLimit(
   handler: (req: Request) => Promise<Response>,
-  limiter: RateLimiter = rateLimiters.api
+  limiter: RateLimiter | PersistentRateLimiter = rateLimiters.api,
 ): (req: Request) => Promise<Response> {
   return async (req: Request): Promise<Response> => {
-    const clientId = getClientId(req)
-    const result = limiter.check(clientId)
+    const clientId = getClientId(req);
+    const result = await Promise.resolve(limiter.check(clientId));
 
     if (!result.allowed) {
       return new Response(
         JSON.stringify({
-          error: 'Rate limit exceeded',
+          error: "Rate limit exceeded",
           retryAfter: result.retryAfter,
         }),
         {
           status: 429,
           headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
             ...limiter.getHeaders(result),
           },
-        }
-      )
+        },
+      );
     }
 
     // Execute handler
-    const response = await handler(req)
+    const response = await handler(req);
 
     // Add rate limit headers to response
-    const headers = new Headers(response.headers)
+    const headers = new Headers(response.headers);
     for (const [key, value] of Object.entries(limiter.getHeaders(result))) {
-      headers.set(key, value)
+      headers.set(key, value);
     }
 
     return new Response(response.body, {
       status: response.status,
       statusText: response.statusText,
       headers,
-    })
-  }
+    });
+  };
 }
 
 /**
@@ -251,23 +322,23 @@ export function withRateLimit(
  * that survives edge function cold starts. Issue #181.
  */
 export class PersistentRateLimiter {
-  private supabase: ReturnType<typeof createClient>
-  private config: Required<RateLimitConfig>
+  private supabase: ReturnType<typeof createClient>;
+  private config: Required<RateLimitConfig>;
   // In-memory fallback for when DB calls fail
-  private fallback: RateLimiter
+  private fallback: RateLimiter;
 
   constructor(
     supabase: ReturnType<typeof createClient>,
-    config: RateLimitConfig = {}
+    config: RateLimitConfig = {},
   ) {
-    this.supabase = supabase
+    this.supabase = supabase;
     this.config = {
       windowMs: config.windowMs ?? 60000,
       maxRequests: config.maxRequests ?? 100,
-      keyPrefix: config.keyPrefix ?? 'rate',
-      skipIps: config.skipIps ?? ['127.0.0.1', '::1'],
-    }
-    this.fallback = new RateLimiter(config)
+      keyPrefix: config.keyPrefix ?? "rate",
+      skipIps: config.skipIps ?? ["127.0.0.1", "::1"],
+    };
+    this.fallback = new RateLimiter(config);
   }
 
   /**
@@ -279,35 +350,35 @@ export class PersistentRateLimiter {
         allowed: true,
         remaining: this.config.maxRequests,
         resetAt: Date.now() + this.config.windowMs,
-      }
+      };
     }
 
-    const key = `${this.config.keyPrefix}:${clientId}`
+    const key = `${this.config.keyPrefix}:${clientId}`;
 
     try {
-      const { data, error } = await this.supabase.rpc('check_rate_limit', {
+      const { data, error } = await this.supabase.rpc("check_rate_limit", {
         p_key: key,
         p_window_ms: this.config.windowMs,
         p_max_requests: this.config.maxRequests,
-      })
+      });
 
       if (error || !data || data.length === 0) {
         // Fall back to in-memory on DB error
-        return this.fallback.check(clientId)
+        return this.fallback.check(clientId);
       }
 
-      const row = data[0]
-      const resetAt = new Date(row.reset_at).getTime()
+      const row = data[0];
+      const resetAt = new Date(row.reset_at).getTime();
 
       return {
         allowed: row.allowed,
         remaining: row.remaining,
         resetAt,
         retryAfter: row.retry_after_seconds ?? undefined,
-      }
+      };
     } catch {
       // Fall back to in-memory on any error
-      return this.fallback.check(clientId)
+      return this.fallback.check(clientId);
     }
   }
 
@@ -316,16 +387,16 @@ export class PersistentRateLimiter {
    */
   getHeaders(result: RateLimitResult): Record<string, string> {
     const headers: Record<string, string> = {
-      'X-RateLimit-Limit': this.config.maxRequests.toString(),
-      'X-RateLimit-Remaining': result.remaining.toString(),
-      'X-RateLimit-Reset': Math.ceil(result.resetAt / 1000).toString(),
-    }
+      "X-RateLimit-Limit": this.config.maxRequests.toString(),
+      "X-RateLimit-Remaining": result.remaining.toString(),
+      "X-RateLimit-Reset": Math.ceil(result.resetAt / 1000).toString(),
+    };
 
     if (result.retryAfter !== undefined) {
-      headers['Retry-After'] = result.retryAfter.toString()
+      headers["Retry-After"] = result.retryAfter.toString();
     }
 
-    return headers
+    return headers;
   }
 }
 
@@ -334,7 +405,7 @@ export class PersistentRateLimiter {
  */
 export function createPersistentRateLimiter(
   supabase: ReturnType<typeof createClient>,
-  config?: RateLimitConfig
+  config?: RateLimitConfig,
 ): PersistentRateLimiter {
-  return new PersistentRateLimiter(supabase, config)
+  return new PersistentRateLimiter(supabase, config);
 }

--- a/supabase/functions/webhook-receiver/index.ts
+++ b/supabase/functions/webhook-receiver/index.ts
@@ -13,54 +13,55 @@
 //
 // Issue: #156
 
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
-import { Logger } from '../_shared/logger.ts'
-import { validateInput } from '../_shared/input-validator.ts'
-import { createRateLimiter, getClientId } from '../_shared/rate-limiter.ts'
-import { CORS_ORIGIN } from '../_shared/cors.ts'
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+import { Logger } from "../_shared/logger.ts";
+import { validateInput } from "../_shared/input-validator.ts";
+import { PersistentRateLimiter, getClientId } from "../_shared/rate-limiter.ts";
+import { CORS_ORIGIN } from "../_shared/cors.ts";
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': CORS_ORIGIN,
-  'Access-Control-Allow-Headers':
-    'authorization, x-client-info, apikey, content-type, x-webhook-signature, stripe-signature, x-hub-signature-256',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-}
+  "Access-Control-Allow-Origin": CORS_ORIGIN,
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-webhook-signature, stripe-signature, x-hub-signature-256",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
 
-// Rate limiter: 100 requests per minute per webhook_id
-const webhookLimiter = createRateLimiter({
-  maxRequests: 100,
-  windowMs: 60000,
-  keyPrefix: 'webhook',
-})
+// Persistent rate limiter: 100 requests per minute per webhook_id
+// Backed by Supabase rate_limit_buckets table — survives cold starts (Issue #181)
+let webhookLimiter: PersistentRateLimiter | null = null;
 
 /**
  * Compute HMAC-SHA256 hex digest using Web Crypto API
  */
 async function hmacSha256Hex(secret: string, payload: string): Promise<string> {
-  const encoder = new TextEncoder()
+  const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
-    'raw',
+    "raw",
     encoder.encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
+    { name: "HMAC", hash: "SHA-256" },
     false,
-    ['sign']
-  )
-  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(payload))
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(payload),
+  );
   return Array.from(new Uint8Array(signature))
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('')
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 /**
  * Constant-time comparison for signature verification
  */
 function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false
-  let result = 0
+  if (a.length !== b.length) return false;
+  let result = 0;
   for (let i = 0; i < a.length; i++) {
-    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
   }
-  return result === 0
+  return result === 0;
 }
 
 /**
@@ -74,210 +75,265 @@ async function verifyWebhookSignature(
   req: Request,
   rawBody: string,
   config: Record<string, unknown>,
-  logger: Logger
+  logger: Logger,
 ): Promise<boolean> {
-  const sigFormat = config.signature_format as string
-  const sigSecret = config.signature_secret as string
+  const sigFormat = config.signature_format as string;
+  const sigSecret = config.signature_secret as string;
 
   if (!sigFormat || !sigSecret) {
     // No signature verification configured — allow
-    return true
+    return true;
   }
 
   switch (sigFormat) {
-    case 'hmac_sha256': {
-      const header = req.headers.get('x-webhook-signature')
+    case "hmac_sha256": {
+      const header = req.headers.get("x-webhook-signature");
       if (!header) {
-        logger.warn('Missing X-Webhook-Signature header')
-        return false
+        logger.warn("Missing X-Webhook-Signature header");
+        return false;
       }
-      const expected = await hmacSha256Hex(sigSecret, rawBody)
-      return timingSafeEqual(expected, header)
+      const expected = await hmacSha256Hex(sigSecret, rawBody);
+      return timingSafeEqual(expected, header);
     }
 
-    case 'stripe': {
-      const header = req.headers.get('stripe-signature')
+    case "stripe": {
+      const header = req.headers.get("stripe-signature");
       if (!header) {
-        logger.warn('Missing Stripe-Signature header')
-        return false
+        logger.warn("Missing Stripe-Signature header");
+        return false;
       }
       // Parse "t=<timestamp>,v1=<signature>"
-      const parts: Record<string, string> = {}
-      for (const part of header.split(',')) {
-        const [key, value] = part.split('=', 2)
-        if (key && value) parts[key.trim()] = value.trim()
+      const parts: Record<string, string> = {};
+      for (const part of header.split(",")) {
+        const [key, value] = part.split("=", 2);
+        if (key && value) parts[key.trim()] = value.trim();
       }
 
       if (!parts.t || !parts.v1) {
-        logger.warn('Invalid Stripe-Signature format')
-        return false
+        logger.warn("Invalid Stripe-Signature format");
+        return false;
       }
 
       // Stripe signs: "<timestamp>.<raw_body>"
-      const signedPayload = `${parts.t}.${rawBody}`
-      const expected = await hmacSha256Hex(sigSecret, signedPayload)
-      return timingSafeEqual(expected, parts.v1)
+      const signedPayload = `${parts.t}.${rawBody}`;
+      const expected = await hmacSha256Hex(sigSecret, signedPayload);
+      return timingSafeEqual(expected, parts.v1);
     }
 
-    case 'github': {
-      const header = req.headers.get('x-hub-signature-256')
+    case "github": {
+      const header = req.headers.get("x-hub-signature-256");
       if (!header) {
-        logger.warn('Missing X-Hub-Signature-256 header')
-        return false
+        logger.warn("Missing X-Hub-Signature-256 header");
+        return false;
       }
       // GitHub format: "sha256=<hex_digest>"
-      const sig = header.startsWith('sha256=') ? header.slice(7) : header
-      const expected = await hmacSha256Hex(sigSecret, rawBody)
-      return timingSafeEqual(expected, sig)
+      const sig = header.startsWith("sha256=") ? header.slice(7) : header;
+      const expected = await hmacSha256Hex(sigSecret, rawBody);
+      return timingSafeEqual(expected, sig);
     }
 
     default:
-      logger.warn('Unknown signature format', { sigFormat })
-      return false
+      logger.warn("Unknown signature format", { sigFormat });
+      return false;
   }
 }
 
 Deno.serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders })
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
   }
 
-  if (req.method !== 'POST') {
-    return new Response(
-      JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    )
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 
-  const logger = Logger.fromRequest(req)
-  logger.logRequest()
-  const start = performance.now()
+  const logger = Logger.fromRequest(req);
+  logger.logRequest();
+  const start = performance.now();
 
   try {
     // Validate input with 1MB limit
-    const validation = await validateInput(req, { maxBodySize: 1024 * 1024 })
+    const validation = await validateInput(req, { maxBodySize: 1024 * 1024 });
     if (!validation.valid) {
       return new Response(
-        JSON.stringify({ error: 'Validation error', message: validation.error }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({
+          error: "Validation error",
+          message: validation.error,
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
-    const body = validation.data as Record<string, unknown>
+    const body = validation.data as Record<string, unknown>;
+
+    // Supabase client (created early for persistent rate limiting)
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Lazy-init persistent rate limiter (reused across requests within same instance)
+    if (!webhookLimiter) {
+      webhookLimiter = new PersistentRateLimiter(supabase, {
+        maxRequests: 100,
+        windowMs: 60000,
+        keyPrefix: "webhook",
+      });
+    }
 
     // Extract webhook_id from body or URL query param
-    const url = new URL(req.url)
-    const webhookId = (body.webhook_id as string) || url.searchParams.get('webhook_id')
+    const url = new URL(req.url);
+    const webhookId =
+      (body.webhook_id as string) || url.searchParams.get("webhook_id");
 
     if (!webhookId) {
       return new Response(
-        JSON.stringify({ error: 'Missing webhook_id in body or query parameter' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({
+          error: "Missing webhook_id in body or query parameter",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
-    // Rate limit per webhook_id
-    const rateResult = webhookLimiter.check(webhookId)
+    // Rate limit per webhook_id (persistent across cold starts — Issue #181)
+    const rateResult = await webhookLimiter.check(webhookId);
     if (!rateResult.allowed) {
-      logger.warn('Webhook rate limit exceeded', { webhookId, retryAfter: rateResult.retryAfter })
+      logger.warn("Webhook rate limit exceeded", {
+        webhookId,
+        retryAfter: rateResult.retryAfter,
+      });
       return new Response(
-        JSON.stringify({ error: 'Rate limit exceeded', retryAfter: rateResult.retryAfter }),
+        JSON.stringify({
+          error: "Rate limit exceeded",
+          retryAfter: rateResult.retryAfter,
+        }),
         {
           status: 429,
           headers: {
             ...corsHeaders,
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
             ...webhookLimiter.getHeaders(rateResult),
           },
-        }
-      )
+        },
+      );
     }
-
-    // Supabase client
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-    const supabase = createClient(supabaseUrl, supabaseServiceKey)
 
     // Look up workflow by webhook_id in trigger_config
     const { data: workflows, error: wfError } = await supabase
-      .from('workflows')
-      .select('id, name, trigger_config')
-      .eq('is_active', true)
-      .eq('trigger_type', 'webhook')
-      .filter('trigger_config->>webhook_id', 'eq', webhookId)
+      .from("workflows")
+      .select("id, name, trigger_config")
+      .eq("is_active", true)
+      .eq("trigger_type", "webhook")
+      .filter("trigger_config->>webhook_id", "eq", webhookId);
 
     if (wfError) {
-      logger.error('Failed to look up workflows', wfError as unknown as Error)
+      logger.error("Failed to look up workflows", wfError as unknown as Error);
       return new Response(
-        JSON.stringify({ error: 'Internal error looking up webhook configuration' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({
+          error: "Internal error looking up webhook configuration",
+        }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
     if (!workflows || workflows.length === 0) {
-      logger.warn('No workflow found for webhook_id', { webhookId })
+      logger.warn("No workflow found for webhook_id", { webhookId });
       return new Response(
-        JSON.stringify({ error: 'No active workflow found for this webhook_id' }),
-        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({
+          error: "No active workflow found for this webhook_id",
+        }),
+        {
+          status: 404,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
-    const workflow = workflows[0]
-    const triggerConfig = workflow.trigger_config as Record<string, unknown> || {}
+    const workflow = workflows[0];
+    const triggerConfig =
+      (workflow.trigger_config as Record<string, unknown>) || {};
 
     // Verify webhook signature if configured
-    const rawBody = JSON.stringify(body)
-    const sigValid = await verifyWebhookSignature(req, rawBody, triggerConfig, logger)
+    const rawBody = JSON.stringify(body);
+    const sigValid = await verifyWebhookSignature(
+      req,
+      rawBody,
+      triggerConfig,
+      logger,
+    );
     if (!sigValid) {
-      logger.warn('Webhook signature verification failed', { webhookId, workflowId: workflow.id })
+      logger.warn("Webhook signature verification failed", {
+        webhookId,
+        workflowId: workflow.id,
+      });
       return new Response(
-        JSON.stringify({ error: 'Webhook signature verification failed' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({ error: "Webhook signature verification failed" }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Dispatch to workflow-executor
-    const schedulerSecret = Deno.env.get('SCHEDULER_SECRET')
+    const schedulerSecret = Deno.env.get("SCHEDULER_SECRET");
     if (!schedulerSecret) {
-      logger.error('SCHEDULER_SECRET not configured')
+      logger.error("SCHEDULER_SECRET not configured");
       return new Response(
-        JSON.stringify({ error: 'Webhook dispatch not configured' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({ error: "Webhook dispatch not configured" }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
-    const dispatchResponse = await fetch(`${supabaseUrl}/functions/v1/workflow-executor`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-scheduler-secret': schedulerSecret,
-        'x-correlation-id': logger.getCorrelationId(),
-      },
-      body: JSON.stringify({
-        workflow_id: workflow.id,
-        trigger_type: 'webhook',
-        trigger_data: {
-          webhook_id: webhookId,
-          payload: body,
-          headers: {
-            'content-type': req.headers.get('content-type'),
-            'user-agent': req.headers.get('user-agent'),
-          },
-          source_ip: getClientId(req),
-          received_at: new Date().toISOString(),
+    const dispatchResponse = await fetch(
+      `${supabaseUrl}/functions/v1/workflow-executor`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-scheduler-secret": schedulerSecret,
+          "x-correlation-id": logger.getCorrelationId(),
         },
-      }),
-    })
+        body: JSON.stringify({
+          workflow_id: workflow.id,
+          trigger_type: "webhook",
+          trigger_data: {
+            webhook_id: webhookId,
+            payload: body,
+            headers: {
+              "content-type": req.headers.get("content-type"),
+              "user-agent": req.headers.get("user-agent"),
+            },
+            source_ip: getClientId(req),
+            received_at: new Date().toISOString(),
+          },
+        }),
+      },
+    );
 
-    const dispatchData = await dispatchResponse.json()
-    const duration = Math.round(performance.now() - start)
+    const dispatchData = await dispatchResponse.json();
+    const duration = Math.round(performance.now() - start);
 
     // Audit log
-    await supabase.rpc('log_audit_event', {
-      p_actor_type: 'system',
+    await supabase.rpc("log_audit_event", {
+      p_actor_type: "system",
       p_actor_id: null,
-      p_action: 'webhook.received',
-      p_resource_type: 'workflow',
+      p_action: "webhook.received",
+      p_resource_type: "workflow",
       p_resource_id: workflow.id,
       p_details: {
         webhook_id: webhookId,
@@ -285,9 +341,9 @@ Deno.serve(async (req) => {
         dispatch_status: dispatchResponse.status,
         duration_ms: duration,
       },
-    })
+    });
 
-    logger.logResponse(200, duration)
+    logger.logResponse(200, duration);
 
     return new Response(
       JSON.stringify({
@@ -301,29 +357,29 @@ Deno.serve(async (req) => {
         status: 200,
         headers: {
           ...corsHeaders,
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           ...logger.getResponseHeaders(),
         },
-      }
-    )
+      },
+    );
   } catch (error) {
-    const duration = Math.round(performance.now() - start)
-    logger.error('Webhook receiver error', error as Error)
-    logger.logResponse(500, duration)
+    const duration = Math.round(performance.now() - start);
+    logger.error("Webhook receiver error", error as Error);
+    logger.logResponse(500, duration);
 
     return new Response(
       JSON.stringify({
-        error: 'Internal server error',
+        error: "Internal server error",
         correlationId: logger.getCorrelationId(),
       }),
       {
         status: 500,
         headers: {
           ...corsHeaders,
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           ...logger.getResponseHeaders(),
         },
-      }
-    )
+      },
+    );
   }
-})
+});


### PR DESCRIPTION
## Summary
- Upgraded webhook-receiver from in-memory `createRateLimiter()` to `PersistentRateLimiter` backed by `rate_limit_buckets` table via `check_rate_limit()` RPC — survives edge function cold starts
- Added `getPersistentRateLimiters()` factory for pre-configured persistent limiters with lazy Supabase client initialization
- Updated `withRateLimit` middleware to accept both sync `RateLimiter` and async `PersistentRateLimiter`
- Deprecated in-memory `rateLimiters` export

## Test plan
- [ ] Verify webhook-receiver rate limiting persists across cold starts
- [ ] Verify `PersistentRateLimiter` falls back to in-memory when DB is unreachable
- [ ] Verify existing schema-validation tests pass

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)