### PR TITLE
fix: recursive trash, owner-scoped empty trash, desktop shortcuts (#205, #206, #207)

### DIFF
--- a/src/components/desktop/Desktop.tsx
+++ b/src/components/desktop/Desktop.tsx
@@ -1,18 +1,18 @@
-import { useCallback, useState } from 'react';
-import { useWindowManagerContext, useWorkspaceContext } from './WindowManager';
-import Window from './Window';
-import DesktopIcon from './DesktopIcon';
-import ContextMenu from './ContextMenu';
-import { useContextMenu, type ContextMenuItem } from '@/hooks/useContextMenu';
-import { useFileSystem } from '@/hooks/useFileSystem';
-import { ROOT_FOLDERS, type FileSystemNode } from '@/lib/desktop-schemas';
-import { Loader2 } from 'lucide-react';
+import { useCallback, useState } from "react";
+import { useWindowManagerContext, useWorkspaceContext } from "./WindowManager";
+import Window from "./Window";
+import DesktopIcon from "./DesktopIcon";
+import ContextMenu from "./ContextMenu";
+import { useContextMenu, type ContextMenuItem } from "@/hooks/useContextMenu";
+import { useFileSystem } from "@/hooks/useFileSystem";
+import { ROOT_FOLDERS, type FileSystemNode } from "@/lib/desktop-schemas";
+import { Loader2 } from "lucide-react";
 
 export default function Desktop() {
   const { state, launchApp } = useWindowManagerContext();
   const workspace = useWorkspaceContext();
   const contextMenu = useContextMenu();
-  const fs = useFileSystem(ROOT_FOLDERS.DESKTOP);
+  const fs = useFileSystem(ROOT_FOLDERS.DESKTOP, workspace.userId);
   const [selectedIconId, setSelectedIconId] = useState<string | null>(null);
 
   const handleDesktopClick = useCallback((e: React.MouseEvent) => {
@@ -21,35 +21,68 @@ export default function Desktop() {
     }
   }, []);
 
-  const handleDesktopContextMenu = useCallback((e: React.MouseEvent) => {
-    const items: ContextMenuItem[] = [
-      { id: 'new-folder', label: 'New Folder', onClick: () => fs.createFolder('New Folder') },
-      { id: 'sep1', label: '', separator: true },
-      { id: 'change-wallpaper', label: 'Change Wallpaper...', onClick: () => launchApp('wallpaper-picker') },
-      { id: 'sep2', label: '', separator: true },
-      { id: 'refresh', label: 'Refresh', shortcut: '⌘R', onClick: () => fs.refresh() },
-    ];
-    contextMenu.openMenu(e, items);
-  }, [contextMenu, fs, launchApp]);
+  const handleDesktopContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      const items: ContextMenuItem[] = [
+        {
+          id: "new-folder",
+          label: "New Folder",
+          onClick: () => fs.createFolder("New Folder"),
+        },
+        { id: "sep1", label: "", separator: true },
+        {
+          id: "change-wallpaper",
+          label: "Change Wallpaper...",
+          onClick: () => launchApp("wallpaper-picker"),
+        },
+        { id: "sep2", label: "", separator: true },
+        {
+          id: "refresh",
+          label: "Refresh",
+          shortcut: "⌘R",
+          onClick: () => fs.refresh(),
+        },
+      ];
+      contextMenu.openMenu(e, items);
+    },
+    [contextMenu, fs, launchApp],
+  );
 
-  const handleIconContextMenu = useCallback((e: React.MouseEvent, node: FileSystemNode) => {
-    const items: ContextMenuItem[] = [
-      { id: 'open', label: 'Open', onClick: () => handleOpenIcon(node) },
-      { id: 'sep1', label: '', separator: true },
-      { id: 'rename', label: 'Rename', onClick: () => { /* TODO */ } },
-      { id: 'sep2', label: '', separator: true },
-      { id: 'trash', label: 'Move to Trash', danger: true, onClick: () => fs.moveToTrash(node.id) },
-    ];
-    contextMenu.openMenu(e, items);
-  }, [contextMenu, fs]);
+  const handleIconContextMenu = useCallback(
+    (e: React.MouseEvent, node: FileSystemNode) => {
+      const items: ContextMenuItem[] = [
+        { id: "open", label: "Open", onClick: () => handleOpenIcon(node) },
+        { id: "sep1", label: "", separator: true },
+        {
+          id: "rename",
+          label: "Rename",
+          onClick: () => {
+            /* TODO */
+          },
+        },
+        { id: "sep2", label: "", separator: true },
+        {
+          id: "trash",
+          label: "Move to Trash",
+          danger: true,
+          onClick: () => fs.moveToTrash(node.id),
+        },
+      ];
+      contextMenu.openMenu(e, items);
+    },
+    [contextMenu, fs],
+  );
 
-  const handleOpenIcon = useCallback((node: FileSystemNode) => {
-    if (node.type === 'folder') {
-      launchApp('file-explorer');
-    } else if (node.app_id) {
-      launchApp(node.app_id);
-    }
-  }, [launchApp]);
+  const handleOpenIcon = useCallback(
+    (node: FileSystemNode) => {
+      if (node.type === "folder") {
+        launchApp("file-explorer");
+      } else if (node.target_type === "app" && node.target_id) {
+        launchApp(node.target_id);
+      }
+    },
+    [launchApp],
+  );
 
   const handleIconSelect = useCallback((id: string) => {
     setSelectedIconId(id);
@@ -74,7 +107,7 @@ export default function Desktop() {
       onContextMenu={handleDesktopContextMenu}
     >
       {/* Desktop Icons */}
-      {fs.children.map(node => (
+      {fs.children.map((node) => (
         <DesktopIcon
           key={node.id}
           node={node}
@@ -87,7 +120,7 @@ export default function Desktop() {
       ))}
 
       {/* Windows */}
-      {state.windows.map(win => (
+      {state.windows.map((win) => (
         <Window key={win.id} window={win} />
       ))}
 

--- a/src/components/desktop/WindowManager.tsx
+++ b/src/components/desktop/WindowManager.tsx
@@ -1,8 +1,14 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useContext, useCallback, useMemo, ReactNode } from 'react';
-import { useWindowManager, WindowManagerState } from '@/hooks/useWindowManager';
-import { useDesktopWorkspace } from '@/hooks/useDesktopWorkspace';
-import { getApp } from './apps/AppRegistry';
+import {
+  createContext,
+  useContext,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from "react";
+import { useWindowManager, WindowManagerState } from "@/hooks/useWindowManager";
+import { useDesktopWorkspace } from "@/hooks/useDesktopWorkspace";
+import { getApp } from "./apps/AppRegistry";
 
 const MAX_OPEN_WINDOWS = 10;
 const MENU_BAR_HEIGHT = 28;
@@ -17,10 +23,17 @@ interface WindowManagerContextType {
   maximizeWindow: (id: string) => void;
   restoreWindow: (id: string) => void;
   moveWindow: (id: string, x: number, y: number) => void;
-  resizeWindow: (id: string, width: number, height: number, x?: number, y?: number) => void;
+  resizeWindow: (
+    id: string,
+    width: number,
+    height: number,
+    x?: number,
+    y?: number,
+  ) => void;
 }
 
 export interface WorkspaceContextType {
+  userId: string;
   isLoading: boolean;
   wallpaper: string;
   dockItems: string[];
@@ -30,8 +43,12 @@ export interface WorkspaceContextType {
   reorderDockItems: (items: string[]) => void;
 }
 
-const WindowManagerContext = createContext<WindowManagerContextType | undefined>(undefined);
-const WorkspaceContext = createContext<WorkspaceContextType | undefined>(undefined);
+const WindowManagerContext = createContext<
+  WindowManagerContextType | undefined
+>(undefined);
+const WorkspaceContext = createContext<WorkspaceContextType | undefined>(
+  undefined,
+);
 
 // Cascade offset for new windows
 let cascadeOffset = 0;
@@ -41,7 +58,10 @@ interface WindowManagerProviderProps {
   children: ReactNode;
 }
 
-export function WindowManagerProvider({ userId, children }: WindowManagerProviderProps) {
+export function WindowManagerProvider({
+  userId,
+  children,
+}: WindowManagerProviderProps) {
   const wm = useWindowManager();
 
   const workspace = useDesktopWorkspace({
@@ -50,58 +70,80 @@ export function WindowManagerProvider({ userId, children }: WindowManagerProvide
     restoreWindowState: wm.restoreState,
   });
 
-  const launchApp = useCallback((appId: string) => {
-    const app = getApp(appId);
-    if (!app) return;
+  const launchApp = useCallback(
+    (appId: string) => {
+      const app = getApp(appId);
+      if (!app) return;
 
-    // Singleton enforcement: focus existing if already open
-    if (app.singleton) {
-      const existing = wm.findWindowByAppId(appId);
-      if (existing) {
-        wm.focusWindow(existing.id);
+      // Singleton enforcement: focus existing if already open
+      if (app.singleton) {
+        const existing = wm.findWindowByAppId(appId);
+        if (existing) {
+          wm.focusWindow(existing.id);
+          return;
+        }
+      }
+
+      // Max window limit
+      const openCount = wm.state.windows.filter((w) => !w.minimized).length;
+      if (openCount >= MAX_OPEN_WINDOWS) {
+        // Could dispatch a notification here in Phase 5
         return;
       }
-    }
 
-    // Max window limit
-    const openCount = wm.state.windows.filter(w => !w.minimized).length;
-    if (openCount >= MAX_OPEN_WINDOWS) {
-      // Could dispatch a notification here in Phase 5
-      return;
-    }
+      // Cascade position for new windows
+      const baseX = 80 + (cascadeOffset % 8) * 30;
+      const baseY = MENU_BAR_HEIGHT + 40 + (cascadeOffset % 8) * 30;
+      cascadeOffset++;
 
-    // Cascade position for new windows
-    const baseX = 80 + (cascadeOffset % 8) * 30;
-    const baseY = MENU_BAR_HEIGHT + 40 + (cascadeOffset % 8) * 30;
-    cascadeOffset++;
+      const { width, height } = app.defaultSize;
+      // Clamp to viewport
+      const maxX = Math.max(0, window.innerWidth - width);
+      const maxY = Math.max(
+        MENU_BAR_HEIGHT,
+        window.innerHeight - DOCK_HEIGHT - height,
+      );
+      const x = Math.min(baseX, maxX);
+      const y = Math.min(baseY, maxY);
 
-    const { width, height } = app.defaultSize;
-    // Clamp to viewport
-    const maxX = Math.max(0, window.innerWidth - width);
-    const maxY = Math.max(MENU_BAR_HEIGHT, window.innerHeight - DOCK_HEIGHT - height);
-    const x = Math.min(baseX, maxX);
-    const y = Math.min(baseY, maxY);
+      wm.openWindow(appId, app.name, x, y, width, height);
+    },
+    [wm],
+  );
 
-    wm.openWindow(appId, app.name, x, y, width, height);
-  }, [wm]);
+  const maximizeWindow = useCallback(
+    (id: string) => {
+      wm.maximizeWindow(id, {
+        width: window.innerWidth,
+        height: window.innerHeight - DOCK_HEIGHT,
+        topOffset: MENU_BAR_HEIGHT,
+      });
+    },
+    [wm],
+  );
 
-  const maximizeWindow = useCallback((id: string) => {
-    wm.maximizeWindow(id, {
-      width: window.innerWidth,
-      height: window.innerHeight - DOCK_HEIGHT,
-      topOffset: MENU_BAR_HEIGHT,
-    });
-  }, [wm]);
-
-  const workspaceValue = useMemo<WorkspaceContextType>(() => ({
-    isLoading: workspace.isLoading,
-    wallpaper: workspace.wallpaper,
-    dockItems: workspace.dockItems,
-    updateWallpaper: workspace.updateWallpaper,
-    pinApp: workspace.pinApp,
-    unpinApp: workspace.unpinApp,
-    reorderDockItems: workspace.reorderDockItems,
-  }), [workspace.isLoading, workspace.wallpaper, workspace.dockItems, workspace.updateWallpaper, workspace.pinApp, workspace.unpinApp, workspace.reorderDockItems]);
+  const workspaceValue = useMemo<WorkspaceContextType>(
+    () => ({
+      userId,
+      isLoading: workspace.isLoading,
+      wallpaper: workspace.wallpaper,
+      dockItems: workspace.dockItems,
+      updateWallpaper: workspace.updateWallpaper,
+      pinApp: workspace.pinApp,
+      unpinApp: workspace.unpinApp,
+      reorderDockItems: workspace.reorderDockItems,
+    }),
+    [
+      userId,
+      workspace.isLoading,
+      workspace.wallpaper,
+      workspace.dockItems,
+      workspace.updateWallpaper,
+      workspace.pinApp,
+      workspace.unpinApp,
+      workspace.reorderDockItems,
+    ],
+  );
 
   return (
     <WindowManagerContext.Provider
@@ -127,7 +169,9 @@ export function WindowManagerProvider({ userId, children }: WindowManagerProvide
 export function useWindowManagerContext() {
   const context = useContext(WindowManagerContext);
   if (context === undefined) {
-    throw new Error('useWindowManagerContext must be used within a WindowManagerProvider');
+    throw new Error(
+      "useWindowManagerContext must be used within a WindowManagerProvider",
+    );
   }
   return context;
 }
@@ -135,7 +179,9 @@ export function useWindowManagerContext() {
 export function useWorkspaceContext() {
   const context = useContext(WorkspaceContext);
   if (context === undefined) {
-    throw new Error('useWorkspaceContext must be used within a WindowManagerProvider');
+    throw new Error(
+      "useWorkspaceContext must be used within a WindowManagerProvider",
+    );
   }
   return context;
 }

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -1,5 +1,5 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
-import { ROOT_FOLDERS, type FileSystemNode } from '@/lib/desktop-schemas';
+import { useState, useCallback, useEffect, useRef } from "react";
+import { ROOT_FOLDERS, type FileSystemNode } from "@/lib/desktop-schemas";
 import {
   getFileSystemChildren,
   createFileSystemNode,
@@ -12,7 +12,7 @@ import {
   searchFileSystem,
   getNodePath,
   updateNodePosition,
-} from '@/lib/desktop-queries';
+} from "@/lib/desktop-queries";
 
 export interface BreadcrumbItem {
   id: string;
@@ -28,14 +28,17 @@ interface UseFileSystemState {
 }
 
 const ROOT_FOLDER_ENTRIES: { id: string; name: string }[] = [
-  { id: ROOT_FOLDERS.DESKTOP, name: 'Desktop' },
-  { id: ROOT_FOLDERS.APPLICATIONS, name: 'Applications' },
-  { id: ROOT_FOLDERS.DOCUMENTS, name: 'Documents' },
-  { id: ROOT_FOLDERS.DOWNLOADS, name: 'Downloads' },
-  { id: ROOT_FOLDERS.TRASH, name: 'Trash' },
+  { id: ROOT_FOLDERS.DESKTOP, name: "Desktop" },
+  { id: ROOT_FOLDERS.APPLICATIONS, name: "Applications" },
+  { id: ROOT_FOLDERS.DOCUMENTS, name: "Documents" },
+  { id: ROOT_FOLDERS.DOWNLOADS, name: "Downloads" },
+  { id: ROOT_FOLDERS.TRASH, name: "Trash" },
 ];
 
-export function useFileSystem(initialParentId: string | null = null) {
+export function useFileSystem(
+  initialParentId: string | null = null,
+  ownerId?: string,
+) {
   const [state, setState] = useState<UseFileSystemState>({
     currentParentId: initialParentId,
     currentPath: [],
@@ -46,30 +49,32 @@ export function useFileSystem(initialParentId: string | null = null) {
   const mountedRef = useRef(true);
 
   useEffect(() => {
-    return () => { mountedRef.current = false; };
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   const fetchChildren = useCallback(async (parentId: string | null) => {
-    setState(prev => ({ ...prev, isLoading: true, error: null }));
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
     try {
       const [children, path] = await Promise.all([
         getFileSystemChildren(parentId),
         parentId ? getNodePath(parentId) : Promise.resolve([]),
       ]);
       if (!mountedRef.current) return;
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
         children,
         currentParentId: parentId,
-        currentPath: path.map(n => ({ id: n.id, name: n.name })),
+        currentPath: path.map((n) => ({ id: n.id, name: n.name })),
         isLoading: false,
       }));
     } catch (err) {
       if (!mountedRef.current) return;
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
         isLoading: false,
-        error: err instanceof Error ? err.message : 'Failed to load files',
+        error: err instanceof Error ? err.message : "Failed to load files",
       }));
     }
   }, []);
@@ -80,9 +85,12 @@ export function useFileSystem(initialParentId: string | null = null) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const navigateTo = useCallback(async (folderId: string) => {
-    await fetchChildren(folderId);
-  }, [fetchChildren]);
+  const navigateTo = useCallback(
+    async (folderId: string) => {
+      await fetchChildren(folderId);
+    },
+    [fetchChildren],
+  );
 
   const navigateUp = useCallback(async () => {
     if (state.currentPath.length > 1) {
@@ -97,167 +105,196 @@ export function useFileSystem(initialParentId: string | null = null) {
     await fetchChildren(null);
   }, [fetchChildren]);
 
-  const createFolder = useCallback(async (name: string) => {
-    try {
-      await createFileSystemNode({
-        parent_id: state.currentParentId,
-        name,
-        type: 'folder',
-        icon: 'Folder',
-      });
-      await fetchChildren(state.currentParentId);
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        error: err instanceof Error ? err.message : 'Failed to create folder',
-      }));
-    }
-  }, [state.currentParentId, fetchChildren]);
+  const createFolder = useCallback(
+    async (name: string) => {
+      try {
+        await createFileSystemNode({
+          parent_id: state.currentParentId,
+          name,
+          type: "folder",
+          icon: "Folder",
+        });
+        await fetchChildren(state.currentParentId);
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : "Failed to create folder",
+        }));
+      }
+    },
+    [state.currentParentId, fetchChildren],
+  );
 
-  const createFile = useCallback(async (
-    name: string,
-    targetType?: string,
-    targetId?: string,
-    icon?: string,
-  ) => {
-    try {
-      await createFileSystemNode({
-        parent_id: state.currentParentId,
-        name,
-        type: targetType ? 'shortcut' : 'file',
-        target_type: targetType ?? null,
-        target_id: targetId ?? null,
-        icon: icon ?? null,
-      });
-      await fetchChildren(state.currentParentId);
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        error: err instanceof Error ? err.message : 'Failed to create file',
-      }));
-    }
-  }, [state.currentParentId, fetchChildren]);
+  const createFile = useCallback(
+    async (
+      name: string,
+      targetType?: string,
+      targetId?: string,
+      icon?: string,
+    ) => {
+      try {
+        await createFileSystemNode({
+          parent_id: state.currentParentId,
+          name,
+          type: targetType ? "shortcut" : "file",
+          target_type: targetType ?? null,
+          target_id: targetId ?? null,
+          icon: icon ?? null,
+        });
+        await fetchChildren(state.currentParentId);
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : "Failed to create file",
+        }));
+      }
+    },
+    [state.currentParentId, fetchChildren],
+  );
 
-  const rename = useCallback(async (id: string, newName: string) => {
-    try {
-      await renameNodeQuery(id, newName);
-      await fetchChildren(state.currentParentId);
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        error: err instanceof Error ? err.message : 'Failed to rename',
-      }));
-    }
-  }, [state.currentParentId, fetchChildren]);
+  const rename = useCallback(
+    async (id: string, newName: string) => {
+      try {
+        await renameNodeQuery(id, newName);
+        await fetchChildren(state.currentParentId);
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : "Failed to rename",
+        }));
+      }
+    },
+    [state.currentParentId, fetchChildren],
+  );
 
-  const move = useCallback(async (id: string, newParentId: string | null) => {
-    try {
-      await moveNodeQuery(id, newParentId);
-      await fetchChildren(state.currentParentId);
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        error: err instanceof Error ? err.message : 'Failed to move',
-      }));
-    }
-  }, [state.currentParentId, fetchChildren]);
+  const move = useCallback(
+    async (id: string, newParentId: string | null) => {
+      try {
+        await moveNodeQuery(id, newParentId);
+        await fetchChildren(state.currentParentId);
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : "Failed to move",
+        }));
+      }
+    },
+    [state.currentParentId, fetchChildren],
+  );
 
-  const moveToTrash = useCallback(async (id: string) => {
-    try {
-      await moveToTrashQuery(id);
-      await fetchChildren(state.currentParentId);
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        error: err instanceof Error ? err.message : 'Failed to move to trash',
-      }));
-    }
-  }, [state.currentParentId, fetchChildren]);
+  const moveToTrash = useCallback(
+    async (id: string) => {
+      try {
+        await moveToTrashQuery(id);
+        await fetchChildren(state.currentParentId);
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : "Failed to move to trash",
+        }));
+      }
+    },
+    [state.currentParentId, fetchChildren],
+  );
 
-  const restoreFromTrash = useCallback(async (id: string) => {
-    try {
-      await restoreFromTrashQuery(id);
-      await fetchChildren(state.currentParentId);
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        error: err instanceof Error ? err.message : 'Failed to restore',
-      }));
-    }
-  }, [state.currentParentId, fetchChildren]);
+  const restoreFromTrash = useCallback(
+    async (id: string) => {
+      try {
+        await restoreFromTrashQuery(id);
+        await fetchChildren(state.currentParentId);
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : "Failed to restore",
+        }));
+      }
+    },
+    [state.currentParentId, fetchChildren],
+  );
 
-  const permanentlyDelete = useCallback(async (id: string) => {
-    try {
-      await permanentlyDeleteQuery(id);
-      await fetchChildren(state.currentParentId);
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        error: err instanceof Error ? err.message : 'Failed to delete',
-      }));
-    }
-  }, [state.currentParentId, fetchChildren]);
+  const permanentlyDelete = useCallback(
+    async (id: string) => {
+      try {
+        await permanentlyDeleteQuery(id);
+        await fetchChildren(state.currentParentId);
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error: err instanceof Error ? err.message : "Failed to delete",
+        }));
+      }
+    },
+    [state.currentParentId, fetchChildren],
+  );
 
   const emptyTrash = useCallback(async () => {
+    if (!ownerId) return;
     try {
-      await emptyTrashQuery();
+      await emptyTrashQuery(ownerId);
       await fetchChildren(state.currentParentId);
     } catch (err) {
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
-        error: err instanceof Error ? err.message : 'Failed to empty trash',
+        error: err instanceof Error ? err.message : "Failed to empty trash",
       }));
     }
-  }, [state.currentParentId, fetchChildren]);
+  }, [state.currentParentId, fetchChildren, ownerId]);
 
-  const search = useCallback(async (query: string) => {
-    if (!query.trim()) {
-      await fetchChildren(state.currentParentId);
-      return;
-    }
-    setState(prev => ({ ...prev, isLoading: true, error: null }));
-    try {
-      const results = await searchFileSystem(query);
-      if (!mountedRef.current) return;
-      setState(prev => ({
-        ...prev,
-        children: results,
-        isLoading: false,
-      }));
-    } catch (err) {
-      if (!mountedRef.current) return;
-      setState(prev => ({
-        ...prev,
-        isLoading: false,
-        error: err instanceof Error ? err.message : 'Search failed',
-      }));
-    }
-  }, [state.currentParentId, fetchChildren]);
+  const search = useCallback(
+    async (query: string) => {
+      if (!query.trim()) {
+        await fetchChildren(state.currentParentId);
+        return;
+      }
+      setState((prev) => ({ ...prev, isLoading: true, error: null }));
+      try {
+        const results = await searchFileSystem(query, ownerId);
+        if (!mountedRef.current) return;
+        setState((prev) => ({
+          ...prev,
+          children: results,
+          isLoading: false,
+        }));
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+          error: err instanceof Error ? err.message : "Search failed",
+        }));
+      }
+    },
+    [state.currentParentId, fetchChildren],
+  );
 
   const refresh = useCallback(async () => {
     await fetchChildren(state.currentParentId);
   }, [state.currentParentId, fetchChildren]);
 
-  const updatePosition = useCallback(async (
-    id: string,
-    position: { x: number; y: number; gridCol?: number; gridRow?: number }
-  ) => {
-    try {
-      await updateNodePosition(id, position);
-      // Optimistic update: update local state without refetching
-      setState(prev => ({
-        ...prev,
-        children: prev.children.map(c =>
-          c.id === id ? { ...c, position } : c
-        ),
-      }));
-    } catch (err) {
-      setState(prev => ({
-        ...prev,
-        error: err instanceof Error ? err.message : 'Failed to update position',
-      }));
-    }
-  }, []);
+  const updatePosition = useCallback(
+    async (
+      id: string,
+      position: { x: number; y: number; gridCol?: number; gridRow?: number },
+    ) => {
+      try {
+        await updateNodePosition(id, position);
+        // Optimistic update: update local state without refetching
+        setState((prev) => ({
+          ...prev,
+          children: prev.children.map((c) =>
+            c.id === id ? { ...c, position } : c,
+          ),
+        }));
+      } catch (err) {
+        setState((prev) => ({
+          ...prev,
+          error:
+            err instanceof Error ? err.message : "Failed to update position",
+        }));
+      }
+    },
+    [],
+  );
 
   return {
     ...state,

--- a/supabase/migrations/20240601000010_desktop_fs_recursive_ops.sql
+++ b/supabase/migrations/20240601000010_desktop_fs_recursive_ops.sql
@@ -1,0 +1,77 @@
+-- Migration: Recursive Filesystem Operations
+-- Issues: #205 (recursive trash cascade), #206 (owner-scoped empty trash)
+--
+-- Adds RPC functions for recursive trash/restore and owner-scoped empty trash
+-- to prevent orphaned rows and cross-tenant data leaks.
+
+-- ============================================
+-- RECURSIVE TRASH: cascade is_trashed to all descendants
+-- ============================================
+
+CREATE OR REPLACE FUNCTION trash_node_recursive(p_node_id UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_affected INTEGER;
+BEGIN
+  WITH RECURSIVE descendants AS (
+    SELECT id FROM desktop_filesystem WHERE id = p_node_id
+    UNION ALL
+    SELECT f.id FROM desktop_filesystem f
+    JOIN descendants d ON f.parent_id = d.id
+  )
+  UPDATE desktop_filesystem
+  SET is_trashed = true, trashed_at = NOW()
+  WHERE id IN (SELECT id FROM descendants);
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$$;
+
+-- ============================================
+-- RECURSIVE RESTORE: cascade is_trashed = false to all descendants
+-- ============================================
+
+CREATE OR REPLACE FUNCTION restore_node_recursive(p_node_id UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_affected INTEGER;
+BEGIN
+  WITH RECURSIVE descendants AS (
+    SELECT id FROM desktop_filesystem WHERE id = p_node_id
+    UNION ALL
+    SELECT f.id FROM desktop_filesystem f
+    JOIN descendants d ON f.parent_id = d.id
+  )
+  UPDATE desktop_filesystem
+  SET is_trashed = false, trashed_at = NULL
+  WHERE id IN (SELECT id FROM descendants);
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$$;
+
+-- ============================================
+-- OWNER-SCOPED EMPTY TRASH: only delete items belonging to a specific owner
+-- ============================================
+
+CREATE OR REPLACE FUNCTION empty_trash_for_owner(p_owner_id TEXT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_deleted INTEGER;
+BEGIN
+  DELETE FROM desktop_filesystem
+  WHERE is_trashed = true
+    AND owner_id = p_owner_id;
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;


### PR DESCRIPTION
## Summary
- **#205 Recursive trash cascade**: Added `trash_node_recursive` and `restore_node_recursive` Postgres RPCs using recursive CTEs to cascade `is_trashed` to all descendant nodes, preventing orphaned rows
- **#206 Owner-scoped empty trash**: Added `empty_trash_for_owner` RPC and threaded `ownerId` through `useFileSystem` hook to scope `emptyTrash()` and `searchFileSystem()` by owner, preventing cross-tenant data deletion
- **#207 Desktop shortcuts broken**: Replaced non-existent `node.app_id` with `node.target_type === 'app' && node.target_id` to fix desktop icon shortcuts

## Files changed
- `supabase/migrations/20240601000010_desktop_fs_recursive_ops.sql` (new)
- `src/lib/desktop-queries.ts`
- `src/hooks/useFileSystem.ts`
- `src/components/desktop/WindowManager.tsx`
- `src/components/desktop/Desktop.tsx`
- `src/components/desktop/apps/FileExplorer.tsx`

## Test plan
- [ ] Trash a folder with children — verify all descendants show in Trash
- [ ] Restore a trashed folder — verify all descendants are restored
- [ ] Empty Trash — verify only current user's items are deleted
- [ ] Click a desktop shortcut with `target_type: 'app'` — verify app launches
- [ ] TypeScript compiles cleanly

Closes #205, #206, #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)