### PR TITLE
feat: replace hardcoded tenant UUIDs, add tenant provisioning (#297, #299)

### DIFF
--- a/src/features/crm/components/DealForm.tsx
+++ b/src/features/crm/components/DealForm.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Loader2, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useAuthenticatedSupabase } from "@/lib/supabase";
+import { useTenantSupabase } from "@/lib/supabase";
 import { getContacts } from "@/lib/crm-queries";
 import { getPipelines, getPipelineStages } from "@/lib/crm-queries";
 import type { Contact, Pipeline, PipelineStage, Deal } from "../schemas";
@@ -42,7 +42,7 @@ export function DealForm({
   onCancel,
   isEditing = false,
 }: DealFormProps) {
-  const { supabase } = useAuthenticatedSupabase();
+  const { supabase, tenantId } = useTenantSupabase();
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);
   const [stages, setStages] = useState<PipelineStage[]>([]);
@@ -132,8 +132,7 @@ export function DealForm({
           : null,
         notes: formData.notes || null,
         lost_reason: initialData?.lost_reason ?? null,
-        tenant_id:
-          initialData?.tenant_id ?? "00000000-0000-0000-0000-000000000001",
+        tenant_id: initialData?.tenant_id ?? tenantId!,
       });
     } finally {
       setIsSaving(false);

--- a/src/features/crm/components/FollowUpList.tsx
+++ b/src/features/crm/components/FollowUpList.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { useAuthenticatedSupabase } from "@/lib/supabase";
+import { useTenantSupabase } from "@/lib/supabase";
 import { createTask } from "@/lib/task-queries";
 import { toast } from "sonner";
 import type { FollowUp } from "../schemas";
@@ -38,10 +38,10 @@ export function FollowUpList({
   contactName,
 }: FollowUpListProps) {
   const navigate = useNavigate();
-  const { supabase } = useAuthenticatedSupabase();
+  const { supabase, tenantId } = useTenantSupabase();
 
   const handleCreateTask = async (followUp: FollowUp) => {
-    if (!supabase) return;
+    if (!supabase || !tenantId) return;
     try {
       const task = await createTask(
         {
@@ -71,7 +71,7 @@ export function FollowUpList({
           parent_task_id: null,
           created_by: "system",
           created_by_email: "system",
-          tenant_id: "00000000-0000-0000-0000-000000000001",
+          tenant_id: tenantId,
         },
         supabase,
       );

--- a/src/features/metrics/pages/DashboardPage.tsx
+++ b/src/features/metrics/pages/DashboardPage.tsx
@@ -10,7 +10,7 @@
 
 import { lazy, Suspense, useState, useCallback } from "react";
 import { useSEO } from "@/lib/seo";
-import { useAuthenticatedSupabase } from "@/lib/supabase";
+import { useTenantSupabase } from "@/lib/supabase";
 import AdminLayout from "@/components/AdminLayout";
 import { Card } from "@/components/ui/card";
 import { SourceModal, type SourceFormData } from "../components/SourceModal";
@@ -20,7 +20,7 @@ import {
   updateMetricsSource,
   deleteMetricsSource,
 } from "@/lib/metrics-queries";
-import { DEFAULT_TENANT_ID, type MetricsSource } from "@/lib/schemas";
+import type { MetricsSource } from "@/lib/schemas";
 
 // Lazy load heavy components with charts
 const MetricsDashboard = lazy(() =>
@@ -46,7 +46,7 @@ function ChartSkeleton() {
 
 export default function DashboardPage() {
   useSEO({ title: "Metrics Dashboard", noIndex: true });
-  const { supabase } = useAuthenticatedSupabase();
+  const { supabase, tenantId } = useTenantSupabase();
 
   // State for modal and detail panel
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -85,7 +85,7 @@ export default function DashboardPage() {
       if (modalMode === "create") {
         await createMetricsSource(
           {
-            tenant_id: DEFAULT_TENANT_ID,
+            tenant_id: tenantId!,
             name: data.name,
             slug: data.slug,
             source_type: data.source_type,

--- a/src/features/metrics/pages/SourcesPage.tsx
+++ b/src/features/metrics/pages/SourcesPage.tsx
@@ -9,7 +9,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useSEO } from "@/lib/seo";
-import { useAuthenticatedSupabase } from "@/lib/supabase";
+import { useTenantSupabase } from "@/lib/supabase";
 import AdminLayout from "@/components/AdminLayout";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -18,7 +18,6 @@ import { DataSourceConfig } from "../components/DataSourceConfig";
 import { SourceModal, type SourceFormData } from "../components/SourceModal";
 import { SourceDetailPanel } from "../components/SourceDetailPanel";
 import type { MetricsSource } from "../schemas";
-import { DEFAULT_TENANT_ID } from "@/lib/schemas";
 import {
   getMetricsSources,
   createMetricsSource,
@@ -28,7 +27,11 @@ import {
 
 export default function SourcesPage() {
   useSEO({ title: "Data Sources - Metrics", noIndex: true });
-  const { supabase } = useAuthenticatedSupabase();
+  const {
+    supabase,
+    tenantId,
+    isLoading: isTenantLoading,
+  } = useTenantSupabase();
 
   const [sources, setSources] = useState<MetricsSource[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -83,7 +86,7 @@ export default function SourcesPage() {
       if (modalMode === "create") {
         await createMetricsSource(
           {
-            tenant_id: DEFAULT_TENANT_ID,
+            tenant_id: tenantId!,
             name: data.name,
             slug: data.slug,
             source_type: data.source_type,
@@ -137,7 +140,7 @@ export default function SourcesPage() {
     [supabase, loadSources],
   );
 
-  if (isLoading) {
+  if (isLoading || isTenantLoading || !tenantId) {
     return (
       <AdminLayout>
         <div className="flex items-center justify-center min-h-[400px]">

--- a/src/features/news/adapters/rss-adapter.ts
+++ b/src/features/news/adapters/rss-adapter.ts
@@ -5,7 +5,7 @@
  * Handles XML parsing, field extraction, and data normalization.
  */
 
-import { type NewsArticle, DEFAULT_TENANT_ID } from "@/lib/schemas";
+import { type NewsArticle } from "@/lib/schemas";
 
 export interface RssFeedItem {
   guid?: string;
@@ -232,7 +232,7 @@ export class RssAdapter {
   convertToArticles(
     feedItems: RssFeedItem[],
     sourceId: string,
-    tenantId: string = DEFAULT_TENANT_ID,
+    tenantId: string,
   ): Omit<NewsArticle, "id" | "created_at" | "updated_at">[] {
     return feedItems.map((item) => ({
       tenant_id: tenantId,

--- a/src/features/news/pages/SourcesPage.tsx
+++ b/src/features/news/pages/SourcesPage.tsx
@@ -11,17 +11,20 @@ import { Rss, Loader2 } from "lucide-react";
 import AdminLayout from "@/components/AdminLayout";
 import { SourceManager } from "../components/SourceManager";
 import { NewsServiceSupabase } from "@/services/news";
-import { useAuthenticatedSupabase } from "@/lib/supabase";
+import { useTenantSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
 import { type NewsSource, type NewsCategory } from "../schemas";
-import { DEFAULT_TENANT_ID } from "@/lib/schemas";
 
 const newsService = new NewsServiceSupabase();
 
 export default function SourcesPage() {
   useSEO({ title: "News Sources", noIndex: true });
-  const { supabase } = useAuthenticatedSupabase();
+  const {
+    supabase,
+    tenantId,
+    isLoading: isTenantLoading,
+  } = useTenantSupabase();
 
   const [sources, setSources] = useState<NewsSource[]>([]);
   const [categories, setCategories] = useState<NewsCategory[]>([]);
@@ -66,7 +69,7 @@ export default function SourcesPage() {
           is_active: data.is_active ?? true,
           icon_url: null,
           order_index: sources.length,
-          tenant_id: DEFAULT_TENANT_ID,
+          tenant_id: tenantId!,
         },
       );
       setSources((prev) => [...prev, created]);
@@ -120,7 +123,7 @@ export default function SourcesPage() {
     }
   };
 
-  if (isLoading) {
+  if (isLoading || isTenantLoading || !tenantId) {
     return (
       <AdminLayout>
         <div className="flex items-center justify-center h-64">

--- a/src/features/tasks/components/TaskComments.tsx
+++ b/src/features/tasks/components/TaskComments.tsx
@@ -11,14 +11,14 @@ import {
   Lock,
 } from "lucide-react";
 import { format } from "date-fns";
-import { useAuthenticatedSupabase } from "@/lib/supabase";
+import { useTenantSupabase } from "@/lib/supabase";
 import {
   getTaskComments,
   createTaskComment,
   updateTaskComment,
   deleteTaskComment,
 } from "@/lib/task-queries";
-import { TaskComment, DEFAULT_TENANT_ID } from "@/lib/schemas";
+import { TaskComment } from "@/lib/schemas";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -28,7 +28,7 @@ interface TaskCommentsProps {
 
 export function TaskComments({ taskId }: TaskCommentsProps) {
   const { user } = useUser();
-  const { supabase } = useAuthenticatedSupabase();
+  const { supabase, tenantId } = useTenantSupabase();
   const [comments, setComments] = useState<TaskComment[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [newComment, setNewComment] = useState("");
@@ -59,13 +59,13 @@ export function TaskComments({ taskId }: TaskCommentsProps) {
 
   async function handleAddComment(e: React.FormEvent) {
     e.preventDefault();
-    if (!supabase || !newComment.trim()) return;
+    if (!supabase || !tenantId || !newComment.trim()) return;
 
     setIsSubmitting(true);
     try {
       const comment = await createTaskComment(
         {
-          tenant_id: DEFAULT_TENANT_ID,
+          tenant_id: tenantId,
           task_id: taskId,
           comment: newComment.trim(),
           author: user?.fullName || user?.id || "Unknown",

--- a/src/features/tasks/components/TaskReminders.tsx
+++ b/src/features/tasks/components/TaskReminders.tsx
@@ -2,13 +2,13 @@ import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { Bell, Plus, Trash2, CheckCircle2, Clock } from "lucide-react";
 import { format } from "date-fns";
-import { useAuthenticatedSupabase } from "@/lib/supabase";
+import { useTenantSupabase } from "@/lib/supabase";
 import {
   getTaskReminders,
   createTaskReminder,
   deleteTaskReminder,
 } from "@/lib/task-queries";
-import { TaskReminder, DEFAULT_TENANT_ID } from "@/lib/schemas";
+import { TaskReminder } from "@/lib/schemas";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -18,7 +18,7 @@ interface TaskRemindersProps {
 }
 
 export function TaskReminders({ taskId }: TaskRemindersProps) {
-  const { supabase } = useAuthenticatedSupabase();
+  const { supabase, tenantId } = useTenantSupabase();
   const [reminders, setReminders] = useState<TaskReminder[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -51,7 +51,7 @@ export function TaskReminders({ taskId }: TaskRemindersProps) {
 
   async function handleAddReminder(e: React.FormEvent) {
     e.preventDefault();
-    if (!supabase || !reminderDate) return;
+    if (!supabase || !tenantId || !reminderDate) return;
 
     setIsSubmitting(true);
     try {
@@ -60,7 +60,7 @@ export function TaskReminders({ taskId }: TaskRemindersProps) {
       ).toISOString();
       const reminder = await createTaskReminder(
         {
-          tenant_id: DEFAULT_TENANT_ID,
+          tenant_id: tenantId,
           task_id: taskId,
           reminder_at: reminderAt,
           reminder_type: reminderType,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,15 +1,24 @@
-import { z } from 'zod';
-import { captureException } from './sentry';
+import { z } from "zod";
+import { captureException } from "./sentry";
 
 // ============================================
 // TENANT SCHEMAS (Multi-tenant support)
 // ============================================
 
-// Default tenant ID for standalone mode
-export const DEFAULT_TENANT_ID = '00000000-0000-0000-0000-000000000001';
+/**
+ * Default tenant ID for standalone mode.
+ * @deprecated Do not use for new code — pass tenantId from useTenantSupabase() or ServiceContext instead (#297).
+ * Retained only for Zod schema .default() calls.
+ */
+export const DEFAULT_TENANT_ID = "00000000-0000-0000-0000-000000000001";
 
 // Tenant Types
-export const TenantTypeSchema = z.enum(['platform', 'organization', 'account', 'user']);
+export const TenantTypeSchema = z.enum([
+  "platform",
+  "organization",
+  "account",
+  "user",
+]);
 export type TenantType = z.infer<typeof TenantTypeSchema>;
 
 // Tenant Schema
@@ -47,7 +56,12 @@ export const AppSuiteSchema = z.object({
 export type AppSuite = z.infer<typeof AppSuiteSchema>;
 
 // Apps
-export const AppStatusSchema = z.enum(['planned', 'in_development', 'available', 'archived']);
+export const AppStatusSchema = z.enum([
+  "planned",
+  "in_development",
+  "available",
+  "archived",
+]);
 export const AppSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -76,7 +90,7 @@ export const AppWithSuiteSchema = AppSchema.extend({
 export type AppWithSuite = z.infer<typeof AppWithSuiteSchema>;
 
 // Blog Posts
-export const BlogPostStatusSchema = z.enum(['draft', 'published', 'scheduled']);
+export const BlogPostStatusSchema = z.enum(["draft", "published", "scheduled"]);
 export const BlogPostSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -110,7 +124,7 @@ export const SiteContentSchema = z.object({
 export type SiteContent = z.infer<typeof SiteContentSchema>;
 
 // Projects
-export const ProjectStatusSchema = z.enum(['draft', 'published', 'scheduled']);
+export const ProjectStatusSchema = z.enum(["draft", "published", "scheduled"]);
 export const ProjectSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -133,7 +147,13 @@ export const ProjectSchema = z.object({
 export type Project = z.infer<typeof ProjectSchema>;
 
 // Contact Links
-export const ContactIconSchema = z.enum(['email', 'linkedin', 'github', 'twitter', 'calendar']);
+export const ContactIconSchema = z.enum([
+  "email",
+  "linkedin",
+  "github",
+  "twitter",
+  "calendar",
+]);
 export const ContactLinkSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -155,8 +175,14 @@ export const WorkHistoryEntrySchema = z.object({
   title: z.string(),
   company: z.string(),
   period: z.string(),
-  highlights: z.array(z.string()).nullable().transform(v => v ?? []),
-  tech: z.array(z.string()).nullable().transform(v => v ?? []),
+  highlights: z
+    .array(z.string())
+    .nullable()
+    .transform((v) => v ?? []),
+  tech: z
+    .array(z.string())
+    .nullable()
+    .transform((v) => v ?? []),
   order_index: z.number(),
   created_at: z.string(),
   updated_at: z.string(),
@@ -178,7 +204,7 @@ export const CaseStudySchema = z.object({
 export type CaseStudy = z.infer<typeof CaseStudySchema>;
 
 // Timelines
-export const TimelineChartTypeSchema = z.enum(['growth', 'linear', 'decline']);
+export const TimelineChartTypeSchema = z.enum(["growth", "linear", "decline"]);
 export const TimelineSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -217,7 +243,7 @@ export type TimelineWithEntries = z.infer<typeof TimelineWithEntriesSchema>;
 export function parseResponse<T>(
   schema: z.ZodSchema<T>,
   data: unknown,
-  context: string
+  context: string,
 ): T {
   const result = schema.safeParse(data);
   if (!result.success) {
@@ -234,15 +260,18 @@ export function parseResponse<T>(
 export function parseArrayResponse<T>(
   schema: z.ZodSchema<T>,
   data: unknown,
-  context: string
+  context: string,
 ): T[] {
   const arraySchema = z.array(schema);
   const result = arraySchema.safeParse(data);
   if (!result.success) {
-    captureException(new Error(`Array schema validation failed for ${context}`), {
-      context,
-      errors: result.error.errors,
-    });
+    captureException(
+      new Error(`Array schema validation failed for ${context}`),
+      {
+        context,
+        errors: result.error.errors,
+      },
+    );
     throw new Error(`Invalid response format from ${context}`);
   }
   return result.data;
@@ -253,7 +282,14 @@ export function parseArrayResponse<T>(
 // ============================================
 
 // News Categories
-export const NewsCategoryColorSchema = z.enum(['blue', 'green', 'purple', 'orange', 'red', 'yellow']);
+export const NewsCategoryColorSchema = z.enum([
+  "blue",
+  "green",
+  "purple",
+  "orange",
+  "red",
+  "yellow",
+]);
 export const NewsCategorySchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -268,7 +304,7 @@ export const NewsCategorySchema = z.object({
 export type NewsCategory = z.infer<typeof NewsCategorySchema>;
 
 // News Sources
-export const NewsSourceTypeSchema = z.enum(['rss', 'api']);
+export const NewsSourceTypeSchema = z.enum(["rss", "api"]);
 export const NewsSourceSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -292,7 +328,9 @@ export type NewsSource = z.infer<typeof NewsSourceSchema>;
 export const NewsSourceWithCategorySchema = NewsSourceSchema.extend({
   category: NewsCategorySchema.nullable(),
 });
-export type NewsSourceWithCategory = z.infer<typeof NewsSourceWithCategorySchema>;
+export type NewsSourceWithCategory = z.infer<
+  typeof NewsSourceWithCategorySchema
+>;
 
 // News Articles
 export const NewsArticleSchema = z.object({
@@ -304,7 +342,7 @@ export const NewsArticleSchema = z.object({
   description: z.string().nullable(),
   content: z.string().nullable(),
   url: z.string(),
-  source_url: z.string().nullable(),  // The source's own article page (for link-blogs)
+  source_url: z.string().nullable(), // The source's own article page (for link-blogs)
   image_url: z.string().nullable(),
   author: z.string().nullable(),
   published_at: z.string().nullable(),
@@ -329,7 +367,12 @@ export const NewsArticleWithSourceSchema = NewsArticleSchema.extend({
 export type NewsArticleWithSource = z.infer<typeof NewsArticleWithSourceSchema>;
 
 // News Filters
-export const NewsFilterTypeSchema = z.enum(['include_keyword', 'exclude_keyword', 'include_topic', 'exclude_source']);
+export const NewsFilterTypeSchema = z.enum([
+  "include_keyword",
+  "exclude_keyword",
+  "include_topic",
+  "exclude_source",
+]);
 export const NewsFilterSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -342,11 +385,17 @@ export const NewsFilterSchema = z.object({
 export type NewsFilter = z.infer<typeof NewsFilterSchema>;
 
 // News Dashboard Tabs
-export const NewsDashboardTabTypeSchema = z.enum(['filter', 'category', 'source', 'saved_search', 'custom']);
+export const NewsDashboardTabTypeSchema = z.enum([
+  "filter",
+  "category",
+  "source",
+  "saved_search",
+  "custom",
+]);
 
 // Tab config schemas for different tab types
 export const TabConfigFilterSchema = z.object({
-  filter: z.enum(['all', 'unread', 'bookmarked', 'curated', 'archived']),
+  filter: z.enum(["all", "unread", "bookmarked", "curated", "archived"]),
 });
 
 export const TabConfigCategorySchema = z.object({
@@ -415,8 +464,15 @@ export type NewsStats = z.infer<typeof NewsStatsSchema>;
 // ============================================
 
 // Agent Commands (input queue)
-export const AgentCommandTypeSchema = z.enum(['chat', 'task', 'cancel']);
-export const AgentCommandStatusSchema = z.enum(['pending', 'received', 'processing', 'completed', 'failed', 'cancelled']);
+export const AgentCommandTypeSchema = z.enum(["chat", "task", "cancel"]);
+export const AgentCommandStatusSchema = z.enum([
+  "pending",
+  "received",
+  "processing",
+  "completed",
+  "failed",
+  "cancelled",
+]);
 export const AgentCommandSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -434,7 +490,15 @@ export const AgentCommandSchema = z.object({
 export type AgentCommand = z.infer<typeof AgentCommandSchema>;
 
 // Agent Responses (output stream)
-export const AgentResponseTypeSchema = z.enum(['message', 'tool_use', 'tool_result', 'progress', 'error', 'complete', 'confirmation_request']);
+export const AgentResponseTypeSchema = z.enum([
+  "message",
+  "tool_use",
+  "tool_result",
+  "progress",
+  "error",
+  "complete",
+  "confirmation_request",
+]);
 export const AgentResponseSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -452,8 +516,14 @@ export const AgentResponseSchema = z.object({
 export type AgentResponse = z.infer<typeof AgentResponseSchema>;
 
 // Agent Tasks
-export const AgentTaskTypeSchema = z.enum(['scheduled', 'triggered', 'manual']);
-export const AgentTaskStatusSchema = z.enum(['active', 'paused', 'completed', 'failed', 'disabled']);
+export const AgentTaskTypeSchema = z.enum(["scheduled", "triggered", "manual"]);
+export const AgentTaskStatusSchema = z.enum([
+  "active",
+  "paused",
+  "completed",
+  "failed",
+  "disabled",
+]);
 export const AgentTaskSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -475,7 +545,12 @@ export const AgentTaskSchema = z.object({
 export type AgentTask = z.infer<typeof AgentTaskSchema>;
 
 // Agent Task Runs
-export const AgentTaskRunStatusSchema = z.enum(['running', 'completed', 'failed', 'cancelled']);
+export const AgentTaskRunStatusSchema = z.enum([
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+]);
 export const AgentTaskRunSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -519,7 +594,12 @@ export const AgentConfigSchema = z.object({
 export type AgentConfig = z.infer<typeof AgentConfigSchema>;
 
 // Agent Confirmations
-export const AgentConfirmationStatusSchema = z.enum(['pending', 'approved', 'rejected', 'expired']);
+export const AgentConfirmationStatusSchema = z.enum([
+  "pending",
+  "approved",
+  "rejected",
+  "expired",
+]);
 export const AgentConfirmationSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -540,10 +620,18 @@ export type AgentConfirmation = z.infer<typeof AgentConfirmationSchema>;
 // ============================================
 
 // Platform Agent Types
-export const PlatformAgentTypeSchema = z.enum(['autonomous', 'supervised', 'tool']);
+export const PlatformAgentTypeSchema = z.enum([
+  "autonomous",
+  "supervised",
+  "tool",
+]);
 export type PlatformAgentType = z.infer<typeof PlatformAgentTypeSchema>;
 
-export const PlatformAgentStatusSchema = z.enum(['active', 'inactive', 'suspended']);
+export const PlatformAgentStatusSchema = z.enum([
+  "active",
+  "inactive",
+  "suspended",
+]);
 export type PlatformAgentStatus = z.infer<typeof PlatformAgentStatusSchema>;
 
 export const AgentPlatformSchema = z.object({
@@ -551,7 +639,10 @@ export const AgentPlatformSchema = z.object({
   name: z.string(),
   type: PlatformAgentTypeSchema,
   status: PlatformAgentStatusSchema,
-  capabilities: z.array(z.string()).nullable().transform(v => v ?? []),
+  capabilities: z
+    .array(z.string())
+    .nullable()
+    .transform((v) => v ?? []),
   api_key_prefix: z.string().nullable(),
   health_status: z.string().nullable(),
   rate_limit_rpm: z.number().nullable(),
@@ -563,7 +654,12 @@ export const AgentPlatformSchema = z.object({
 export type AgentPlatform = z.infer<typeof AgentPlatformSchema>;
 
 // Workflow Types
-export const WorkflowTriggerTypeSchema = z.enum(['manual', 'scheduled', 'webhook', 'event']);
+export const WorkflowTriggerTypeSchema = z.enum([
+  "manual",
+  "scheduled",
+  "webhook",
+  "event",
+]);
 export type WorkflowTriggerType = z.infer<typeof WorkflowTriggerTypeSchema>;
 
 export const WorkflowSchema = z.object({
@@ -572,7 +668,10 @@ export const WorkflowSchema = z.object({
   description: z.string().nullable(),
   trigger_type: WorkflowTriggerTypeSchema,
   trigger_config: z.record(z.unknown()).nullable(),
-  steps: z.array(z.record(z.unknown())).nullable().transform(v => v ?? []),
+  steps: z
+    .array(z.record(z.unknown()))
+    .nullable()
+    .transform((v) => v ?? []),
   is_active: z.boolean(),
   created_by: z.string().nullable(),
   created_at: z.string(),
@@ -581,7 +680,13 @@ export const WorkflowSchema = z.object({
 export type Workflow = z.infer<typeof WorkflowSchema>;
 
 // Workflow Run Types
-export const WorkflowRunStatusSchema = z.enum(['pending', 'running', 'completed', 'failed', 'cancelled']);
+export const WorkflowRunStatusSchema = z.enum([
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+]);
 export type WorkflowRunStatus = z.infer<typeof WorkflowRunStatusSchema>;
 
 export const WorkflowRunSchema = z.object({
@@ -590,7 +695,10 @@ export const WorkflowRunSchema = z.object({
   status: WorkflowRunStatusSchema,
   trigger_type: z.string().nullable(),
   trigger_data: z.record(z.unknown()).nullable(),
-  step_results: z.array(z.record(z.unknown())).nullable().transform(v => v ?? []),
+  step_results: z
+    .array(z.record(z.unknown()))
+    .nullable()
+    .transform((v) => v ?? []),
   error: z.string().nullable(),
   started_at: z.string().nullable(),
   completed_at: z.string().nullable(),
@@ -599,10 +707,17 @@ export const WorkflowRunSchema = z.object({
 export type WorkflowRun = z.infer<typeof WorkflowRunSchema>;
 
 // Integration Types
-export const IntegrationServiceTypeSchema = z.enum(['oauth2', 'api_key', 'webhook', 'custom']);
-export type IntegrationServiceType = z.infer<typeof IntegrationServiceTypeSchema>;
+export const IntegrationServiceTypeSchema = z.enum([
+  "oauth2",
+  "api_key",
+  "webhook",
+  "custom",
+]);
+export type IntegrationServiceType = z.infer<
+  typeof IntegrationServiceTypeSchema
+>;
 
-export const IntegrationStatusSchema = z.enum(['active', 'inactive', 'error']);
+export const IntegrationStatusSchema = z.enum(["active", "inactive", "error"]);
 export type IntegrationStatus = z.infer<typeof IntegrationStatusSchema>;
 
 export const IntegrationSchema = z.object({
@@ -623,14 +738,22 @@ export type Integration = z.infer<typeof IntegrationSchema>;
 export const AgentIntegrationSchema = z.object({
   agent_id: z.string().uuid(),
   integration_id: z.string().uuid(),
-  granted_scopes: z.array(z.string()).nullable().transform(v => v ?? []),
+  granted_scopes: z
+    .array(z.string())
+    .nullable()
+    .transform((v) => v ?? []),
   granted_at: z.string(),
   granted_by: z.string().nullable(),
 });
 export type AgentIntegration = z.infer<typeof AgentIntegrationSchema>;
 
 // Audit Log Entry (Phase 1 partitioned table)
-export const AuditLogActorTypeSchema = z.enum(['user', 'agent', 'system', 'scheduler']);
+export const AuditLogActorTypeSchema = z.enum([
+  "user",
+  "agent",
+  "system",
+  "scheduler",
+]);
 export type AuditLogActorType = z.infer<typeof AuditLogActorTypeSchema>;
 
 export const AuditLogEntrySchema = z.object({
@@ -665,7 +788,13 @@ export type ScheduledWorkflowRun = z.infer<typeof ScheduledWorkflowRunSchema>;
 // ============================================
 
 // Bookmarks
-export const BookmarkSourceSchema = z.enum(['twitter', 'pocket', 'raindrop', 'manual', 'other']);
+export const BookmarkSourceSchema = z.enum([
+  "twitter",
+  "pocket",
+  "raindrop",
+  "manual",
+  "other",
+]);
 export const BookmarkSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -726,10 +855,18 @@ export const BookmarkCollectionItemSchema = z.object({
   notes: z.string().nullable(),
   added_at: z.string(),
 });
-export type BookmarkCollectionItem = z.infer<typeof BookmarkCollectionItemSchema>;
+export type BookmarkCollectionItem = z.infer<
+  typeof BookmarkCollectionItemSchema
+>;
 
 // Bookmark Import Jobs
-export const BookmarkImportJobStatusSchema = z.enum(['pending', 'processing', 'completed', 'failed', 'partial']);
+export const BookmarkImportJobStatusSchema = z.enum([
+  "pending",
+  "processing",
+  "completed",
+  "failed",
+  "partial",
+]);
 export const BookmarkImportJobSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -766,8 +903,16 @@ export type BookmarkCategory = z.infer<typeof BookmarkCategorySchema>;
 // ============================================
 
 // Contact Types
-export const ContactTypeSchema = z.enum(['lead', 'prospect', 'client', 'partner', 'vendor', 'personal', 'other']);
-export const ContactStatusSchema = z.enum(['active', 'inactive', 'archived']);
+export const ContactTypeSchema = z.enum([
+  "lead",
+  "prospect",
+  "client",
+  "partner",
+  "vendor",
+  "personal",
+  "other",
+]);
+export const ContactStatusSchema = z.enum(["active", "inactive", "archived"]);
 
 // Contacts
 export const ContactSchema = z.object({
@@ -807,15 +952,21 @@ export type Contact = z.infer<typeof ContactSchema>;
 
 // Interaction Types
 export const InteractionTypeSchema = z.enum([
-  'email_sent', 'email_received',
-  'call_outbound', 'call_inbound',
-  'meeting', 'video_call',
-  'message', 'linkedin_message',
-  'note', 'task_completed',
-  'website_visit', 'form_submission',
-  'other'
+  "email_sent",
+  "email_received",
+  "call_outbound",
+  "call_inbound",
+  "meeting",
+  "video_call",
+  "message",
+  "linkedin_message",
+  "note",
+  "task_completed",
+  "website_visit",
+  "form_submission",
+  "other",
 ]);
-export const SentimentSchema = z.enum(['positive', 'neutral', 'negative']);
+export const SentimentSchema = z.enum(["positive", "neutral", "negative"]);
 
 // Interactions
 export const InteractionSchema = z.object({
@@ -829,11 +980,13 @@ export const InteractionSchema = z.object({
   outcome: z.string().nullable(),
   sentiment: SentimentSchema.nullable(),
   related_url: z.string().nullable(),
-  attachments: z.array(z.object({
-    name: z.string(),
-    url: z.string(),
-    type: z.string().optional(),
-  })),
+  attachments: z.array(
+    z.object({
+      name: z.string(),
+      url: z.string(),
+      type: z.string().optional(),
+    }),
+  ),
   occurred_at: z.string(),
   created_at: z.string(),
   created_by: z.string().nullable(),
@@ -841,9 +994,26 @@ export const InteractionSchema = z.object({
 export type Interaction = z.infer<typeof InteractionSchema>;
 
 // Follow-up Types
-export const FollowUpTypeSchema = z.enum(['reminder', 'call', 'email', 'meeting', 'task', 'review']);
-export const FollowUpStatusSchema = z.enum(['pending', 'completed', 'skipped', 'snoozed']);
-export const FollowUpPrioritySchema = z.enum(['low', 'normal', 'high', 'urgent']);
+export const FollowUpTypeSchema = z.enum([
+  "reminder",
+  "call",
+  "email",
+  "meeting",
+  "task",
+  "review",
+]);
+export const FollowUpStatusSchema = z.enum([
+  "pending",
+  "completed",
+  "skipped",
+  "snoozed",
+]);
+export const FollowUpPrioritySchema = z.enum([
+  "low",
+  "normal",
+  "high",
+  "urgent",
+]);
 
 // Follow-ups
 export const FollowUpSchema = z.object({
@@ -875,7 +1045,7 @@ export const ContactListSchema = z.object({
   name: z.string(),
   slug: z.string(),
   description: z.string().nullable(),
-  list_type: z.enum(['static', 'smart']),
+  list_type: z.enum(["static", "smart"]),
   smart_filter: z.record(z.unknown()).nullable(),
   color: z.string(),
   icon: z.string().nullable(),
@@ -913,7 +1083,7 @@ export const PipelineStageSchema = z.object({
 export type PipelineStage = z.infer<typeof PipelineStageSchema>;
 
 // Deals
-export const DealStatusSchema = z.enum(['open', 'won', 'lost']);
+export const DealStatusSchema = z.enum(["open", "won", "lost"]);
 export const DealSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -953,8 +1123,19 @@ export type CRMStats = z.infer<typeof CRMStatsSchema>;
 // ============================================
 
 // Metrics Source Types
-export const MetricsSourceTypeSchema = z.enum(['github', 'analytics', 'supabase', 'webhook', 'custom']);
-export const MetricsAuthTypeSchema = z.enum(['none', 'api_key', 'oauth', 'bearer']);
+export const MetricsSourceTypeSchema = z.enum([
+  "github",
+  "analytics",
+  "supabase",
+  "webhook",
+  "custom",
+]);
+export const MetricsAuthTypeSchema = z.enum([
+  "none",
+  "api_key",
+  "oauth",
+  "bearer",
+]);
 
 export const MetricsSourceSchema = z.object({
   id: z.string().uuid(),
@@ -982,7 +1163,12 @@ export const MetricsSourceSchema = z.object({
 export type MetricsSource = z.infer<typeof MetricsSourceSchema>;
 
 // Metrics Data Types
-export const MetricsDataTypeSchema = z.enum(['counter', 'gauge', 'histogram', 'summary']);
+export const MetricsDataTypeSchema = z.enum([
+  "counter",
+  "gauge",
+  "histogram",
+  "summary",
+]);
 
 export const MetricsDataSchema = z.object({
   id: z.string().uuid(),
@@ -1001,7 +1187,7 @@ export type MetricsData = z.infer<typeof MetricsDataSchema>;
 // Dashboard Widget Types
 export const DashboardWidgetSchema = z.object({
   id: z.string(),
-  type: z.enum(['line', 'bar', 'area', 'stat', 'table']),
+  type: z.enum(["line", "bar", "area", "stat", "table"]),
   title: z.string(),
   source_id: z.string().uuid().nullable(),
   metric_name: z.string().nullable(),
@@ -1061,13 +1247,29 @@ export type MetricsStats = z.infer<typeof MetricsStatsSchema>;
 
 // Component Types
 export const SiteBuilderComponentTypeSchema = z.enum([
-  'hero', 'features', 'testimonials', 'cta', 'text', 'image',
-  'video', 'spacer', 'divider', 'grid', 'columns', 'accordion',
-  'tabs', 'gallery', 'stats', 'team', 'pricing', 'faq', 'contact'
+  "hero",
+  "features",
+  "testimonials",
+  "cta",
+  "text",
+  "image",
+  "video",
+  "spacer",
+  "divider",
+  "grid",
+  "columns",
+  "accordion",
+  "tabs",
+  "gallery",
+  "stats",
+  "team",
+  "pricing",
+  "faq",
+  "contact",
 ]);
 
 // Page Status
-export const SiteBuilderPageStatusSchema = z.enum(['draft', 'published']);
+export const SiteBuilderPageStatusSchema = z.enum(["draft", "published"]);
 
 // Site Builder Page
 export const SiteBuilderPageSchema = z.object({
@@ -1101,7 +1303,9 @@ export const SiteBuilderPageVersionSchema = z.object({
   created_by: z.string(),
   created_at: z.string(),
 });
-export type SiteBuilderPageVersion = z.infer<typeof SiteBuilderPageVersionSchema>;
+export type SiteBuilderPageVersion = z.infer<
+  typeof SiteBuilderPageVersionSchema
+>;
 
 // Page Component
 export const SiteBuilderPageComponentSchema = z.object({
@@ -1115,7 +1319,9 @@ export const SiteBuilderPageComponentSchema = z.object({
   created_at: z.string(),
   updated_at: z.string(),
 });
-export type SiteBuilderPageComponent = z.infer<typeof SiteBuilderPageComponentSchema>;
+export type SiteBuilderPageComponent = z.infer<
+  typeof SiteBuilderPageComponentSchema
+>;
 
 // Component Template
 export const SiteBuilderComponentTemplateSchema = z.object({
@@ -1132,13 +1338,19 @@ export const SiteBuilderComponentTemplateSchema = z.object({
   created_at: z.string(),
   updated_at: z.string(),
 });
-export type SiteBuilderComponentTemplate = z.infer<typeof SiteBuilderComponentTemplateSchema>;
+export type SiteBuilderComponentTemplate = z.infer<
+  typeof SiteBuilderComponentTemplateSchema
+>;
 
 // Page with Components (for editor)
-export const SiteBuilderPageWithComponentsSchema = SiteBuilderPageSchema.extend({
-  components: z.array(SiteBuilderPageComponentSchema),
-});
-export type SiteBuilderPageWithComponents = z.infer<typeof SiteBuilderPageWithComponentsSchema>;
+export const SiteBuilderPageWithComponentsSchema = SiteBuilderPageSchema.extend(
+  {
+    components: z.array(SiteBuilderPageComponentSchema),
+  },
+);
+export type SiteBuilderPageWithComponents = z.infer<
+  typeof SiteBuilderPageWithComponentsSchema
+>;
 
 // ============================================
 // TASK SYSTEM SCHEMAS
@@ -1160,8 +1372,14 @@ export const TaskCategorySchema = z.object({
 export type TaskCategory = z.infer<typeof TaskCategorySchema>;
 
 // Tasks
-export const TaskStatusSchema = z.enum(['todo', 'in_progress', 'review', 'done', 'cancelled']);
-export const TaskPrioritySchema = z.enum(['low', 'medium', 'high', 'urgent']);
+export const TaskStatusSchema = z.enum([
+  "todo",
+  "in_progress",
+  "review",
+  "done",
+  "cancelled",
+]);
+export const TaskPrioritySchema = z.enum(["low", "medium", "high", "urgent"]);
 
 export const TaskSchema = z.object({
   id: z.string().uuid(),
@@ -1210,7 +1428,7 @@ export const TaskCommentSchema = z.object({
 export type TaskComment = z.infer<typeof TaskCommentSchema>;
 
 // Task Reminders
-export const TaskReminderTypeSchema = z.enum(['email', 'notification', 'both']);
+export const TaskReminderTypeSchema = z.enum(["email", "notification", "both"]);
 export const TaskReminderSchema = z.object({
   id: z.string().uuid(),
   tenant_id: z.string().uuid().default(DEFAULT_TENANT_ID),
@@ -1241,7 +1459,12 @@ export type TaskStats = z.infer<typeof TaskStatsSchema>;
 // ============================================
 
 // Email Subscriber Status
-export const EmailSubscriberStatusSchema = z.enum(['active', 'unsubscribed', 'bounced', 'complained']);
+export const EmailSubscriberStatusSchema = z.enum([
+  "active",
+  "unsubscribed",
+  "bounced",
+  "complained",
+]);
 
 // Email Subscribers
 export const EmailSubscriberSchema = z.object({
@@ -1289,7 +1512,14 @@ export const EmailListSchema = z.object({
 export type EmailList = z.infer<typeof EmailListSchema>;
 
 // Email Campaign Status
-export const EmailCampaignStatusSchema = z.enum(['draft', 'scheduled', 'sending', 'sent', 'paused', 'cancelled']);
+export const EmailCampaignStatusSchema = z.enum([
+  "draft",
+  "scheduled",
+  "sending",
+  "sent",
+  "paused",
+  "cancelled",
+]);
 
 // Email Campaigns
 export const EmailCampaignSchema = z.object({
@@ -1325,7 +1555,12 @@ export const EmailCampaignSchema = z.object({
 export type EmailCampaign = z.infer<typeof EmailCampaignSchema>;
 
 // Email Template Types
-export const EmailTemplateTypeSchema = z.enum(['newsletter', 'transactional', 'promotional', 'custom']);
+export const EmailTemplateTypeSchema = z.enum([
+  "newsletter",
+  "transactional",
+  "promotional",
+  "custom",
+]);
 
 // Email Templates
 export const EmailTemplateSchema = z.object({
@@ -1351,7 +1586,15 @@ export const EmailTemplateSchema = z.object({
 export type EmailTemplate = z.infer<typeof EmailTemplateSchema>;
 
 // Email Event Types
-export const EmailEventTypeSchema = z.enum(['sent', 'delivered', 'opened', 'clicked', 'bounced', 'complained', 'unsubscribed']);
+export const EmailEventTypeSchema = z.enum([
+  "sent",
+  "delivered",
+  "opened",
+  "clicked",
+  "bounced",
+  "complained",
+  "unsubscribed",
+]);
 
 // Email Events
 export const EmailEventSchema = z.object({
@@ -1374,7 +1617,12 @@ export const EmailEventSchema = z.object({
 export type EmailEvent = z.infer<typeof EmailEventSchema>;
 
 // NPS Survey Status
-export const NPSSurveyStatusSchema = z.enum(['draft', 'active', 'paused', 'closed']);
+export const NPSSurveyStatusSchema = z.enum([
+  "draft",
+  "active",
+  "paused",
+  "closed",
+]);
 
 // NPS Surveys
 export const NPSSurveySchema = z.object({
@@ -1399,7 +1647,7 @@ export const NPSSurveySchema = z.object({
 export type NPSSurvey = z.infer<typeof NPSSurveySchema>;
 
 // NPS Response Category
-export const NPSCategorySchema = z.enum(['promoter', 'passive', 'detractor']);
+export const NPSCategorySchema = z.enum(["promoter", "passive", "detractor"]);
 
 // NPS Responses
 export const NPSResponseSchema = z.object({
@@ -1420,8 +1668,19 @@ export const NPSResponseSchema = z.object({
 export type NPSResponse = z.infer<typeof NPSResponseSchema>;
 
 // Content Suggestion Types
-export const ContentSuggestionTypeSchema = z.enum(['email_subject', 'email_body', 'social_post', 'blog_title', 'landing_page_copy']);
-export const ContentSuggestionStatusSchema = z.enum(['pending', 'approved', 'rejected', 'used']);
+export const ContentSuggestionTypeSchema = z.enum([
+  "email_subject",
+  "email_body",
+  "social_post",
+  "blog_title",
+  "landing_page_copy",
+]);
+export const ContentSuggestionStatusSchema = z.enum([
+  "pending",
+  "approved",
+  "rejected",
+  "used",
+]);
 
 // Content Suggestions
 export const ContentSuggestionSchema = z.object({
@@ -1481,7 +1740,9 @@ export type AgentSkill = z.infer<typeof AgentSkillSchema>;
 export const AgentSkillWithCapabilitySchema = AgentSkillSchema.extend({
   capability_definitions: CapabilityDefinitionSchema.nullable(),
 });
-export type AgentSkillWithCapability = z.infer<typeof AgentSkillWithCapabilitySchema>;
+export type AgentSkillWithCapability = z.infer<
+  typeof AgentSkillWithCapabilitySchema
+>;
 
 // Event Types
 export const EventTypeSchema = z.object({
@@ -1496,7 +1757,11 @@ export const EventTypeSchema = z.object({
 export type EventType = z.infer<typeof EventTypeSchema>;
 
 // Event Subscriptions
-export const EventSubscriberTypeSchema = z.enum(['workflow', 'agent', 'webhook']);
+export const EventSubscriberTypeSchema = z.enum([
+  "workflow",
+  "agent",
+  "webhook",
+]);
 export type EventSubscriberType = z.infer<typeof EventSubscriberTypeSchema>;
 
 export const EventSubscriptionSchema = z.object({
@@ -1512,7 +1777,13 @@ export const EventSubscriptionSchema = z.object({
 export type EventSubscription = z.infer<typeof EventSubscriptionSchema>;
 
 // Events
-export const EventSourceTypeSchema = z.enum(['agent', 'workflow', 'system', 'webhook', 'user']);
+export const EventSourceTypeSchema = z.enum([
+  "agent",
+  "workflow",
+  "system",
+  "webhook",
+  "user",
+]);
 export type EventSourceType = z.infer<typeof EventSourceTypeSchema>;
 
 export const EventSchema = z.object({
@@ -1550,11 +1821,16 @@ export const StepTemplateSchema = z.object({
   name: z.string(),
   description: z.string().nullable(),
   category: z.string(),
-  step_type: z.enum(['agent_command', 'wait', 'condition', 'integration_action']),
+  step_type: z.enum([
+    "agent_command",
+    "wait",
+    "condition",
+    "integration_action",
+  ]),
   config: z.record(z.unknown()),
   timeout_ms: z.number(),
   retries: z.number(),
-  on_failure: z.enum(['continue', 'stop', 'skip']),
+  on_failure: z.enum(["continue", "stop", "skip"]),
   integration_action_id: z.string().uuid().nullable(),
   is_active: z.boolean(),
   created_at: z.string(),

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -6,15 +6,15 @@
  * enabling future extraction of features as standalone products.
  */
 
-import { SupabaseClient } from '@supabase/supabase-js';
-import { DEFAULT_TENANT_ID } from '@/lib/schemas';
+import { SupabaseClient } from "@supabase/supabase-js";
+import { DEFAULT_TENANT_ID } from "@/lib/schemas";
 
 /**
  * Service mode determines the underlying implementation.
  * - 'supabase': Direct Supabase client access (current)
  * - 'api': REST API access (future, for standalone apps)
  */
-export type ServiceMode = 'supabase' | 'api';
+export type ServiceMode = "supabase" | "api";
 
 /**
  * Context passed to all service operations.
@@ -61,7 +61,21 @@ export interface BaseService {
 
 /**
  * Helper to get tenant ID from context, with default fallback.
+ * @deprecated Use getTenantIdStrict() instead — default fallback bypasses tenant isolation (#297)
  */
 export function getTenantId(ctx: ServiceContext): string {
   return ctx.tenantId ?? DEFAULT_TENANT_ID;
+}
+
+/**
+ * Strict helper to get tenant ID from context.
+ * Throws if tenantId is missing — ensures callers always provide explicit tenant context.
+ */
+export function getTenantIdStrict(ctx: ServiceContext): string {
+  if (!ctx.tenantId) {
+    throw new Error(
+      "tenantId is required but was not provided in ServiceContext",
+    );
+  }
+  return ctx.tenantId;
 }

--- a/supabase/functions/provision-tenant/index.ts
+++ b/supabase/functions/provision-tenant/index.ts
@@ -1,0 +1,479 @@
+// Supabase Edge Function: Provision Tenant
+// Deploy with: supabase functions deploy provision-tenant
+// Invoke: POST /functions/v1/provision-tenant
+//
+// Provisions a new tenant atomically:
+// 1. Validate input (name, slug, plan, admin_email, branding)
+// 2. Call app.provision_tenant() RPC (atomic DB work)
+// 3. Create Clerk Organization via REST API
+// 4. Send welcome email via Resend/SendGrid
+// 5. Audit log
+//
+// Auth: x-provisioning-secret header
+//
+// Required env vars:
+//   PROVISIONING_SECRET — shared secret for endpoint auth
+//   CLERK_SECRET_KEY    — Clerk backend API key
+//   RESEND_API_KEY or SENDGRID_API_KEY — email provider
+//   EMAIL_FROM          — sender address
+//
+// Issue: #299
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+import { Logger } from "../_shared/logger.ts";
+import { validateInput, validateFields } from "../_shared/input-validator.ts";
+import { CORS_ORIGIN } from "../_shared/cors.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": CORS_ORIGIN,
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-provisioning-secret",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+/**
+ * Create a Clerk Organization via REST API.
+ * Sets publicMetadata.tenant_id so the frontend can resolve it.
+ */
+async function createClerkOrganization(
+  tenantId: string,
+  name: string,
+  slug: string,
+  adminEmail: string | null,
+  clerkSecretKey: string,
+  logger: Logger,
+): Promise<{ clerk_org_id: string } | null> {
+  try {
+    const response = await fetch("https://api.clerk.com/v1/organizations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${clerkSecretKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name,
+        slug,
+        public_metadata: { tenant_id: tenantId },
+        ...(adminEmail ? { created_by: adminEmail } : {}),
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      logger.error("Clerk organization creation failed", new Error(errorBody), {
+        status: response.status,
+      });
+      return null;
+    }
+
+    const data = await response.json();
+    logger.info("Clerk organization created", {
+      clerk_org_id: data.id,
+      tenant_id: tenantId,
+    });
+    return { clerk_org_id: data.id };
+  } catch (error) {
+    logger.error(
+      "Clerk API call failed",
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    return null;
+  }
+}
+
+/**
+ * Send a welcome email via Resend (preferred) or SendGrid.
+ */
+async function sendWelcomeEmail(
+  adminEmail: string,
+  tenantName: string,
+  slug: string,
+  logger: Logger,
+): Promise<boolean> {
+  const resendKey = Deno.env.get("RESEND_API_KEY");
+  const sendgridKey = Deno.env.get("SENDGRID_API_KEY");
+  const emailFrom = Deno.env.get("EMAIL_FROM") || "noreply@mejohnc.org";
+
+  if (!adminEmail) return true; // No email to send
+
+  const subject = `Welcome to ${tenantName}!`;
+  const htmlBody = `
+    <h1>Welcome to ${tenantName}</h1>
+    <p>Your workspace has been provisioned and is ready to use.</p>
+    <p>Workspace slug: <strong>${slug}</strong></p>
+    <p>You can sign in at your organization dashboard to get started.</p>
+  `;
+
+  try {
+    if (resendKey) {
+      const response = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${resendKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: emailFrom,
+          to: [adminEmail],
+          subject,
+          html: htmlBody,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        logger.warn("Resend email failed", {
+          status: response.status,
+          error: errorBody,
+        });
+        return false;
+      }
+
+      logger.info("Welcome email sent via Resend", { to: adminEmail });
+      return true;
+    }
+
+    if (sendgridKey) {
+      const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${sendgridKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          personalizations: [{ to: [{ email: adminEmail }] }],
+          from: { email: emailFrom },
+          subject,
+          content: [{ type: "text/html", value: htmlBody }],
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        logger.warn("SendGrid email failed", {
+          status: response.status,
+          error: errorBody,
+        });
+        return false;
+      }
+
+      logger.info("Welcome email sent via SendGrid", { to: adminEmail });
+      return true;
+    }
+
+    logger.warn(
+      "No email provider configured (RESEND_API_KEY or SENDGRID_API_KEY)",
+    );
+    return false;
+  } catch (error) {
+    logger.warn("Welcome email failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+Deno.serve(async (req) => {
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const logger = Logger.fromRequest(req);
+  logger.logRequest();
+  const start = performance.now();
+
+  try {
+    // ── Auth: verify provisioning secret ──
+    const provisioningSecret = Deno.env.get("PROVISIONING_SECRET");
+    if (!provisioningSecret) {
+      logger.error("PROVISIONING_SECRET not configured");
+      return new Response(
+        JSON.stringify({ error: "Server misconfiguration" }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const headerSecret = req.headers.get("x-provisioning-secret");
+    if (!headerSecret || headerSecret !== provisioningSecret) {
+      logger.warn("Unauthorized provisioning attempt");
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // ── Validate input ──
+    const validation = await validateInput(req, { maxBodySize: 64 * 1024 });
+    if (!validation.valid) {
+      return new Response(
+        JSON.stringify({
+          error: "Validation error",
+          message: validation.error,
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const body = validation.data as Record<string, unknown>;
+
+    const fieldError = validateFields(body, {
+      name: { required: true, type: "string", minLength: 1, maxLength: 255 },
+      slug: {
+        required: true,
+        type: "string",
+        minLength: 3,
+        maxLength: 100,
+        pattern: /^[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+      },
+      plan: { type: "string", enum: ["free", "starter", "pro", "enterprise"] },
+      admin_email: {
+        type: "string",
+        pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+      },
+      branding: { type: "object" },
+    });
+
+    if (fieldError) {
+      return new Response(
+        JSON.stringify({ error: "Validation error", message: fieldError }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const name = body.name as string;
+    const slug = body.slug as string;
+    const plan = (body.plan as string) || "free";
+    const adminEmail = (body.admin_email as string) || null;
+    const branding = (body.branding as Record<string, unknown>) || {};
+
+    // ── Supabase client ──
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    // ── Step 1: Call app.provision_tenant() RPC ──
+    const { data: provisionResult, error: provisionError } = await supabase.rpc(
+      "provision_tenant",
+      {
+        p_name: name,
+        p_slug: slug,
+        p_type: "organization",
+        p_admin_email: adminEmail,
+        p_plan: plan,
+        p_branding: branding,
+      },
+    );
+
+    if (provisionError) {
+      const isConflict = provisionError.message?.includes("already taken");
+      const status = isConflict ? 409 : 500;
+      logger.error(
+        "provision_tenant RPC failed",
+        new Error(provisionError.message),
+      );
+      return new Response(
+        JSON.stringify({
+          error: isConflict ? "Slug already taken" : "Provisioning failed",
+          message: provisionError.message,
+          correlationId: logger.getCorrelationId(),
+        }),
+        {
+          status,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const tenantId = provisionResult?.[0]?.tenant_id;
+    const tenantCreatedAt = provisionResult?.[0]?.created_at;
+
+    if (!tenantId) {
+      logger.error("provision_tenant returned no tenant_id");
+      return new Response(
+        JSON.stringify({
+          error: "Provisioning failed",
+          message: "No tenant_id returned from RPC",
+        }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    logger.info("Tenant provisioned in database", {
+      tenant_id: tenantId,
+      slug,
+    });
+
+    // ── Step 2: Create Clerk Organization ──
+    let clerkOrgId: string | null = null;
+    const clerkSecretKey = Deno.env.get("CLERK_SECRET_KEY");
+
+    if (clerkSecretKey) {
+      const clerkResult = await createClerkOrganization(
+        tenantId,
+        name,
+        slug,
+        adminEmail,
+        clerkSecretKey,
+        logger,
+      );
+
+      if (clerkResult) {
+        clerkOrgId = clerkResult.clerk_org_id;
+      } else {
+        // Mark tenant as clerk_failed so it can be retried
+        await supabase
+          .from("tenants")
+          .update({
+            settings: supabase.rpc("jsonb_set_key", {
+              target_json: null, // Unused; we use raw SQL below
+            }),
+          })
+          .eq("id", tenantId);
+
+        // Direct update to mark clerk failure in settings
+        await supabase.rpc("log_audit_event", {
+          p_actor_type: "system",
+          p_actor_id: null,
+          p_action: "tenant.clerk_failed",
+          p_resource_type: "tenant",
+          p_resource_id: tenantId,
+          p_details: { slug, name },
+        });
+
+        // Update settings to indicate clerk_failed
+        const { error: updateError } = await supabase
+          .schema("app")
+          .from("tenants")
+          .update({
+            settings: {
+              plan,
+              branding,
+              provisioning_status: "clerk_failed",
+              provisioned_at: tenantCreatedAt,
+            },
+          })
+          .eq("id", tenantId);
+
+        if (updateError) {
+          logger.warn("Failed to update tenant settings for clerk_failed", {
+            error: updateError.message,
+          });
+        }
+
+        const duration = Math.round(performance.now() - start);
+        logger.logResponse(500, duration);
+
+        return new Response(
+          JSON.stringify({
+            error: "Clerk organization creation failed",
+            tenant_id: tenantId,
+            message:
+              "Tenant was created in DB but Clerk org failed. Retry or fix manually.",
+            correlationId: logger.getCorrelationId(),
+          }),
+          {
+            status: 500,
+            headers: {
+              ...corsHeaders,
+              "Content-Type": "application/json",
+              ...logger.getResponseHeaders(),
+            },
+          },
+        );
+      }
+    } else {
+      logger.warn(
+        "CLERK_SECRET_KEY not configured — skipping Clerk org creation",
+      );
+    }
+
+    // ── Step 3: Send welcome email (non-critical) ──
+    let emailSent = false;
+    if (adminEmail) {
+      emailSent = await sendWelcomeEmail(adminEmail, name, slug, logger);
+    }
+
+    // ── Step 4: Audit log ──
+    await supabase.rpc("log_audit_event", {
+      p_actor_type: "system",
+      p_actor_id: null,
+      p_action: "tenant.provisioned",
+      p_resource_type: "tenant",
+      p_resource_id: tenantId,
+      p_details: {
+        slug,
+        name,
+        plan,
+        admin_email: adminEmail,
+        clerk_org_id: clerkOrgId,
+        email_sent: emailSent,
+      },
+    });
+
+    const duration = Math.round(performance.now() - start);
+    logger.logResponse(201, duration);
+
+    return new Response(
+      JSON.stringify({
+        tenant_id: tenantId,
+        slug,
+        name,
+        plan,
+        clerk_org_id: clerkOrgId,
+        email_sent: emailSent,
+        created_at: tenantCreatedAt,
+        correlationId: logger.getCorrelationId(),
+      }),
+      {
+        status: 201,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json",
+          ...logger.getResponseHeaders(),
+        },
+      },
+    );
+  } catch (error) {
+    const duration = Math.round(performance.now() - start);
+    logger.error(
+      "Provision tenant error",
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    logger.logResponse(500, duration);
+
+    return new Response(
+      JSON.stringify({
+        error: "Internal server error",
+        correlationId: logger.getCorrelationId(),
+      }),
+      {
+        status: 500,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json",
+          ...logger.getResponseHeaders(),
+        },
+      },
+    );
+  }
+});

--- a/supabase/migrations/20260217000001_provision_tenant_rpc.sql
+++ b/supabase/migrations/20260217000001_provision_tenant_rpc.sql
@@ -1,0 +1,104 @@
+-- =====================================================================
+-- MIGRATION: Tenant Provisioning RPC
+-- Issue: #299 - Tenant provisioning automation
+--
+-- Creates app.provision_tenant() — an atomic function that:
+-- 1. Validates slug uniqueness (raises exception if taken)
+-- 2. Inserts into app.tenants
+-- 3. Inserts admin into admin_users
+-- 4. Seeds 5 default filesystem folders (Desktop, Applications, Documents, Downloads, Trash)
+-- 5. Returns (tenant_id, created_at)
+-- =====================================================================
+
+BEGIN;
+
+-- ============================================
+-- provision_tenant RPC
+-- ============================================
+
+CREATE OR REPLACE FUNCTION app.provision_tenant(
+  p_name         TEXT,
+  p_slug         TEXT,
+  p_type         TEXT DEFAULT 'organization',
+  p_admin_email  TEXT DEFAULT NULL,
+  p_plan         TEXT DEFAULT 'free',
+  p_branding     JSONB DEFAULT '{}'::JSONB
+)
+RETURNS TABLE(tenant_id UUID, created_at TIMESTAMPTZ)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = app, public
+AS $$
+DECLARE
+  v_tenant_id UUID;
+  v_created_at TIMESTAMPTZ;
+BEGIN
+  -- 1. Validate slug uniqueness
+  IF EXISTS (SELECT 1 FROM app.tenants t WHERE t.slug = p_slug) THEN
+    RAISE EXCEPTION 'Tenant slug "%" is already taken', p_slug
+      USING ERRCODE = 'unique_violation';
+  END IF;
+
+  -- Validate inputs
+  IF p_name IS NULL OR length(trim(p_name)) = 0 THEN
+    RAISE EXCEPTION 'Tenant name is required'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF p_slug IS NULL OR length(trim(p_slug)) = 0 THEN
+    RAISE EXCEPTION 'Tenant slug is required'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF p_slug !~ '^[a-z0-9][a-z0-9-]{1,98}[a-z0-9]$' THEN
+    RAISE EXCEPTION 'Tenant slug must be lowercase alphanumeric with hyphens, 3-100 chars'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- 2. Insert tenant
+  INSERT INTO app.tenants (name, slug, type, hierarchy_path, settings, is_active)
+  VALUES (
+    trim(p_name),
+    trim(p_slug),
+    p_type,
+    trim(p_slug)::ltree,
+    jsonb_build_object(
+      'plan', p_plan,
+      'branding', p_branding,
+      'provisioning_status', 'active',
+      'provisioned_at', now()::text
+    ),
+    true
+  )
+  RETURNING id, app.tenants.created_at
+  INTO v_tenant_id, v_created_at;
+
+  -- 3. Insert admin user (if email provided)
+  IF p_admin_email IS NOT NULL AND length(trim(p_admin_email)) > 0 THEN
+    INSERT INTO public.admin_users (email, tenant_id)
+    VALUES (trim(p_admin_email), v_tenant_id)
+    ON CONFLICT (email, tenant_id) DO NOTHING;
+  END IF;
+
+  -- 4. Seed default filesystem folders
+  INSERT INTO public.desktop_filesystem (tenant_id, parent_id, name, type, icon, metadata)
+  VALUES
+    (v_tenant_id, NULL, 'Desktop',      'folder', 'monitor',        '{"system": true}'::jsonb),
+    (v_tenant_id, NULL, 'Applications', 'folder', 'grid',           '{"system": true}'::jsonb),
+    (v_tenant_id, NULL, 'Documents',    'folder', 'file-text',      '{"system": true}'::jsonb),
+    (v_tenant_id, NULL, 'Downloads',    'folder', 'download',       '{"system": true}'::jsonb),
+    (v_tenant_id, NULL, 'Trash',        'folder', 'trash-2',        '{"system": true}'::jsonb);
+
+  -- 5. Return result
+  RETURN QUERY SELECT v_tenant_id, v_created_at;
+END;
+$$;
+
+-- Grant execute to authenticated and service_role
+GRANT EXECUTE ON FUNCTION app.provision_tenant(TEXT, TEXT, TEXT, TEXT, TEXT, JSONB)
+  TO service_role;
+
+COMMENT ON FUNCTION app.provision_tenant IS
+  'Atomically provisions a new tenant with admin user and default filesystem folders. Issue #299.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- **#297**: Replace all hardcoded `DEFAULT_TENANT_ID` / inline UUID usage in 7 React components and 2 adapters with dynamic `tenantId` from `useTenantSupabase()` hook. Add `getTenantIdStrict()` helper. Deprecate `DEFAULT_TENANT_ID` constant (retained only for Zod schema defaults).
- **#299**: Add `app.provision_tenant()` SQL RPC for atomic tenant creation (validates slug, inserts tenant + admin user, seeds 5 filesystem folders). Add `provision-tenant` Edge Function with provisioning secret auth, Clerk Organization creation, welcome email, and audit logging.

## Changes
| File | Change |
|------|--------|
| `src/services/types.ts` | Add `getTenantIdStrict()`, deprecate `getTenantId()` |
| `src/lib/schemas.ts` | Deprecate `DEFAULT_TENANT_ID` with JSDoc |
| 5 React pages/components | Swap `useAuthenticatedSupabase` → `useTenantSupabase`, use dynamic `tenantId` |
| 2 CRM components | Replace inline hardcoded UUIDs with `tenantId` from hook |
| 2 news adapters | Make `tenantId` param required (remove defaults) |
| `supabase/migrations/20260217000001_provision_tenant_rpc.sql` | **New** — `app.provision_tenant()` RPC |
| `supabase/functions/provision-tenant/index.ts` | **New** — provisioning Edge Function |

## Test plan
- [x] `npm run build` passes (TypeScript compilation + eslint + prettier + typecheck)
- [x] Grep confirms `00000000-0000-0000-0000-000000000001` only remains in `schemas.ts` Zod defaults
- [ ] Manual test: POST to `provision-tenant` with valid payload → tenant created, Clerk org created
- [ ] Verify existing pages load correctly with `useTenantSupabase()` providing `tenantId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)