### PR TITLE
fix: close gaps in theme injection (#303) and app filtering (#304)

### DIFF
--- a/src/lib/color-utils.ts
+++ b/src/lib/color-utils.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared color conversion utilities.
+ *
+ * Extracted from tailwind-generator.ts so tenant-theme.ts can
+ * also convert admin-stored hex values to the HSL format
+ * required by CSS custom properties.
+ *
+ * @see https://github.com/mejohnc-ft/MeJohnC.Org/issues/303
+ */
+
+/**
+ * Convert a hex color string to HSL components.
+ */
+export function hexToHSL(hex: string): { h: number; s: number; l: number } {
+  hex = hex.replace(/^#/, "");
+
+  const r = parseInt(hex.slice(0, 2), 16) / 255;
+  const g = parseInt(hex.slice(2, 4), 16) / 255;
+  const b = parseInt(hex.slice(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+    switch (max) {
+      case r:
+        h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+        break;
+      case g:
+        h = ((b - r) / d + 2) / 6;
+        break;
+      case b:
+        h = ((r - g) / d + 4) / 6;
+        break;
+    }
+  }
+
+  return {
+    h: Math.round(h * 360),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+}
+
+/**
+ * Convert a hex color to the space-separated HSL string used by
+ * shadcn/ui CSS custom properties, e.g. `"239 84% 67%"`.
+ *
+ * Non-hex values (already in HSL format) are returned unchanged.
+ */
+export function hexToHslString(value: string): string {
+  if (!value.startsWith("#")) return value;
+  const { h, s, l } = hexToHSL(value);
+  return `${h} ${s}% ${l}%`;
+}

--- a/src/lib/tailwind-generator.ts
+++ b/src/lib/tailwind-generator.ts
@@ -9,7 +9,8 @@ import type {
   TypographyToken,
   SpacingToken,
   RadiusToken,
-} from './figma-api';
+} from "./figma-api";
+import { hexToHSL } from "./color-utils";
 
 // ============================================
 // TYPES
@@ -18,7 +19,10 @@ import type {
 export interface TailwindTheme {
   colors: Record<string, string | Record<string, string>>;
   fontFamily: Record<string, string[]>;
-  fontSize: Record<string, [string, { lineHeight: string; letterSpacing?: string }]>;
+  fontSize: Record<
+    string,
+    [string, { lineHeight: string; letterSpacing?: string }]
+  >;
   spacing: Record<string, string>;
   borderRadius: Record<string, string>;
 }
@@ -40,56 +44,16 @@ export interface GeneratedConfig {
 function tokenToVariableName(name: string): string {
   return name
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-/**
- * Convert hex to HSL for CSS variables
- */
-function hexToHSL(hex: string): { h: number; s: number; l: number } {
-  // Remove # if present
-  hex = hex.replace(/^#/, '');
-
-  // Parse hex to RGB
-  const r = parseInt(hex.slice(0, 2), 16) / 255;
-  const g = parseInt(hex.slice(2, 4), 16) / 255;
-  const b = parseInt(hex.slice(4, 6), 16) / 255;
-
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  let h = 0;
-  let s = 0;
-  const l = (max + min) / 2;
-
-  if (max !== min) {
-    const d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-
-    switch (max) {
-      case r:
-        h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
-        break;
-      case g:
-        h = ((b - r) / d + 2) / 6;
-        break;
-      case b:
-        h = ((r - g) / d + 4) / 6;
-        break;
-    }
-  }
-
-  return {
-    h: Math.round(h * 360),
-    s: Math.round(s * 100),
-    l: Math.round(l * 100),
-  };
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 /**
  * Group colors by category
  */
-function groupColorsByCategory(colors: ColorToken[]): Record<string, ColorToken[]> {
+function groupColorsByCategory(
+  colors: ColorToken[],
+): Record<string, ColorToken[]> {
   return colors.reduce(
     (acc, color) => {
       if (!acc[color.category]) {
@@ -98,7 +62,7 @@ function groupColorsByCategory(colors: ColorToken[]): Record<string, ColorToken[
       acc[color.category].push(color);
       return acc;
     },
-    {} as Record<string, ColorToken[]>
+    {} as Record<string, ColorToken[]>,
   );
 }
 
@@ -109,7 +73,9 @@ function groupColorsByCategory(colors: ColorToken[]): Record<string, ColorToken[
 /**
  * Generate Tailwind colors object from tokens
  */
-function generateColors(colors: ColorToken[]): Record<string, string | Record<string, string>> {
+function generateColors(
+  colors: ColorToken[],
+): Record<string, string | Record<string, string>> {
   const grouped = groupColorsByCategory(colors);
   const result: Record<string, string | Record<string, string>> = {};
 
@@ -123,8 +89,10 @@ function generateColors(colors: ColorToken[]): Record<string, string | Record<st
       categoryColors.forEach((color) => {
         // Extract shade from name if present (e.g., "Primary 500" -> "500")
         const shadeMatch = color.name.match(/(\d+)$/);
-        const shade = shadeMatch ? shadeMatch[1] : tokenToVariableName(color.name.replace(category, ''));
-        nested[shade || 'DEFAULT'] = color.value;
+        const shade = shadeMatch
+          ? shadeMatch[1]
+          : tokenToVariableName(color.name.replace(category, ""));
+        nested[shade || "DEFAULT"] = color.value;
       });
       result[category] = nested;
     }
@@ -136,22 +104,24 @@ function generateColors(colors: ColorToken[]): Record<string, string | Record<st
 /**
  * Generate Tailwind font family from tokens
  */
-function generateFontFamily(typography: TypographyToken[]): Record<string, string[]> {
+function generateFontFamily(
+  typography: TypographyToken[],
+): Record<string, string[]> {
   const families = new Set<string>();
   typography.forEach((t) => families.add(t.fontFamily));
 
   const result: Record<string, string[]> = {};
   families.forEach((family) => {
     const key = tokenToVariableName(family);
-    result[key] = [family, 'sans-serif'];
+    result[key] = [family, "sans-serif"];
   });
 
   // Add default sans and mono
-  if (!result['sans']) {
-    result['sans'] = ['Inter', 'system-ui', 'sans-serif'];
+  if (!result["sans"]) {
+    result["sans"] = ["Inter", "system-ui", "sans-serif"];
   }
-  if (!result['mono']) {
-    result['mono'] = ['JetBrains Mono', 'Menlo', 'monospace'];
+  if (!result["mono"]) {
+    result["mono"] = ["JetBrains Mono", "Menlo", "monospace"];
   }
 
   return result;
@@ -161,14 +131,18 @@ function generateFontFamily(typography: TypographyToken[]): Record<string, strin
  * Generate Tailwind font sizes from tokens
  */
 function generateFontSizes(
-  typography: TypographyToken[]
+  typography: TypographyToken[],
 ): Record<string, [string, { lineHeight: string; letterSpacing?: string }]> {
-  const result: Record<string, [string, { lineHeight: string; letterSpacing?: string }]> = {};
+  const result: Record<
+    string,
+    [string, { lineHeight: string; letterSpacing?: string }]
+  > = {};
 
   typography.forEach((t) => {
     const key = tokenToVariableName(t.name);
     const lineHeight = (t.lineHeight / t.fontSize).toFixed(3);
-    const letterSpacing = t.letterSpacing !== 0 ? `${t.letterSpacing}px` : undefined;
+    const letterSpacing =
+      t.letterSpacing !== 0 ? `${t.letterSpacing}px` : undefined;
 
     result[key] = [
       `${t.fontSize}px`,
@@ -190,7 +164,7 @@ function generateSpacing(spacing: SpacingToken[]): Record<string, string> {
 
   spacing.forEach((s) => {
     // Use number as key for spacing
-    const key = s.name.replace('spacing-', '');
+    const key = s.name.replace("spacing-", "");
     result[key] = `${s.value}px`;
   });
 
@@ -204,7 +178,7 @@ function generateBorderRadius(radii: RadiusToken[]): Record<string, string> {
   const result: Record<string, string> = {};
 
   radii.forEach((r) => {
-    result[r.name] = r.value === 9999 ? '9999px' : `${r.value}px`;
+    result[r.name] = r.value === 9999 ? "9999px" : `${r.value}px`;
   });
 
   return result;
@@ -214,10 +188,10 @@ function generateBorderRadius(radii: RadiusToken[]): Record<string, string> {
  * Generate CSS variables from tokens
  */
 function generateCSSVariables(tokens: DesignTokens): string {
-  const lines: string[] = [':root {'];
+  const lines: string[] = [":root {"];
 
   // Colors
-  lines.push('  /* Colors */');
+  lines.push("  /* Colors */");
   tokens.colors.forEach((color) => {
     const hsl = hexToHSL(color.value);
     const varName = `--color-${tokenToVariableName(color.name)}`;
@@ -225,8 +199,8 @@ function generateCSSVariables(tokens: DesignTokens): string {
   });
 
   // Typography
-  lines.push('');
-  lines.push('  /* Typography */');
+  lines.push("");
+  lines.push("  /* Typography */");
   const families = new Set<string>();
   tokens.typography.forEach((t) => families.add(t.fontFamily));
   families.forEach((family) => {
@@ -235,24 +209,26 @@ function generateCSSVariables(tokens: DesignTokens): string {
   });
 
   // Spacing
-  lines.push('');
-  lines.push('  /* Spacing */');
+  lines.push("");
+  lines.push("  /* Spacing */");
   tokens.spacing.forEach((s) => {
-    const varName = `--spacing-${s.name.replace('spacing-', '')}`;
+    const varName = `--spacing-${s.name.replace("spacing-", "")}`;
     lines.push(`  ${varName}: ${s.value}px;`);
   });
 
   // Border Radius
-  lines.push('');
-  lines.push('  /* Border Radius */');
+  lines.push("");
+  lines.push("  /* Border Radius */");
   tokens.radii.forEach((r) => {
     const varName = `--radius-${r.name}`;
-    lines.push(`  ${varName}: ${r.value === 9999 ? '9999px' : `${r.value}px`};`);
+    lines.push(
+      `  ${varName}: ${r.value === 9999 ? "9999px" : `${r.value}px`};`,
+    );
   });
 
-  lines.push('}');
+  lines.push("}");
 
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 /**
@@ -276,52 +252,56 @@ module.exports = ${JSON.stringify(config, null, 2)}`;
  */
 function generateDocumentation(tokens: DesignTokens): string {
   const lines: string[] = [
-    '# Design Tokens',
-    '',
+    "# Design Tokens",
+    "",
     `Generated from: ${tokens.metadata.fileName}`,
     `Last updated: ${new Date(tokens.metadata.extractedAt).toLocaleString()}`,
-    '',
-    '## Colors',
-    '',
-    '| Name | Value | Category |',
-    '|------|-------|----------|',
+    "",
+    "## Colors",
+    "",
+    "| Name | Value | Category |",
+    "|------|-------|----------|",
   ];
 
   tokens.colors.forEach((c) => {
     lines.push(`| ${c.name} | \`${c.value}\` | ${c.category} |`);
   });
 
-  lines.push('');
-  lines.push('## Typography');
-  lines.push('');
-  lines.push('| Name | Font | Size | Weight | Line Height |');
-  lines.push('|------|------|------|--------|-------------|');
+  lines.push("");
+  lines.push("## Typography");
+  lines.push("");
+  lines.push("| Name | Font | Size | Weight | Line Height |");
+  lines.push("|------|------|------|--------|-------------|");
 
   tokens.typography.forEach((t) => {
-    lines.push(`| ${t.name} | ${t.fontFamily} | ${t.fontSize}px | ${t.fontWeight} | ${t.lineHeight.toFixed(1)}px |`);
+    lines.push(
+      `| ${t.name} | ${t.fontFamily} | ${t.fontSize}px | ${t.fontWeight} | ${t.lineHeight.toFixed(1)}px |`,
+    );
   });
 
-  lines.push('');
-  lines.push('## Spacing');
-  lines.push('');
-  lines.push('| Name | Value |');
-  lines.push('|------|-------|');
+  lines.push("");
+  lines.push("## Spacing");
+  lines.push("");
+  lines.push("| Name | Value |");
+  lines.push("|------|-------|");
 
   tokens.spacing.forEach((s) => {
     lines.push(`| ${s.name} | ${s.value}px |`);
   });
 
-  lines.push('');
-  lines.push('## Border Radius');
-  lines.push('');
-  lines.push('| Name | Value |');
-  lines.push('|------|-------|');
+  lines.push("");
+  lines.push("## Border Radius");
+  lines.push("");
+  lines.push("| Name | Value |");
+  lines.push("|------|-------|");
 
   tokens.radii.forEach((r) => {
-    lines.push(`| ${r.name} | ${r.value === 9999 ? '9999px' : `${r.value}px`} |`);
+    lines.push(
+      `| ${r.name} | ${r.value === 9999 ? "9999px" : `${r.value}px`} |`,
+    );
   });
 
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 // ============================================
@@ -358,74 +338,217 @@ export function generateDefaultTokens(): DesignTokens {
   return {
     colors: [
       // Primary palette - Centrex Green
-      { name: 'Centrex Primary (Green)', value: '#3dae2b', rgba: { r: 61, g: 174, b: 43, a: 1 }, category: 'primary' },
-      { name: 'Centrex Primary Light', value: '#4ade80', rgba: { r: 74, g: 222, b: 128, a: 1 }, category: 'primary' },
+      {
+        name: "Centrex Primary (Green)",
+        value: "#3dae2b",
+        rgba: { r: 61, g: 174, b: 43, a: 1 },
+        category: "primary",
+      },
+      {
+        name: "Centrex Primary Light",
+        value: "#4ade80",
+        rgba: { r: 74, g: 222, b: 128, a: 1 },
+        category: "primary",
+      },
       // Secondary palette - Centrex Blue
-      { name: 'Centrex Secondary (Blue)', value: '#0071ce', rgba: { r: 0, g: 113, b: 206, a: 1 }, category: 'secondary' },
-      { name: 'Centrex Secondary Light', value: '#3b82f6', rgba: { r: 59, g: 130, b: 246, a: 1 }, category: 'secondary' },
+      {
+        name: "Centrex Secondary (Blue)",
+        value: "#0071ce",
+        rgba: { r: 0, g: 113, b: 206, a: 1 },
+        category: "secondary",
+      },
+      {
+        name: "Centrex Secondary Light",
+        value: "#3b82f6",
+        rgba: { r: 59, g: 130, b: 246, a: 1 },
+        category: "secondary",
+      },
       // Accent - Centrex Orange
-      { name: 'Centrex Tertiary (Orange)', value: '#ff8300', rgba: { r: 255, g: 131, b: 0, a: 1 }, category: 'accent' },
-      { name: 'Centrex Tertiary Light', value: '#fb923c', rgba: { r: 251, g: 146, b: 60, a: 1 }, category: 'accent' },
+      {
+        name: "Centrex Tertiary (Orange)",
+        value: "#ff8300",
+        rgba: { r: 255, g: 131, b: 0, a: 1 },
+        category: "accent",
+      },
+      {
+        name: "Centrex Tertiary Light",
+        value: "#fb923c",
+        rgba: { r: 251, g: 146, b: 60, a: 1 },
+        category: "accent",
+      },
       // Semantic - Centrex Red
-      { name: 'Centrex Accent (Red)', value: '#e1251b', rgba: { r: 225, g: 37, b: 27, a: 1 }, category: 'semantic' },
-      { name: 'Centrex Accent Light', value: '#f87171', rgba: { r: 248, g: 113, b: 113, a: 1 }, category: 'semantic' },
+      {
+        name: "Centrex Accent (Red)",
+        value: "#e1251b",
+        rgba: { r: 225, g: 37, b: 27, a: 1 },
+        category: "semantic",
+      },
+      {
+        name: "Centrex Accent Light",
+        value: "#f87171",
+        rgba: { r: 248, g: 113, b: 113, a: 1 },
+        category: "semantic",
+      },
       // Backgrounds (Dark theme)
-      { name: 'Background Body', value: '#050505', rgba: { r: 5, g: 5, b: 5, a: 1 }, category: 'background' },
-      { name: 'Background Card', value: '#121212', rgba: { r: 18, g: 18, b: 18, a: 1 }, category: 'background' },
-      { name: 'Background Panel', value: '#1a1a1a', rgba: { r: 26, g: 26, b: 26, a: 1 }, category: 'background' },
-      { name: 'Background Input', value: '#262626', rgba: { r: 38, g: 38, b: 38, a: 1 }, category: 'background' },
+      {
+        name: "Background Body",
+        value: "#050505",
+        rgba: { r: 5, g: 5, b: 5, a: 1 },
+        category: "background",
+      },
+      {
+        name: "Background Card",
+        value: "#121212",
+        rgba: { r: 18, g: 18, b: 18, a: 1 },
+        category: "background",
+      },
+      {
+        name: "Background Panel",
+        value: "#1a1a1a",
+        rgba: { r: 26, g: 26, b: 26, a: 1 },
+        category: "background",
+      },
+      {
+        name: "Background Input",
+        value: "#262626",
+        rgba: { r: 38, g: 38, b: 38, a: 1 },
+        category: "background",
+      },
       // Foreground/Text
-      { name: 'Text Primary', value: '#e5e5e5', rgba: { r: 229, g: 229, b: 229, a: 1 }, category: 'foreground' },
-      { name: 'Text Secondary', value: '#a3a3a3', rgba: { r: 163, g: 163, b: 163, a: 1 }, category: 'foreground' },
-      { name: 'Text Muted', value: '#525252', rgba: { r: 82, g: 82, b: 82, a: 1 }, category: 'foreground' },
+      {
+        name: "Text Primary",
+        value: "#e5e5e5",
+        rgba: { r: 229, g: 229, b: 229, a: 1 },
+        category: "foreground",
+      },
+      {
+        name: "Text Secondary",
+        value: "#a3a3a3",
+        rgba: { r: 163, g: 163, b: 163, a: 1 },
+        category: "foreground",
+      },
+      {
+        name: "Text Muted",
+        value: "#525252",
+        rgba: { r: 82, g: 82, b: 82, a: 1 },
+        category: "foreground",
+      },
       // Border
-      { name: 'Border', value: '#262626', rgba: { r: 38, g: 38, b: 38, a: 1 }, category: 'border' },
+      {
+        name: "Border",
+        value: "#262626",
+        rgba: { r: 38, g: 38, b: 38, a: 1 },
+        category: "border",
+      },
     ],
     typography: [
-      { name: 'Display', fontFamily: 'GilmerBold', fontSize: 72, fontWeight: 700, lineHeight: 80, letterSpacing: -1 },
-      { name: 'Heading 1', fontFamily: 'GilmerBold', fontSize: 48, fontWeight: 700, lineHeight: 56, letterSpacing: -0.5 },
-      { name: 'Heading 2', fontFamily: 'GilmerBold', fontSize: 36, fontWeight: 700, lineHeight: 44, letterSpacing: -0.25 },
-      { name: 'Heading 3', fontFamily: 'GilmerBold', fontSize: 24, fontWeight: 600, lineHeight: 32, letterSpacing: 0 },
-      { name: 'Body Large', fontFamily: 'Hind', fontSize: 20, fontWeight: 400, lineHeight: 28, letterSpacing: 0 },
-      { name: 'Body', fontFamily: 'Hind', fontSize: 16, fontWeight: 400, lineHeight: 24, letterSpacing: 0 },
-      { name: 'Body Small', fontFamily: 'Hind', fontSize: 14, fontWeight: 400, lineHeight: 20, letterSpacing: 0 },
-      { name: 'Caption', fontFamily: 'Hind', fontSize: 12, fontWeight: 400, lineHeight: 16, letterSpacing: 0.25 },
-      { name: 'Code', fontFamily: 'Consolas', fontSize: 14, fontWeight: 400, lineHeight: 20, letterSpacing: 0 },
+      {
+        name: "Display",
+        fontFamily: "GilmerBold",
+        fontSize: 72,
+        fontWeight: 700,
+        lineHeight: 80,
+        letterSpacing: -1,
+      },
+      {
+        name: "Heading 1",
+        fontFamily: "GilmerBold",
+        fontSize: 48,
+        fontWeight: 700,
+        lineHeight: 56,
+        letterSpacing: -0.5,
+      },
+      {
+        name: "Heading 2",
+        fontFamily: "GilmerBold",
+        fontSize: 36,
+        fontWeight: 700,
+        lineHeight: 44,
+        letterSpacing: -0.25,
+      },
+      {
+        name: "Heading 3",
+        fontFamily: "GilmerBold",
+        fontSize: 24,
+        fontWeight: 600,
+        lineHeight: 32,
+        letterSpacing: 0,
+      },
+      {
+        name: "Body Large",
+        fontFamily: "Hind",
+        fontSize: 20,
+        fontWeight: 400,
+        lineHeight: 28,
+        letterSpacing: 0,
+      },
+      {
+        name: "Body",
+        fontFamily: "Hind",
+        fontSize: 16,
+        fontWeight: 400,
+        lineHeight: 24,
+        letterSpacing: 0,
+      },
+      {
+        name: "Body Small",
+        fontFamily: "Hind",
+        fontSize: 14,
+        fontWeight: 400,
+        lineHeight: 20,
+        letterSpacing: 0,
+      },
+      {
+        name: "Caption",
+        fontFamily: "Hind",
+        fontSize: 12,
+        fontWeight: 400,
+        lineHeight: 16,
+        letterSpacing: 0.25,
+      },
+      {
+        name: "Code",
+        fontFamily: "Consolas",
+        fontSize: 14,
+        fontWeight: 400,
+        lineHeight: 20,
+        letterSpacing: 0,
+      },
     ],
     spacing: [
-      { name: 'spacing-0', value: 0, unit: 'px' },
-      { name: 'spacing-1', value: 4, unit: 'px' },
-      { name: 'spacing-2', value: 8, unit: 'px' },
-      { name: 'spacing-3', value: 12, unit: 'px' },
-      { name: 'spacing-4', value: 16, unit: 'px' },
-      { name: 'spacing-5', value: 20, unit: 'px' },
-      { name: 'spacing-6', value: 24, unit: 'px' },
-      { name: 'spacing-8', value: 32, unit: 'px' },
-      { name: 'spacing-9', value: 36, unit: 'px' },
-      { name: 'spacing-10', value: 40, unit: 'px' },
-      { name: 'spacing-12', value: 48, unit: 'px' },
-      { name: 'spacing-16', value: 64, unit: 'px' },
+      { name: "spacing-0", value: 0, unit: "px" },
+      { name: "spacing-1", value: 4, unit: "px" },
+      { name: "spacing-2", value: 8, unit: "px" },
+      { name: "spacing-3", value: 12, unit: "px" },
+      { name: "spacing-4", value: 16, unit: "px" },
+      { name: "spacing-5", value: 20, unit: "px" },
+      { name: "spacing-6", value: 24, unit: "px" },
+      { name: "spacing-8", value: 32, unit: "px" },
+      { name: "spacing-9", value: 36, unit: "px" },
+      { name: "spacing-10", value: 40, unit: "px" },
+      { name: "spacing-12", value: 48, unit: "px" },
+      { name: "spacing-16", value: 64, unit: "px" },
     ],
     shadows: [
-      { name: 'Natural', value: '6px 6px 9px rgba(0, 0, 0, 0.2)' },
-      { name: 'Deep', value: '12px 12px 50px rgba(0, 0, 0, 0.4)' },
-      { name: 'Crisp', value: '6px 6px 0px rgba(0, 0, 0, 1)' },
-      { name: 'Card', value: '0 20px 50px -12px rgba(0, 0, 0, 0.9)' },
-      { name: 'Primary Glow', value: '0 4px 12px rgba(61, 174, 43, 0.3)' },
+      { name: "Natural", value: "6px 6px 9px rgba(0, 0, 0, 0.2)" },
+      { name: "Deep", value: "12px 12px 50px rgba(0, 0, 0, 0.4)" },
+      { name: "Crisp", value: "6px 6px 0px rgba(0, 0, 0, 1)" },
+      { name: "Card", value: "0 20px 50px -12px rgba(0, 0, 0, 0.9)" },
+      { name: "Primary Glow", value: "0 4px 12px rgba(61, 174, 43, 0.3)" },
     ],
     radii: [
-      { name: 'none', value: 0, unit: 'px' },
-      { name: 'sm', value: 4, unit: 'px' },
-      { name: 'md', value: 8, unit: 'px' },
-      { name: 'lg', value: 12, unit: 'px' },
-      { name: 'xl', value: 16, unit: 'px' },
-      { name: '2xl', value: 20, unit: 'px' },
-      { name: 'full', value: 9999, unit: 'px' },
+      { name: "none", value: 0, unit: "px" },
+      { name: "sm", value: 4, unit: "px" },
+      { name: "md", value: 8, unit: "px" },
+      { name: "lg", value: 12, unit: "px" },
+      { name: "xl", value: 16, unit: "px" },
+      { name: "2xl", value: 20, unit: "px" },
+      { name: "full", value: 9999, unit: "px" },
     ],
     metadata: {
-      source: 'custom',
-      fileKey: 'centrexstyle',
-      fileName: 'CentrexStyle Design System',
+      source: "custom",
+      fileKey: "centrexstyle",
+      fileName: "CentrexStyle Design System",
       lastModified: new Date().toISOString(),
       extractedAt: new Date().toISOString(),
     },

--- a/src/lib/tenant-theme.ts
+++ b/src/lib/tenant-theme.ts
@@ -8,6 +8,8 @@
  * @see https://github.com/mejohnc-ft/MeJohnC.Org/issues/303
  */
 
+import { hexToHslString } from "./color-utils";
+
 export interface TenantBranding {
   /** Display name for the tenant (used in document title, etc.) */
   name?: string;
@@ -37,20 +39,28 @@ export interface TenantBranding {
 export function applyTenantTheme(branding: TenantBranding): void {
   const root = document.documentElement;
 
-  // Color overrides (HSL values without the hsl() wrapper)
+  // Color overrides (HSL values without the hsl() wrapper).
+  // Admin may store hex (#6366f1) — convert to HSL space-separated format.
   if (branding.primary_color) {
-    root.style.setProperty("--primary", branding.primary_color);
-    root.style.setProperty("--accent", branding.primary_color);
-    root.style.setProperty("--ring", branding.primary_color);
+    const hsl = hexToHslString(branding.primary_color);
+    root.style.setProperty("--primary", hsl);
+    root.style.setProperty("--accent", hsl);
+    root.style.setProperty("--ring", hsl);
   }
   if (branding.accent_color) {
-    root.style.setProperty("--accent", branding.accent_color);
+    root.style.setProperty("--accent", hexToHslString(branding.accent_color));
   }
   if (branding.background_color) {
-    root.style.setProperty("--background", branding.background_color);
+    root.style.setProperty(
+      "--background",
+      hexToHslString(branding.background_color),
+    );
   }
   if (branding.foreground_color) {
-    root.style.setProperty("--foreground", branding.foreground_color);
+    root.style.setProperty(
+      "--foreground",
+      hexToHslString(branding.foreground_color),
+    );
   }
   if (branding.border_radius) {
     root.style.setProperty("--radius", branding.border_radius);


### PR DESCRIPTION
## Summary

Closes three end-to-end gaps that prevented #303 (Theme Injection) and #304 (App Filtering) from working correctly:

- **Hex-to-HSL conversion:** Admin stores hex colors (`#6366f1`) but CSS custom properties need HSL (`239 84% 67%`). Extracted `hexToHSL` into shared `color-utils.ts` and convert in `applyTenantTheme()` before injecting — non-hex values pass through unchanged.
- **WindowManager launch permission:** `launchApp()` now calls `isAppLocked()` before creating a window, showing a toast and blocking apps outside the tenant's plan/whitelist.
- **Workspace restoration filtering:** `deserializeWindows()` now filters out locked apps alongside unregistered apps, so downgraded tenants don't get stale windows restored on refresh.

## Test plan

- [ ] Set tenant `primary_color` to `#e11d48` in admin → inspect `:root` → `--primary` should be `347 77% 50%`
- [ ] On Starter plan, try launching a Business-tier app from desktop icon → toast + blocked
- [ ] On Business plan, open a Business app → downgrade to Starter → refresh → window should not restore
- [ ] Verify existing HSL values (e.g. `25 95% 53%`) still pass through unchanged
- [ ] TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)