### PR TITLE
fix: add aria-modal and focus management to windows (#213)

### DIFF
--- a/src/components/desktop/Window.tsx
+++ b/src/components/desktop/Window.tsx
@@ -219,6 +219,22 @@ export default function Window({ window: win }: WindowProps) {
     callbacks: resizeCallbacks,
   });
 
+  // Move focus into the window when it becomes the focused window
+  useEffect(() => {
+    if (!isFocused || !windowRef.current) return;
+    // If focus is already inside this window, don't steal it
+    if (windowRef.current.contains(document.activeElement)) return;
+    // Focus the first interactive element, or the window itself
+    const focusable = windowRef.current.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    if (focusable) {
+      focusable.focus();
+    } else {
+      windowRef.current.focus();
+    }
+  }, [isFocused]);
+
   const handlePointerDown = useCallback(() => {
     if (!isFocused) {
       focusWindow(win.id);
@@ -324,8 +340,10 @@ export default function Window({ window: win }: WindowProps) {
         {...motionAnimProps}
         role="dialog"
         aria-label={win.title}
+        aria-modal={isFocused}
+        tabIndex={-1}
         className={`
-          absolute flex flex-col rounded-lg overflow-visible
+          absolute flex flex-col rounded-lg overflow-visible outline-none
           ${isFocused ? "shadow-2xl ring-1 ring-border" : "shadow-lg ring-1 ring-border/50"}
         `}
         style={{


### PR DESCRIPTION
## Summary
- Added \`aria-modal={isFocused}\` — active when window is the focused dialog
- Added \`tabIndex={-1}\` so the window container can be programmatically focused
- When a window becomes focused, moves focus to the first interactive element inside it (or the window itself as fallback)
- Respects existing focus — if focus is already inside the window, doesn't steal it

## Test plan
- [ ] Open a window — first interactive element should receive focus
- [ ] Switch between windows — focus should move to newly focused window
- [ ] Screen reader should announce the focused window as a modal dialog
- [ ] Typing in an input and switching back should preserve in-window focus

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)