### PR TITLE
fix: skip global shortcuts inside input fields (#210)

### DIFF
--- a/src/hooks/useDesktopShortcuts.ts
+++ b/src/hooks/useDesktopShortcuts.ts
@@ -1,5 +1,5 @@
-import { useEffect, useCallback } from 'react';
-import type { WindowState } from './useWindowManager';
+import { useEffect, useCallback } from "react";
+import type { WindowState } from "./useWindowManager";
 
 interface UseDesktopShortcutsOptions {
   closeWindow: (id: string) => void;
@@ -25,38 +25,59 @@ export function useDesktopShortcuts({
   const handleModKey = useCallback(
     (e: KeyboardEvent) => {
       switch (e.key) {
-        case 'w':
+        case "w":
           e.preventDefault();
           if (focusedWindowId) closeWindow(focusedWindowId);
           break;
-        case 'm':
+        case "m":
           e.preventDefault();
           if (focusedWindowId) minimizeWindow(focusedWindowId);
           break;
-        case '`': {
+        case "`": {
           e.preventDefault();
           const nonMinimized = windows
-            .filter(w => !w.minimized)
+            .filter((w) => !w.minimized)
             .sort((a, b) => b.zIndex - a.zIndex);
           if (nonMinimized.length < 2) break;
-          const currentIdx = nonMinimized.findIndex(w => w.id === focusedWindowId);
+          const currentIdx = nonMinimized.findIndex(
+            (w) => w.id === focusedWindowId,
+          );
           const nextIdx = (currentIdx + 1) % nonMinimized.length;
           focusWindow(nonMinimized[nextIdx].id);
           break;
         }
-        case 'k':
-        case ' ':
+        case "k":
+        case " ":
           e.preventDefault();
           if (isSpotlightOpen) closeSpotlight();
           else openSpotlight();
           break;
       }
     },
-    [closeWindow, minimizeWindow, focusWindow, focusedWindowId, windows, openSpotlight, closeSpotlight, isSpotlightOpen]
+    [
+      closeWindow,
+      minimizeWindow,
+      focusWindow,
+      focusedWindowId,
+      windows,
+      openSpotlight,
+      closeSpotlight,
+      isSpotlightOpen,
+    ],
   );
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Skip global shortcuts when focus is inside input fields
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
       const mod = e.metaKey || e.ctrlKey;
 
       if (mod) {
@@ -64,13 +85,13 @@ export function useDesktopShortcuts({
         return;
       }
 
-      if (e.key === 'Escape' && isSpotlightOpen) {
+      if (e.key === "Escape" && isSpotlightOpen) {
         e.preventDefault();
         closeSpotlight();
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [handleModKey, isSpotlightOpen, closeSpotlight]);
 }


### PR DESCRIPTION
## Summary
- Global keyboard shortcuts (Cmd+W, Cmd+M, Cmd+`, Cmd+K) now check `e.target` before firing
- If focus is inside an `<input>`, `<textarea>`, or `contentEditable` element, the global handler yields to the in-app handler

## Test plan
- [ ] Open a text input inside an app window, press Cmd+W — window should NOT close
- [ ] Press Cmd+W when no input is focused — window should close normally
- [ ] Spotlight Cmd+K still works from desktop

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)