### PR TITLE
fix: increase traffic light button hit areas to 24x24px (#215)

### DIFF
--- a/src/components/desktop/WindowTitleBar.tsx
+++ b/src/components/desktop/WindowTitleBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState } from "react";
 
 interface WindowTitleBarProps {
   title: string;
@@ -37,94 +37,143 @@ export default function WindowTitleBar({
     <div
       className={`
         h-9 flex items-center px-3 select-none shrink-0 rounded-t-lg
-        ${focused
-          ? 'bg-card border-b border-border'
-          : 'bg-muted/80 border-b border-border/50'
+        ${
+          focused
+            ? "bg-card border-b border-border"
+            : "bg-muted/80 border-b border-border/50"
         }
       `}
       onPointerDown={onPointerDown}
       onDoubleClick={onDoubleClick}
     >
-      {/* Traffic light buttons */}
+      {/* Traffic light buttons — 24x24 hit areas around 12px visible dots (WCAG 2.5.5) */}
       <div
-        className="flex items-center gap-1.5 mr-3"
+        className="flex items-center -ml-1.5 mr-1.5"
         onMouseEnter={() => setHovering(true)}
         onMouseLeave={() => setHovering(false)}
       >
         {/* Close (red) */}
         <button
-          onClick={(e) => { e.stopPropagation(); onClose(); }}
-          className={`
-            w-3 h-3 rounded-full transition-colors
-            ${focused
-              ? 'bg-red-500 hover:bg-red-600'
-              : 'bg-muted-foreground/30'
-            }
-          `}
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          className="w-6 h-6 flex items-center justify-center"
           aria-label="Close window"
         >
-          {hovering && focused && (
-            <svg className="w-3 h-3 text-red-900/80" viewBox="0 0 12 12">
-              <path d="M3.5 3.5L8.5 8.5M8.5 3.5L3.5 8.5" stroke="currentColor" strokeWidth="1.2" fill="none" />
-            </svg>
-          )}
+          <span
+            className={`
+            w-3 h-3 rounded-full transition-colors relative
+            ${focused ? "bg-red-500 hover:bg-red-600" : "bg-muted-foreground/30"}
+          `}
+          >
+            {hovering && focused && (
+              <svg
+                className="w-3 h-3 text-red-900/80 absolute inset-0"
+                viewBox="0 0 12 12"
+              >
+                <path
+                  d="M3.5 3.5L8.5 8.5M8.5 3.5L3.5 8.5"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  fill="none"
+                />
+              </svg>
+            )}
+          </span>
         </button>
 
         {/* Minimize (yellow) */}
         <button
-          onClick={(e) => { e.stopPropagation(); onMinimize(); }}
-          className={`
-            w-3 h-3 rounded-full transition-colors
-            ${focused
-              ? 'bg-yellow-500 hover:bg-yellow-600'
-              : 'bg-muted-foreground/30'
-            }
-          `}
+          onClick={(e) => {
+            e.stopPropagation();
+            onMinimize();
+          }}
+          className="w-6 h-6 flex items-center justify-center"
           aria-label="Minimize window"
         >
-          {hovering && focused && (
-            <svg className="w-3 h-3 text-yellow-900/80" viewBox="0 0 12 12">
-              <path d="M3 6H9" stroke="currentColor" strokeWidth="1.2" fill="none" />
-            </svg>
-          )}
+          <span
+            className={`
+            w-3 h-3 rounded-full transition-colors relative
+            ${focused ? "bg-yellow-500 hover:bg-yellow-600" : "bg-muted-foreground/30"}
+          `}
+          >
+            {hovering && focused && (
+              <svg
+                className="w-3 h-3 text-yellow-900/80 absolute inset-0"
+                viewBox="0 0 12 12"
+              >
+                <path
+                  d="M3 6H9"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  fill="none"
+                />
+              </svg>
+            )}
+          </span>
         </button>
 
         {/* Maximize/Restore (green) */}
         <button
-          onClick={(e) => { e.stopPropagation(); handleMaxToggle(); }}
-          className={`
-            w-3 h-3 rounded-full transition-colors
-            ${focused
-              ? 'bg-green-500 hover:bg-green-600'
-              : 'bg-muted-foreground/30'
-            }
-          `}
-          aria-label={maximized ? 'Restore window' : 'Maximize window'}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleMaxToggle();
+          }}
+          className="w-6 h-6 flex items-center justify-center"
+          aria-label={maximized ? "Restore window" : "Maximize window"}
         >
-          {hovering && focused && (
-            <svg className="w-3 h-3 text-green-900/80" viewBox="0 0 12 12">
-              {maximized ? (
-                // Restore icon (two overlapping squares)
-                <>
-                  <rect x="2.5" y="4.5" width="5" height="5" rx="0.5" stroke="currentColor" strokeWidth="1" fill="none" />
-                  <path d="M4.5 4.5V3a.5.5 0 0 1 .5-.5H9a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5H7.5" stroke="currentColor" strokeWidth="1" fill="none" />
-                </>
-              ) : (
-                // Full screen arrows
-                <>
-                  <path d="M3 3L5.5 5.5M9 3L6.5 5.5M3 9L5.5 6.5M9 9L6.5 6.5" stroke="currentColor" strokeWidth="1" fill="none" />
-                </>
-              )}
-            </svg>
-          )}
+          <span
+            className={`
+            w-3 h-3 rounded-full transition-colors relative
+            ${focused ? "bg-green-500 hover:bg-green-600" : "bg-muted-foreground/30"}
+          `}
+          >
+            {hovering && focused && (
+              <svg
+                className="w-3 h-3 text-green-900/80 absolute inset-0"
+                viewBox="0 0 12 12"
+              >
+                {maximized ? (
+                  <>
+                    <rect
+                      x="2.5"
+                      y="4.5"
+                      width="5"
+                      height="5"
+                      rx="0.5"
+                      stroke="currentColor"
+                      strokeWidth="1"
+                      fill="none"
+                    />
+                    <path
+                      d="M4.5 4.5V3a.5.5 0 0 1 .5-.5H9a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5H7.5"
+                      stroke="currentColor"
+                      strokeWidth="1"
+                      fill="none"
+                    />
+                  </>
+                ) : (
+                  <path
+                    d="M3 3L5.5 5.5M9 3L6.5 5.5M3 9L5.5 6.5M9 9L6.5 6.5"
+                    stroke="currentColor"
+                    strokeWidth="1"
+                    fill="none"
+                  />
+                )}
+              </svg>
+            )}
+          </span>
         </button>
       </div>
 
       {/* Title */}
-      <span className={`
+      <span
+        className={`
         flex-1 text-center text-xs font-medium truncate pointer-events-none
-        ${focused ? 'text-foreground' : 'text-muted-foreground'}
-      `}>
+        ${focused ? "text-foreground" : "text-muted-foreground"}
+      `}
+      >
         {title}
       </span>
 


### PR DESCRIPTION
## Summary
- Clickable button area expanded from 12x12px to 24x24px (WCAG 2.5.5 Level AA)
- Visible colored dot remains 12px — same visual appearance as macOS
- Negative margin on container compensates for larger hit areas to preserve visual spacing

## Test plan
- [ ] Traffic light dots still look identical visually (12px colored circles)
- [ ] Clicking in the 24px area around any dot triggers the action
- [ ] Hover state with icons still appears correctly

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)