### PR TITLE
fix: enable Realtime and auto-create sessions for agent platform

### DIFF
--- a/supabase/migrations/20260221100001_enable_agent_realtime.sql
+++ b/supabase/migrations/20260221100001_enable_agent_realtime.sql
@@ -1,0 +1,8 @@
+-- Enable Supabase Realtime on agent tables
+-- Without this, neither the worker's Realtime subscription nor the frontend's
+-- subscription on agent_responses will fire.
+-- These were commented out in the foundation migration.
+
+ALTER PUBLICATION supabase_realtime ADD TABLE agent_commands;
+ALTER PUBLICATION supabase_realtime ADD TABLE agent_responses;
+ALTER PUBLICATION supabase_realtime ADD TABLE agent_confirmations;

--- a/supabase/migrations/20260221100002_fix_session_upsert.sql
+++ b/supabase/migrations/20260221100002_fix_session_upsert.sql
@@ -1,0 +1,19 @@
+-- Fix agent session auto-creation
+-- The frontend generates a sessionId via crypto.randomUUID() and inserts commands
+-- referencing it, but never creates an agent_sessions row first. The existing
+-- update_session_message_count trigger tries to UPDATE a session that doesn't exist,
+-- so the message_count never increments and there's no session record.
+-- Fix: Replace with an UPSERT that creates the session if missing.
+
+CREATE OR REPLACE FUNCTION update_session_message_count()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO agent_sessions (id, user_id, user_email, message_count, last_message_at)
+  VALUES (NEW.session_id, NEW.user_id, NEW.user_email, 1, now())
+  ON CONFLICT (id) DO UPDATE SET
+    message_count = agent_sessions.message_count + 1,
+    last_message_at = now(),
+    updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- Enable Supabase Realtime publication on `agent_commands`, `agent_responses`, and `agent_confirmations` tables (were commented out in foundation migration)
- Replace `update_session_message_count()` trigger with an UPSERT that auto-creates `agent_sessions` rows when the frontend inserts commands

## Context
The AI Manager frontend inserts commands and subscribes to responses via Supabase Realtime, but the Realtime publication was never enabled on the agent tables — so nothing fires. Additionally, the frontend generates a `sessionId` but never creates an `agent_sessions` row, causing the message count trigger to silently fail.

These are the two Supabase-side blockers to the server-side agent worker processing commands.

Closes #265

## Test plan
- [ ] Run `supabase db push` or apply migrations via dashboard
- [ ] Start the site-manager-agent worker (`npm start`)
- [ ] Open AI Manager → Server mode → send a message
- [ ] Verify command is picked up by worker and response appears in UI
- [ ] Verify `agent_sessions` row is auto-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)