### PR TITLE
fix: portal SnapPreview to avoid contain:paint clipping (#211)

### DIFF
--- a/src/hooks/useSnapZones.tsx
+++ b/src/hooks/useSnapZones.tsx
@@ -1,17 +1,18 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 const SNAP_THRESHOLD = 12;
 const MENU_BAR_HEIGHT = 28;
 const DOCK_HEIGHT = 64;
 
 export type SnapZone =
-  | 'left-half'
-  | 'right-half'
-  | 'full'
-  | 'top-left'
-  | 'top-right'
-  | 'bottom-left'
-  | 'bottom-right'
+  | "left-half"
+  | "right-half"
+  | "full"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
   | null;
 
 /** Get the snap zone based on cursor position relative to viewport edges */
@@ -25,17 +26,17 @@ function detectSnapZone(clientX: number, clientY: number): SnapZone {
   const nearBottom = clientY >= vh - DOCK_HEIGHT - SNAP_THRESHOLD;
 
   // Corners take priority
-  if (nearTop && nearLeft) return 'top-left';
-  if (nearTop && nearRight) return 'top-right';
-  if (nearBottom && nearLeft) return 'bottom-left';
-  if (nearBottom && nearRight) return 'bottom-right';
+  if (nearTop && nearLeft) return "top-left";
+  if (nearTop && nearRight) return "top-right";
+  if (nearBottom && nearLeft) return "bottom-left";
+  if (nearBottom && nearRight) return "bottom-right";
 
   // Full screen via top edge
-  if (nearTop) return 'full';
+  if (nearTop) return "full";
 
   // Halves via left/right edges
-  if (nearLeft) return 'left-half';
-  if (nearRight) return 'right-half';
+  if (nearLeft) return "left-half";
+  if (nearRight) return "right-half";
 
   return null;
 }
@@ -56,20 +57,35 @@ export function getSnapGeometry(zone: SnapZone): {
   const halfH = Math.floor(usableHeight / 2);
 
   switch (zone) {
-    case 'full':
+    case "full":
       return { x: 0, y: MENU_BAR_HEIGHT, width: vw, height: usableHeight };
-    case 'left-half':
+    case "left-half":
       return { x: 0, y: MENU_BAR_HEIGHT, width: halfW, height: usableHeight };
-    case 'right-half':
-      return { x: halfW, y: MENU_BAR_HEIGHT, width: vw - halfW, height: usableHeight };
-    case 'top-left':
+    case "right-half":
+      return {
+        x: halfW,
+        y: MENU_BAR_HEIGHT,
+        width: vw - halfW,
+        height: usableHeight,
+      };
+    case "top-left":
       return { x: 0, y: MENU_BAR_HEIGHT, width: halfW, height: halfH };
-    case 'top-right':
+    case "top-right":
       return { x: halfW, y: MENU_BAR_HEIGHT, width: vw - halfW, height: halfH };
-    case 'bottom-left':
-      return { x: 0, y: MENU_BAR_HEIGHT + halfH, width: halfW, height: usableHeight - halfH };
-    case 'bottom-right':
-      return { x: halfW, y: MENU_BAR_HEIGHT + halfH, width: vw - halfW, height: usableHeight - halfH };
+    case "bottom-left":
+      return {
+        x: 0,
+        y: MENU_BAR_HEIGHT + halfH,
+        width: halfW,
+        height: usableHeight - halfH,
+      };
+    case "bottom-right":
+      return {
+        x: halfW,
+        y: MENU_BAR_HEIGHT + halfH,
+        width: vw - halfW,
+        height: usableHeight - halfH,
+      };
     default:
       return null;
   }
@@ -104,23 +120,24 @@ export function useSnapZones() {
   return { activeZone, updateSnapZone, clearSnapZone, commitSnap };
 }
 
-/** Semi-transparent blue snap preview overlay */
+/** Semi-transparent blue snap preview overlay — portaled to document.body to avoid contain:paint clipping */
 export function SnapPreview({ zone }: { zone: SnapZone }) {
   const geo = getSnapGeometry(zone);
   if (!geo) return null;
 
-  return (
+  return createPortal(
     <div
       style={{
-        position: 'fixed',
+        position: "fixed",
         left: geo.x,
         top: geo.y,
         width: geo.width,
         height: geo.height,
         zIndex: 9999,
-        pointerEvents: 'none',
+        pointerEvents: "none",
       }}
       className="bg-blue-500/20 border-2 border-blue-500/40 rounded-lg transition-all duration-150"
-    />
+    />,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary
- SnapPreview now uses `createPortal(…, document.body)` to render outside the Window component
- This avoids the \`contain: layout style paint\` on Window.tsx which was creating a new stacking context and clipping the fixed-positioned overlay

## Test plan
- [ ] Drag a window to screen edges — snap preview overlay should appear correctly at viewport level
- [ ] Snap preview should cover the expected zone (left half, right half, corners, full)
- [ ] Release mouse — window should snap to the previewed zone

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)