### PR TITLE
fix: show toast when 10-window limit reached (#212)

### DIFF
--- a/src/components/desktop/DesktopShell.tsx
+++ b/src/components/desktop/DesktopShell.tsx
@@ -1,23 +1,30 @@
-import { useState, useCallback } from 'react';
-import { Navigate } from 'react-router-dom';
-import { useAuth } from '@/lib/auth';
-import { Loader2 } from 'lucide-react';
-import { WindowManagerProvider, useWindowManagerContext } from './WindowManager';
-import { useDesktopShortcuts } from '@/hooks/useDesktopShortcuts';
-import MenuBar from './MenuBar';
-import Desktop from './Desktop';
-import Dock from './Dock';
-import Spotlight from './Spotlight';
-import NotificationCenter from './NotificationCenter';
+import { useState, useCallback } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/lib/auth";
+import { Loader2 } from "lucide-react";
+import {
+  WindowManagerProvider,
+  useWindowManagerContext,
+} from "./WindowManager";
+import { useDesktopShortcuts } from "@/hooks/useDesktopShortcuts";
+import MenuBar from "./MenuBar";
+import Desktop from "./Desktop";
+import Dock from "./Dock";
+import Spotlight from "./Spotlight";
+import NotificationCenter from "./NotificationCenter";
 
 function DesktopShellContent() {
-  const { state, closeWindow, minimizeWindow, focusWindow } = useWindowManagerContext();
+  const { state, toastMessage, closeWindow, minimizeWindow, focusWindow } =
+    useWindowManagerContext();
   const [spotlightOpen, setSpotlightOpen] = useState(false);
   const [notificationCenterOpen, setNotificationCenterOpen] = useState(false);
 
   const openSpotlight = useCallback(() => setSpotlightOpen(true), []);
   const closeSpotlight = useCallback(() => setSpotlightOpen(false), []);
-  const toggleNotifications = useCallback(() => setNotificationCenterOpen(prev => !prev), []);
+  const toggleNotifications = useCallback(
+    () => setNotificationCenterOpen((prev) => !prev),
+    [],
+  );
 
   useDesktopShortcuts({
     closeWindow,
@@ -36,7 +43,18 @@ function DesktopShellContent() {
       <Desktop />
       <Dock />
       <Spotlight isOpen={spotlightOpen} onClose={closeSpotlight} />
-      <NotificationCenter isOpen={notificationCenterOpen} onClose={() => setNotificationCenterOpen(false)} />
+      <NotificationCenter
+        isOpen={notificationCenterOpen}
+        onClose={() => setNotificationCenterOpen(false)}
+      />
+      {toastMessage && (
+        <div
+          className="fixed bottom-20 left-1/2 -translate-x-1/2 px-4 py-2 bg-card/95 backdrop-blur-md border border-border rounded-lg shadow-xl text-xs text-foreground animate-in fade-in slide-in-from-bottom-2 z-50"
+          role="alert"
+        >
+          {toastMessage}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Added \`toastMessage\` state to WindowManagerProvider with 3-second auto-dismiss
- When user tries to open an 11th window, shows: "Maximum of 10 windows open. Close a window to open a new one."
- Toast renders as a centered bottom overlay with backdrop blur

## Test plan
- [ ] Open 10 windows, try to open an 11th — toast should appear
- [ ] Toast should auto-dismiss after 3 seconds
- [ ] Close a window, then try again — new window should open normally

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)