### PR TITLE
fix: make desktop icons keyboard-reachable (#214)

### DIFF
--- a/src/components/desktop/DesktopIcon.tsx
+++ b/src/components/desktop/DesktopIcon.tsx
@@ -1,17 +1,46 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef } from "react";
 import {
-  Folder, FileText, Monitor, AppWindow, Download, Trash2, Link,
-  File, Bot, GitBranch, Plug, Settings, Bookmark, Users, CheckSquare,
-} from 'lucide-react';
-import type { FileSystemNode } from '@/lib/desktop-schemas';
+  Folder,
+  FileText,
+  Monitor,
+  AppWindow,
+  Download,
+  Trash2,
+  Link,
+  File,
+  Bot,
+  GitBranch,
+  Plug,
+  Settings,
+  Bookmark,
+  Users,
+  CheckSquare,
+} from "lucide-react";
+import type { FileSystemNode } from "@/lib/desktop-schemas";
 
 const MENU_BAR_HEIGHT = 28;
 const DOCK_HEIGHT = 64;
 const ICON_SIZE = 80; // total icon cell size
 
-const ICON_COMPONENTS: Record<string, React.ComponentType<{ className?: string }>> = {
-  Folder, FileText, Monitor, AppWindow, Download, Trash2, Link,
-  File, Bot, GitBranch, Plug, Settings, Bookmark, Users, CheckSquare,
+const ICON_COMPONENTS: Record<
+  string,
+  React.ComponentType<{ className?: string }>
+> = {
+  Folder,
+  FileText,
+  Monitor,
+  AppWindow,
+  Download,
+  Trash2,
+  Link,
+  File,
+  Bot,
+  GitBranch,
+  Plug,
+  Settings,
+  Bookmark,
+  Users,
+  CheckSquare,
 };
 
 interface DesktopIconProps {
@@ -32,102 +61,143 @@ export default function DesktopIcon({
   onPositionChange,
 }: DesktopIconProps) {
   const iconRef = useRef<HTMLDivElement>(null);
-  const dragStartRef = useRef<{ px: number; py: number; startX: number; startY: number } | null>(null);
+  const dragStartRef = useRef<{
+    px: number;
+    py: number;
+    startX: number;
+    startY: number;
+  } | null>(null);
   const isDraggingRef = useRef(false);
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const Icon = ICON_COMPONENTS[node.icon ?? ''] ?? File;
+  const Icon = ICON_COMPONENTS[node.icon ?? ""] ?? File;
   const position = node.position ?? { x: 0, y: 0 };
 
-  const handlePointerDown = useCallback((e: React.PointerEvent) => {
-    if (e.button !== 0) return; // left click only
-    e.preventDefault();
-    e.stopPropagation();
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return; // left click only
+      e.preventDefault();
+      e.stopPropagation();
 
-    onSelect(node.id);
+      onSelect(node.id);
 
-    const el = iconRef.current;
-    if (!el) return;
+      const el = iconRef.current;
+      if (!el) return;
 
-    dragStartRef.current = {
-      px: e.clientX,
-      py: e.clientY,
-      startX: position.x,
-      startY: position.y,
-    };
-    isDraggingRef.current = false;
-    el.setPointerCapture(e.pointerId);
+      dragStartRef.current = {
+        px: e.clientX,
+        py: e.clientY,
+        startX: position.x,
+        startY: position.y,
+      };
+      isDraggingRef.current = false;
+      el.setPointerCapture(e.pointerId);
 
-    const handleMove = (moveEvent: PointerEvent) => {
-      if (!dragStartRef.current) return;
-      const dx = moveEvent.clientX - dragStartRef.current.px;
-      const dy = moveEvent.clientY - dragStartRef.current.py;
+      const handleMove = (moveEvent: PointerEvent) => {
+        if (!dragStartRef.current) return;
+        const dx = moveEvent.clientX - dragStartRef.current.px;
+        const dy = moveEvent.clientY - dragStartRef.current.py;
 
-      if (!isDraggingRef.current && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
-        isDraggingRef.current = true;
-      }
-      if (!isDraggingRef.current) return;
+        if (!isDraggingRef.current && (Math.abs(dx) > 3 || Math.abs(dy) > 3)) {
+          isDraggingRef.current = true;
+        }
+        if (!isDraggingRef.current) return;
 
-      const viewW = window.innerWidth;
-      const viewH = window.innerHeight;
-
-      let newX = dragStartRef.current.startX + dx;
-      let newY = dragStartRef.current.startY + dy;
-
-      // Clamp within desktop area
-      newX = Math.max(0, Math.min(viewW - ICON_SIZE, newX));
-      newY = Math.max(MENU_BAR_HEIGHT, Math.min(viewH - DOCK_HEIGHT - ICON_SIZE, newY));
-
-      if (iconRef.current) {
-        iconRef.current.style.left = `${newX}px`;
-        iconRef.current.style.top = `${newY}px`;
-      }
-    };
-
-    const handleUp = (upEvent: PointerEvent) => {
-      el.removeEventListener('pointermove', handleMove);
-      el.removeEventListener('pointerup', handleUp);
-
-      if (isDraggingRef.current && dragStartRef.current) {
-        const dx = upEvent.clientX - dragStartRef.current.px;
-        const dy = upEvent.clientY - dragStartRef.current.py;
         const viewW = window.innerWidth;
         const viewH = window.innerHeight;
 
         let newX = dragStartRef.current.startX + dx;
         let newY = dragStartRef.current.startY + dy;
+
+        // Clamp within desktop area
         newX = Math.max(0, Math.min(viewW - ICON_SIZE, newX));
-        newY = Math.max(MENU_BAR_HEIGHT, Math.min(viewH - DOCK_HEIGHT - ICON_SIZE, newY));
+        newY = Math.max(
+          MENU_BAR_HEIGHT,
+          Math.min(viewH - DOCK_HEIGHT - ICON_SIZE, newY),
+        );
 
-        onPositionChange?.(node.id, { x: newX, y: newY });
+        if (iconRef.current) {
+          iconRef.current.style.left = `${newX}px`;
+          iconRef.current.style.top = `${newY}px`;
+        }
+      };
+
+      const handleUp = (upEvent: PointerEvent) => {
+        el.removeEventListener("pointermove", handleMove);
+        el.removeEventListener("pointerup", handleUp);
+
+        if (isDraggingRef.current && dragStartRef.current) {
+          const dx = upEvent.clientX - dragStartRef.current.px;
+          const dy = upEvent.clientY - dragStartRef.current.py;
+          const viewW = window.innerWidth;
+          const viewH = window.innerHeight;
+
+          let newX = dragStartRef.current.startX + dx;
+          let newY = dragStartRef.current.startY + dy;
+          newX = Math.max(0, Math.min(viewW - ICON_SIZE, newX));
+          newY = Math.max(
+            MENU_BAR_HEIGHT,
+            Math.min(viewH - DOCK_HEIGHT - ICON_SIZE, newY),
+          );
+
+          onPositionChange?.(node.id, { x: newX, y: newY });
+        }
+
+        dragStartRef.current = null;
+        isDraggingRef.current = false;
+      };
+
+      el.addEventListener("pointermove", handleMove);
+      el.addEventListener("pointerup", handleUp);
+    },
+    [node.id, position.x, position.y, onSelect, onPositionChange],
+  );
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (isDraggingRef.current) return;
+      onSelect(node.id);
+    },
+    [node.id, onSelect],
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (clickTimerRef.current) {
+        clearTimeout(clickTimerRef.current);
+        clickTimerRef.current = null;
       }
+      onOpen(node);
+    },
+    [node, onOpen],
+  );
 
-      dragStartRef.current = null;
-      isDraggingRef.current = false;
-    };
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      onContextMenu(e, node);
+    },
+    [node, onContextMenu],
+  );
 
-    el.addEventListener('pointermove', handleMove);
-    el.addEventListener('pointerup', handleUp);
-  }, [node.id, position.x, position.y, onSelect, onPositionChange]);
-
-  const handleClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (isDraggingRef.current) return;
-    onSelect(node.id);
-  }, [node.id, onSelect]);
-
-  const handleDoubleClick = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (clickTimerRef.current) {
-      clearTimeout(clickTimerRef.current);
-      clickTimerRef.current = null;
-    }
-    onOpen(node);
-  }, [node, onOpen]);
-
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
-    onContextMenu(e, node);
-  }, [node, onContextMenu]);
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "Enter":
+        case " ":
+          e.preventDefault();
+          onOpen(node);
+          break;
+        case "Delete":
+        case "Backspace":
+          e.preventDefault();
+          onContextMenu(e as unknown as React.MouseEvent, node);
+          break;
+      }
+    },
+    [node, onOpen, onContextMenu],
+  );
 
   return (
     <div
@@ -135,7 +205,8 @@ export default function DesktopIcon({
       className={`
         absolute flex flex-col items-center justify-start gap-1 p-2
         rounded-lg cursor-default select-none touch-none
-        ${isSelected ? 'bg-primary/20 ring-1 ring-primary/40' : 'hover:bg-white/5'}
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-primary
+        ${isSelected ? "bg-primary/20 ring-1 ring-primary/40" : "hover:bg-white/5"}
       `}
       style={{
         left: position.x,
@@ -147,11 +218,15 @@ export default function DesktopIcon({
       onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}
       onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
       role="button"
       aria-label={node.name}
       aria-selected={isSelected}
     >
-      <Icon className={`w-8 h-8 ${node.color ?? 'text-blue-400'} drop-shadow-md`} />
+      <Icon
+        className={`w-8 h-8 ${node.color ?? "text-blue-400"} drop-shadow-md`}
+      />
       <span className="text-[10px] text-white text-center leading-tight line-clamp-2 drop-shadow-md font-medium">
         {node.name}
       </span>


### PR DESCRIPTION
## Summary
- Added `tabIndex={0}` so desktop icons are reachable via Tab key
- Enter/Space opens the icon (same as double-click)
- Delete/Backspace triggers the context menu for trash/rename actions
- Added `focus-visible:ring-2` for clear keyboard focus indication

## Test plan
- [ ] Tab through desktop icons — each icon should receive focus with visible ring
- [ ] Press Enter on a focused icon — should open it
- [ ] Press Delete on a focused icon — should show context menu
- [ ] Mouse interaction still works as before

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)