### PR TITLE
fix: replace browser prompt() with inline rename in FileExplorer (#208)

### DIFF
--- a/src/components/desktop/apps/FileExplorerContent.tsx
+++ b/src/components/desktop/apps/FileExplorerContent.tsx
@@ -1,24 +1,106 @@
-import { useCallback } from 'react';
+import { useCallback, useState, useRef, useEffect } from "react";
 import {
-  Folder, FileText, Link, File, Bot, GitBranch, Plug, Bookmark,
-  Users, CheckSquare, AppWindow, Monitor, Download, Trash2, Settings,
-} from 'lucide-react';
-import type { FileSystemNode, FileExplorerViewMode } from '@/lib/desktop-schemas';
-import type { ContextMenuItem } from '@/hooks/useContextMenu';
+  Folder,
+  FileText,
+  Link,
+  File,
+  Bot,
+  GitBranch,
+  Plug,
+  Bookmark,
+  Users,
+  CheckSquare,
+  AppWindow,
+  Monitor,
+  Download,
+  Trash2,
+  Settings,
+} from "lucide-react";
+import type {
+  FileSystemNode,
+  FileExplorerViewMode,
+} from "@/lib/desktop-schemas";
+import type { ContextMenuItem } from "@/hooks/useContextMenu";
 
 const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
-  Folder, FileText, Link, File, Bot, GitBranch, Plug, Bookmark,
-  Users, CheckSquare, AppWindow, Monitor, Download, Trash2, Settings,
+  Folder,
+  FileText,
+  Link,
+  File,
+  Bot,
+  GitBranch,
+  Plug,
+  Bookmark,
+  Users,
+  CheckSquare,
+  AppWindow,
+  Monitor,
+  Download,
+  Trash2,
+  Settings,
 };
 
 function NodeIcon({ node }: { node: FileSystemNode }) {
-  const Icon = ICON_MAP[node.icon ?? ''] ?? (node.type === 'folder' ? Folder : File);
-  return <Icon className={`w-4 h-4 ${node.color ?? 'text-blue-400'} shrink-0`} />;
+  const Icon =
+    ICON_MAP[node.icon ?? ""] ?? (node.type === "folder" ? Folder : File);
+  return (
+    <Icon className={`w-4 h-4 ${node.color ?? "text-blue-400"} shrink-0`} />
+  );
 }
 
 function LargeNodeIcon({ node }: { node: FileSystemNode }) {
-  const Icon = ICON_MAP[node.icon ?? ''] ?? (node.type === 'folder' ? Folder : File);
-  return <Icon className={`w-10 h-10 ${node.color ?? 'text-blue-400'}`} />;
+  const Icon =
+    ICON_MAP[node.icon ?? ""] ?? (node.type === "folder" ? Folder : File);
+  return <Icon className={`w-10 h-10 ${node.color ?? "text-blue-400"}`} />;
+}
+
+// Inline rename input shared across views
+function InlineRenameInput({
+  name,
+  onConfirm,
+  onCancel,
+}: {
+  name: string;
+  onConfirm: (newName: string) => void;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    input.focus();
+    // Select the name part before the extension (if any)
+    const dotIndex = name.lastIndexOf(".");
+    input.setSelectionRange(0, dotIndex > 0 ? dotIndex : name.length);
+  }, [name]);
+
+  const confirm = () => {
+    onConfirm(value);
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === "Enter") {
+          e.preventDefault();
+          confirm();
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          onCancel();
+        }
+      }}
+      onBlur={confirm}
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => e.stopPropagation()}
+      className="bg-card border border-primary rounded px-1 py-0 text-[10px] text-foreground outline-none w-full text-center leading-tight"
+    />
+  );
 }
 
 interface FileExplorerContentProps {
@@ -32,6 +114,9 @@ interface FileExplorerContentProps {
   onOpen: (node: FileSystemNode) => void;
   onContextMenu: (e: React.MouseEvent, items: ContextMenuItem[]) => void;
   getNodeMenuItems: (node: FileSystemNode) => ContextMenuItem[];
+  renamingId: string | null;
+  onRenameConfirm: (nodeId: string, newName: string) => void;
+  onRenameCancel: () => void;
 }
 
 export default function FileExplorerContent({
@@ -45,6 +130,9 @@ export default function FileExplorerContent({
   onOpen,
   onContextMenu,
   getNodeMenuItems,
+  renamingId,
+  onRenameConfirm,
+  onRenameCancel,
 }: FileExplorerContentProps) {
   if (isLoading) {
     return (
@@ -65,54 +153,115 @@ export default function FileExplorerContent({
   if (children.length === 0) {
     return (
       <div className="flex-1 flex items-center justify-center text-xs text-muted-foreground">
-        {isTrash ? 'Trash is empty' : 'This folder is empty'}
+        {isTrash ? "Trash is empty" : "This folder is empty"}
       </div>
     );
   }
 
-  if (viewMode === 'icons') {
-    return <IconView items={children} selectedIds={selectedIds} onSelect={onSelect} onOpen={onOpen} onContextMenu={onContextMenu} getNodeMenuItems={getNodeMenuItems} />;
+  if (viewMode === "icons") {
+    return (
+      <IconView
+        items={children}
+        selectedIds={selectedIds}
+        onSelect={onSelect}
+        onOpen={onOpen}
+        onContextMenu={onContextMenu}
+        getNodeMenuItems={getNodeMenuItems}
+        renamingId={renamingId}
+        onRenameConfirm={onRenameConfirm}
+        onRenameCancel={onRenameCancel}
+      />
+    );
   }
-  if (viewMode === 'list') {
-    return <ListView items={children} selectedIds={selectedIds} onSelect={onSelect} onOpen={onOpen} onContextMenu={onContextMenu} getNodeMenuItems={getNodeMenuItems} />;
+  if (viewMode === "list") {
+    return (
+      <ListView
+        items={children}
+        selectedIds={selectedIds}
+        onSelect={onSelect}
+        onOpen={onOpen}
+        onContextMenu={onContextMenu}
+        getNodeMenuItems={getNodeMenuItems}
+        renamingId={renamingId}
+        onRenameConfirm={onRenameConfirm}
+        onRenameCancel={onRenameCancel}
+      />
+    );
   }
-  return <ColumnView items={children} selectedIds={selectedIds} onSelect={onSelect} onOpen={onOpen} onContextMenu={onContextMenu} getNodeMenuItems={getNodeMenuItems} />;
+  return (
+    <ColumnView
+      items={children}
+      selectedIds={selectedIds}
+      onSelect={onSelect}
+      onOpen={onOpen}
+      onContextMenu={onContextMenu}
+      getNodeMenuItems={getNodeMenuItems}
+      renamingId={renamingId}
+      onRenameConfirm={onRenameConfirm}
+      onRenameCancel={onRenameCancel}
+    />
+  );
 }
 
 // ============================================
 // ICON VIEW
 // ============================================
 
-function IconView({ items, selectedIds, onSelect, onOpen, onContextMenu, getNodeMenuItems }: {
+interface ViewProps {
   items: FileSystemNode[];
   selectedIds: Set<string>;
   onSelect: (id: string) => void;
   onOpen: (node: FileSystemNode) => void;
   onContextMenu: (e: React.MouseEvent, items: ContextMenuItem[]) => void;
   getNodeMenuItems: (node: FileSystemNode) => ContextMenuItem[];
-}) {
+  renamingId: string | null;
+  onRenameConfirm: (nodeId: string, newName: string) => void;
+  onRenameCancel: () => void;
+}
+
+function IconView({
+  items,
+  selectedIds,
+  onSelect,
+  onOpen,
+  onContextMenu,
+  getNodeMenuItems,
+  renamingId,
+  onRenameConfirm,
+  onRenameCancel,
+}: ViewProps) {
   return (
     <div className="flex-1 p-4 overflow-auto">
       <div className="grid grid-cols-[repeat(auto-fill,minmax(80px,1fr))] gap-2">
-        {items.map(node => (
+        {items.map((node) => (
           <button
             key={node.id}
             className={`
               flex flex-col items-center gap-1 p-2 rounded-lg text-center
               transition-colors cursor-default
-              ${selectedIds.has(node.id) ? 'bg-primary/15 ring-1 ring-primary/30' : 'hover:bg-muted/50'}
+              ${selectedIds.has(node.id) ? "bg-primary/15 ring-1 ring-primary/30" : "hover:bg-muted/50"}
             `}
             onClick={() => onSelect(node.id)}
-            onDoubleClick={() => onOpen(node)}
-            onContextMenu={e => {
+            onDoubleClick={() => {
+              if (renamingId !== node.id) onOpen(node);
+            }}
+            onContextMenu={(e) => {
               e.preventDefault();
               onContextMenu(e, getNodeMenuItems(node));
             }}
           >
             <LargeNodeIcon node={node} />
-            <span className="text-[10px] text-foreground/80 line-clamp-2 leading-tight w-full">
-              {node.name}
-            </span>
+            {renamingId === node.id ? (
+              <InlineRenameInput
+                name={node.name}
+                onConfirm={(newName) => onRenameConfirm(node.id, newName)}
+                onCancel={onRenameCancel}
+              />
+            ) : (
+              <span className="text-[10px] text-foreground/80 line-clamp-2 leading-tight w-full">
+                {node.name}
+              </span>
+            )}
           </button>
         ))}
       </div>
@@ -124,19 +273,22 @@ function IconView({ items, selectedIds, onSelect, onOpen, onContextMenu, getNode
 // LIST VIEW
 // ============================================
 
-function ListView({ items, selectedIds, onSelect, onOpen, onContextMenu, getNodeMenuItems }: {
-  items: FileSystemNode[];
-  selectedIds: Set<string>;
-  onSelect: (id: string) => void;
-  onOpen: (node: FileSystemNode) => void;
-  onContextMenu: (e: React.MouseEvent, items: ContextMenuItem[]) => void;
-  getNodeMenuItems: (node: FileSystemNode) => ContextMenuItem[];
-}) {
+function ListView({
+  items,
+  selectedIds,
+  onSelect,
+  onOpen,
+  onContextMenu,
+  getNodeMenuItems,
+  renamingId,
+  onRenameConfirm,
+  onRenameCancel,
+}: ViewProps) {
   const formatDate = useCallback((dateStr: string) => {
     return new Date(dateStr).toLocaleDateString(undefined, {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
+      month: "short",
+      day: "numeric",
+      year: "numeric",
     });
   }, []);
 
@@ -145,22 +297,30 @@ function ListView({ items, selectedIds, onSelect, onOpen, onContextMenu, getNode
       <table className="w-full text-xs">
         <thead className="sticky top-0 bg-card border-b border-border">
           <tr>
-            <th className="text-left px-3 py-1.5 font-medium text-muted-foreground">Name</th>
-            <th className="text-left px-3 py-1.5 font-medium text-muted-foreground w-24">Type</th>
-            <th className="text-left px-3 py-1.5 font-medium text-muted-foreground w-32">Modified</th>
+            <th className="text-left px-3 py-1.5 font-medium text-muted-foreground">
+              Name
+            </th>
+            <th className="text-left px-3 py-1.5 font-medium text-muted-foreground w-24">
+              Type
+            </th>
+            <th className="text-left px-3 py-1.5 font-medium text-muted-foreground w-32">
+              Modified
+            </th>
           </tr>
         </thead>
         <tbody>
-          {items.map(node => (
+          {items.map((node) => (
             <tr
               key={node.id}
               className={`
                 border-b border-border/30 cursor-default transition-colors
-                ${selectedIds.has(node.id) ? 'bg-primary/15' : 'hover:bg-muted/30'}
+                ${selectedIds.has(node.id) ? "bg-primary/15" : "hover:bg-muted/30"}
               `}
               onClick={() => onSelect(node.id)}
-              onDoubleClick={() => onOpen(node)}
-              onContextMenu={e => {
+              onDoubleClick={() => {
+                if (renamingId !== node.id) onOpen(node);
+              }}
+              onContextMenu={(e) => {
                 e.preventDefault();
                 onContextMenu(e, getNodeMenuItems(node));
               }}
@@ -168,11 +328,23 @@ function ListView({ items, selectedIds, onSelect, onOpen, onContextMenu, getNode
               <td className="px-3 py-1.5">
                 <div className="flex items-center gap-2">
                   <NodeIcon node={node} />
-                  <span className="truncate">{node.name}</span>
+                  {renamingId === node.id ? (
+                    <InlineRenameInput
+                      name={node.name}
+                      onConfirm={(newName) => onRenameConfirm(node.id, newName)}
+                      onCancel={onRenameCancel}
+                    />
+                  ) : (
+                    <span className="truncate">{node.name}</span>
+                  )}
                 </div>
               </td>
-              <td className="px-3 py-1.5 text-muted-foreground capitalize">{node.type}</td>
-              <td className="px-3 py-1.5 text-muted-foreground">{formatDate(node.updated_at)}</td>
+              <td className="px-3 py-1.5 text-muted-foreground capitalize">
+                {node.type}
+              </td>
+              <td className="px-3 py-1.5 text-muted-foreground">
+                {formatDate(node.updated_at)}
+              </td>
             </tr>
           ))}
         </tbody>
@@ -185,35 +357,50 @@ function ListView({ items, selectedIds, onSelect, onOpen, onContextMenu, getNode
 // COLUMN VIEW (simplified)
 // ============================================
 
-function ColumnView({ items, selectedIds, onSelect, onOpen, onContextMenu, getNodeMenuItems }: {
-  items: FileSystemNode[];
-  selectedIds: Set<string>;
-  onSelect: (id: string) => void;
-  onOpen: (node: FileSystemNode) => void;
-  onContextMenu: (e: React.MouseEvent, items: ContextMenuItem[]) => void;
-  getNodeMenuItems: (node: FileSystemNode) => ContextMenuItem[];
-}) {
+function ColumnView({
+  items,
+  selectedIds,
+  onSelect,
+  onOpen,
+  onContextMenu,
+  getNodeMenuItems,
+  renamingId,
+  onRenameConfirm,
+  onRenameCancel,
+}: ViewProps) {
   return (
     <div className="flex-1 flex overflow-x-auto">
       <div className="min-w-[200px] max-w-[250px] border-r border-border overflow-y-auto">
-        {items.map(node => (
+        {items.map((node) => (
           <button
             key={node.id}
             className={`
               w-full flex items-center gap-2 px-3 py-1.5 text-xs transition-colors
-              ${selectedIds.has(node.id) ? 'bg-primary/15' : 'hover:bg-muted/30'}
+              ${selectedIds.has(node.id) ? "bg-primary/15" : "hover:bg-muted/30"}
             `}
             onClick={() => onSelect(node.id)}
-            onDoubleClick={() => onOpen(node)}
-            onContextMenu={e => {
+            onDoubleClick={() => {
+              if (renamingId !== node.id) onOpen(node);
+            }}
+            onContextMenu={(e) => {
               e.preventDefault();
               onContextMenu(e, getNodeMenuItems(node));
             }}
           >
             <NodeIcon node={node} />
-            <span className="truncate flex-1 text-left">{node.name}</span>
-            {node.type === 'folder' && (
-              <span className="text-muted-foreground/50">›</span>
+            {renamingId === node.id ? (
+              <InlineRenameInput
+                name={node.name}
+                onConfirm={(newName) => onRenameConfirm(node.id, newName)}
+                onCancel={onRenameCancel}
+              />
+            ) : (
+              <>
+                <span className="truncate flex-1 text-left">{node.name}</span>
+                {node.type === "folder" && (
+                  <span className="text-muted-foreground/50">›</span>
+                )}
+              </>
             )}
           </button>
         ))}

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -106,20 +106,22 @@ export function useFileSystem(
   }, [fetchChildren]);
 
   const createFolder = useCallback(
-    async (name: string) => {
+    async (name: string): Promise<FileSystemNode | null> => {
       try {
-        await createFileSystemNode({
+        const node = await createFileSystemNode({
           parent_id: state.currentParentId,
           name,
           type: "folder",
           icon: "Folder",
         });
         await fetchChildren(state.currentParentId);
+        return node;
       } catch (err) {
         setState((prev) => ({
           ...prev,
           error: err instanceof Error ? err.message : "Failed to create folder",
         }));
+        return null;
       }
     },
     [state.currentParentId, fetchChildren],


### PR DESCRIPTION
## Summary
- Removed all \`prompt()\` calls from FileExplorer — no more browser dialogs breaking the OS illusion
- **Rename**: Context menu "Rename" now shows an inline \`<input>\` over the filename
  - Enter confirms, Escape cancels, blur confirms
  - Pre-selects the filename (excluding extension)
- **New Folder**: Creates "Untitled Folder" and immediately enters inline rename mode
- Works across all three view modes (icons, list, column)
- \`useFileSystem.createFolder\` now returns the created \`FileSystemNode\` for rename targeting

## Files changed
- \`src/components/desktop/apps/FileExplorer.tsx\` — state management, removed prompt() calls
- \`src/components/desktop/apps/FileExplorerContent.tsx\` — \`InlineRenameInput\` component, integrated into all 3 views
- \`src/hooks/useFileSystem.ts\` — \`createFolder\` returns created node

## Test plan
- [ ] Right-click a file → Rename → inline input appears with name selected
- [ ] Press Enter → name updates
- [ ] Press Escape → rename cancelled, original name preserved
- [ ] Click away (blur) → rename confirms
- [ ] Right-click background → New Folder → "Untitled Folder" created with rename input active
- [ ] Works in icons, list, and column views

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)