### PR TITLE
feat: enable org-membership RBAC for multi-tenant auth

### DIFF
--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -37,7 +37,7 @@ import {
   Calendar,
 } from "lucide-react";
 import { useAuth } from "@/lib/auth";
-import { UserButton } from "@clerk/clerk-react";
+import { UserButton, OrganizationSwitcher } from "@clerk/clerk-react";
 import { Button } from "@/components/ui/button";
 import { ThemeToggleMinimal } from "./ThemeToggle";
 import AdminSearch from "./admin/AdminSearch";
@@ -323,6 +323,20 @@ const SidebarContent = ({
 
     {/* Footer */}
     <div className="px-3 py-3 border-t border-border space-y-1 flex-shrink-0">
+      {/* Organization Switcher */}
+      <div className="px-4 py-2">
+        <OrganizationSwitcher
+          hidePersonal={true}
+          appearance={{
+            elements: {
+              rootBox: "w-full",
+              organizationSwitcherTrigger:
+                "w-full justify-between text-sm text-muted-foreground hover:text-foreground",
+            },
+          }}
+        />
+      </div>
+
       {/* User info with Clerk UserButton */}
       <div className="flex items-center gap-3 px-4 py-2">
         <UserButton
@@ -333,7 +347,7 @@ const SidebarContent = ({
           }}
         />
         <span className="text-xs text-muted-foreground truncate whitespace-nowrap">
-          {user?.primaryEmailAddress?.emailAddress}
+          {user?.email}
         </span>
       </div>
 

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -4,8 +4,8 @@
  * Provides hooks to check permissions in React components
  */
 
-import { useUser } from '@clerk/clerk-react';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback } from "react";
+import { useAuth } from "../lib/auth";
 import {
   Role,
   Resource,
@@ -16,16 +16,16 @@ import {
   checkPermission,
   PermissionCheckResult,
   ROLE_DEFINITIONS,
-} from '../lib/rbac';
+} from "../lib/rbac";
 
 /**
  * Hook to get the current user's role
  */
 export function useRole(): Role {
-  const { user, isLoaded } = useUser();
+  const { user, isLoaded } = useAuth();
 
   return useMemo(() => {
-    if (!isLoaded) return 'guest';
+    if (!isLoaded) return "guest";
     return getUserRole(user);
   }, [user, isLoaded]);
 }
@@ -35,20 +35,26 @@ export function useRole(): Role {
  */
 export function usePermission(resource: Resource, action: Action): boolean {
   const role = useRole();
-  return useMemo(() => hasPermission(role, resource, action), [role, resource, action]);
+  return useMemo(
+    () => hasPermission(role, resource, action),
+    [role, resource, action],
+  );
 }
 
 /**
  * Hook to check multiple permissions at once
  */
 export function usePermissions(
-  checks: Array<{ resource: Resource; action: Action }>
+  checks: Array<{ resource: Resource; action: Action }>,
 ): boolean[] {
   const role = useRole();
 
   return useMemo(
-    () => checks.map(({ resource, action }) => hasPermission(role, resource, action)),
-    [role, checks]
+    () =>
+      checks.map(({ resource, action }) =>
+        hasPermission(role, resource, action),
+      ),
+    [role, checks],
   );
 }
 
@@ -62,7 +68,7 @@ export function usePermissionChecker() {
     (resource: Resource, action: Action): PermissionCheckResult => {
       return checkPermission(role, resource, action);
     },
-    [role]
+    [role],
   );
 }
 
@@ -85,7 +91,7 @@ export function useRoleInfo() {
     return {
       role,
       displayName: definition?.displayName || role,
-      description: definition?.description || '',
+      description: definition?.description || "",
       permissions: definition?.permissions || [],
     };
   }, [role]);
@@ -96,42 +102,42 @@ export function useRoleInfo() {
  */
 export function useIsAdmin(): boolean {
   const role = useRole();
-  return role === 'admin';
+  return role === "admin";
 }
 
 /**
  * Hook for checking if user can edit content
  */
 export function useCanEdit(resource: Resource): boolean {
-  return usePermission(resource, 'update');
+  return usePermission(resource, "update");
 }
 
 /**
  * Hook for checking if user can delete content
  */
 export function useCanDelete(resource: Resource): boolean {
-  return usePermission(resource, 'delete');
+  return usePermission(resource, "delete");
 }
 
 /**
  * Hook for checking if user can create content
  */
 export function useCanCreate(resource: Resource): boolean {
-  return usePermission(resource, 'create');
+  return usePermission(resource, "create");
 }
 
 /**
  * Hook for checking if user can publish content
  */
 export function useCanPublish(resource: Resource): boolean {
-  return usePermission(resource, 'publish');
+  return usePermission(resource, "publish");
 }
 
 /**
  * Hook for checking if user can manage a resource
  */
 export function useCanManage(resource: Resource): boolean {
-  return usePermission(resource, 'manage');
+  return usePermission(resource, "manage");
 }
 
 /**
@@ -142,13 +148,13 @@ export function useResourcePermissions(resource: Resource) {
 
   return useMemo(
     () => ({
-      canCreate: hasPermission(role, resource, 'create'),
-      canRead: hasPermission(role, resource, 'read'),
-      canUpdate: hasPermission(role, resource, 'update'),
-      canDelete: hasPermission(role, resource, 'delete'),
-      canPublish: hasPermission(role, resource, 'publish'),
-      canManage: hasPermission(role, resource, 'manage'),
+      canCreate: hasPermission(role, resource, "create"),
+      canRead: hasPermission(role, resource, "read"),
+      canUpdate: hasPermission(role, resource, "update"),
+      canDelete: hasPermission(role, resource, "delete"),
+      canPublish: hasPermission(role, resource, "publish"),
+      canManage: hasPermission(role, resource, "manage"),
     }),
-    [role, resource]
+    [role, resource],
   );
 }

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -10,12 +10,12 @@
  * @see https://github.com/mejohnc-ft/MeJohnC.Org/issues/104
  */
 
-import type { ReactNode } from 'react';
+import type { ReactNode } from "react";
 
 /**
  * Authentication modes supported by the app
  */
-export type AuthMode = 'clerk' | 'platform' | 'disabled';
+export type AuthMode = "clerk" | "platform" | "disabled";
 
 /**
  * User information normalized across all auth adapters
@@ -28,6 +28,7 @@ export interface AuthUser {
   fullName: string | null;
   imageUrl: string | null;
   metadata?: Record<string, unknown>;
+  orgRole?: string | null;
 }
 
 /**

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -11,31 +11,37 @@
 /**
  * Available roles in the system
  */
-export type Role = 'admin' | 'editor' | 'author' | 'viewer' | 'guest';
+export type Role = "admin" | "editor" | "author" | "viewer" | "guest";
 
 /**
  * Resources that can be protected
  */
 export type Resource =
-  | 'apps'
-  | 'projects'
-  | 'blog_posts'
-  | 'site_content'
-  | 'contacts'
-  | 'bookmarks'
-  | 'news'
-  | 'metrics'
-  | 'tasks'
-  | 'marketing'
-  | 'site_builder'
-  | 'users'
-  | 'settings'
-  | 'audit_logs';
+  | "apps"
+  | "projects"
+  | "blog_posts"
+  | "site_content"
+  | "contacts"
+  | "bookmarks"
+  | "news"
+  | "metrics"
+  | "tasks"
+  | "marketing"
+  | "site_builder"
+  | "users"
+  | "settings"
+  | "audit_logs";
 
 /**
  * Actions that can be performed on resources
  */
-export type Action = 'create' | 'read' | 'update' | 'delete' | 'publish' | 'manage';
+export type Action =
+  | "create"
+  | "read"
+  | "update"
+  | "delete"
+  | "publish"
+  | "manage";
 
 /**
  * Permission definition
@@ -61,87 +67,135 @@ export interface RoleDefinition {
  */
 export const ROLE_DEFINITIONS: Record<Role, RoleDefinition> = {
   admin: {
-    name: 'admin',
-    displayName: 'Administrator',
-    description: 'Full access to all resources and settings',
+    name: "admin",
+    displayName: "Administrator",
+    description: "Full access to all resources and settings",
     permissions: [
-      { resource: 'apps', actions: ['create', 'read', 'update', 'delete', 'publish', 'manage'] },
-      { resource: 'projects', actions: ['create', 'read', 'update', 'delete', 'publish', 'manage'] },
-      { resource: 'blog_posts', actions: ['create', 'read', 'update', 'delete', 'publish', 'manage'] },
-      { resource: 'site_content', actions: ['create', 'read', 'update', 'delete', 'publish', 'manage'] },
-      { resource: 'contacts', actions: ['create', 'read', 'update', 'delete', 'manage'] },
-      { resource: 'bookmarks', actions: ['create', 'read', 'update', 'delete', 'manage'] },
-      { resource: 'news', actions: ['create', 'read', 'update', 'delete', 'manage'] },
-      { resource: 'metrics', actions: ['read', 'manage'] },
-      { resource: 'tasks', actions: ['create', 'read', 'update', 'delete', 'manage'] },
-      { resource: 'marketing', actions: ['create', 'read', 'update', 'delete', 'publish', 'manage'] },
-      { resource: 'site_builder', actions: ['create', 'read', 'update', 'delete', 'publish', 'manage'] },
-      { resource: 'users', actions: ['create', 'read', 'update', 'delete', 'manage'] },
-      { resource: 'settings', actions: ['read', 'update', 'manage'] },
-      { resource: 'audit_logs', actions: ['read'] },
+      {
+        resource: "apps",
+        actions: ["create", "read", "update", "delete", "publish", "manage"],
+      },
+      {
+        resource: "projects",
+        actions: ["create", "read", "update", "delete", "publish", "manage"],
+      },
+      {
+        resource: "blog_posts",
+        actions: ["create", "read", "update", "delete", "publish", "manage"],
+      },
+      {
+        resource: "site_content",
+        actions: ["create", "read", "update", "delete", "publish", "manage"],
+      },
+      {
+        resource: "contacts",
+        actions: ["create", "read", "update", "delete", "manage"],
+      },
+      {
+        resource: "bookmarks",
+        actions: ["create", "read", "update", "delete", "manage"],
+      },
+      {
+        resource: "news",
+        actions: ["create", "read", "update", "delete", "manage"],
+      },
+      { resource: "metrics", actions: ["read", "manage"] },
+      {
+        resource: "tasks",
+        actions: ["create", "read", "update", "delete", "manage"],
+      },
+      {
+        resource: "marketing",
+        actions: ["create", "read", "update", "delete", "publish", "manage"],
+      },
+      {
+        resource: "site_builder",
+        actions: ["create", "read", "update", "delete", "publish", "manage"],
+      },
+      {
+        resource: "users",
+        actions: ["create", "read", "update", "delete", "manage"],
+      },
+      { resource: "settings", actions: ["read", "update", "manage"] },
+      { resource: "audit_logs", actions: ["read"] },
     ],
   },
 
   editor: {
-    name: 'editor',
-    displayName: 'Editor',
-    description: 'Can edit and publish content',
+    name: "editor",
+    displayName: "Editor",
+    description: "Can edit and publish content",
     permissions: [
-      { resource: 'apps', actions: ['create', 'read', 'update', 'publish'] },
-      { resource: 'projects', actions: ['create', 'read', 'update', 'publish'] },
-      { resource: 'blog_posts', actions: ['create', 'read', 'update', 'publish'] },
-      { resource: 'site_content', actions: ['read', 'update', 'publish'] },
-      { resource: 'contacts', actions: ['create', 'read', 'update'] },
-      { resource: 'bookmarks', actions: ['create', 'read', 'update', 'delete'] },
-      { resource: 'news', actions: ['create', 'read', 'update'] },
-      { resource: 'metrics', actions: ['read'] },
-      { resource: 'tasks', actions: ['create', 'read', 'update'] },
-      { resource: 'marketing', actions: ['create', 'read', 'update', 'publish'] },
-      { resource: 'site_builder', actions: ['create', 'read', 'update', 'publish'] },
+      { resource: "apps", actions: ["create", "read", "update", "publish"] },
+      {
+        resource: "projects",
+        actions: ["create", "read", "update", "publish"],
+      },
+      {
+        resource: "blog_posts",
+        actions: ["create", "read", "update", "publish"],
+      },
+      { resource: "site_content", actions: ["read", "update", "publish"] },
+      { resource: "contacts", actions: ["create", "read", "update"] },
+      {
+        resource: "bookmarks",
+        actions: ["create", "read", "update", "delete"],
+      },
+      { resource: "news", actions: ["create", "read", "update"] },
+      { resource: "metrics", actions: ["read"] },
+      { resource: "tasks", actions: ["create", "read", "update"] },
+      {
+        resource: "marketing",
+        actions: ["create", "read", "update", "publish"],
+      },
+      {
+        resource: "site_builder",
+        actions: ["create", "read", "update", "publish"],
+      },
     ],
   },
 
   author: {
-    name: 'author',
-    displayName: 'Author',
-    description: 'Can create and edit own content',
+    name: "author",
+    displayName: "Author",
+    description: "Can create and edit own content",
     permissions: [
-      { resource: 'apps', actions: ['create', 'read', 'update'] },
-      { resource: 'projects', actions: ['create', 'read', 'update'] },
-      { resource: 'blog_posts', actions: ['create', 'read', 'update'] },
-      { resource: 'site_content', actions: ['read'] },
-      { resource: 'contacts', actions: ['read'] },
-      { resource: 'bookmarks', actions: ['create', 'read', 'update'] },
-      { resource: 'news', actions: ['read'] },
-      { resource: 'tasks', actions: ['create', 'read', 'update'] },
+      { resource: "apps", actions: ["create", "read", "update"] },
+      { resource: "projects", actions: ["create", "read", "update"] },
+      { resource: "blog_posts", actions: ["create", "read", "update"] },
+      { resource: "site_content", actions: ["read"] },
+      { resource: "contacts", actions: ["read"] },
+      { resource: "bookmarks", actions: ["create", "read", "update"] },
+      { resource: "news", actions: ["read"] },
+      { resource: "tasks", actions: ["create", "read", "update"] },
     ],
   },
 
   viewer: {
-    name: 'viewer',
-    displayName: 'Viewer',
-    description: 'Read-only access to content',
+    name: "viewer",
+    displayName: "Viewer",
+    description: "Read-only access to content",
     permissions: [
-      { resource: 'apps', actions: ['read'] },
-      { resource: 'projects', actions: ['read'] },
-      { resource: 'blog_posts', actions: ['read'] },
-      { resource: 'site_content', actions: ['read'] },
-      { resource: 'bookmarks', actions: ['read'] },
-      { resource: 'news', actions: ['read'] },
-      { resource: 'metrics', actions: ['read'] },
-      { resource: 'tasks', actions: ['read'] },
+      { resource: "apps", actions: ["read"] },
+      { resource: "projects", actions: ["read"] },
+      { resource: "blog_posts", actions: ["read"] },
+      { resource: "site_content", actions: ["read"] },
+      { resource: "bookmarks", actions: ["read"] },
+      { resource: "news", actions: ["read"] },
+      { resource: "metrics", actions: ["read"] },
+      { resource: "tasks", actions: ["read"] },
     ],
   },
 
   guest: {
-    name: 'guest',
-    displayName: 'Guest',
-    description: 'Limited public access',
+    name: "guest",
+    displayName: "Guest",
+    description: "Limited public access",
     permissions: [
-      { resource: 'apps', actions: ['read'] },
-      { resource: 'projects', actions: ['read'] },
-      { resource: 'blog_posts', actions: ['read'] },
-      { resource: 'site_content', actions: ['read'] },
+      { resource: "apps", actions: ["read"] },
+      { resource: "projects", actions: ["read"] },
+      { resource: "blog_posts", actions: ["read"] },
+      { resource: "site_content", actions: ["read"] },
     ],
   },
 };
@@ -152,7 +206,7 @@ export const ROLE_DEFINITIONS: Record<Role, RoleDefinition> = {
 export function hasPermission(
   role: Role | Role[],
   resource: Resource,
-  action: Action
+  action: Action,
 ): boolean {
   const roles = Array.isArray(role) ? role : [role];
 
@@ -160,7 +214,9 @@ export function hasPermission(
     const definition = ROLE_DEFINITIONS[r];
     if (!definition) continue;
 
-    const resourcePermission = definition.permissions.find((p) => p.resource === resource);
+    const resourcePermission = definition.permissions.find(
+      (p) => p.resource === resource,
+    );
     if (resourcePermission?.actions.includes(action)) {
       return true;
     }
@@ -199,21 +255,24 @@ export function getRolePermissions(role: Role): Permission[] {
  * Check if a role can access a specific admin route
  */
 export function canAccessRoute(role: Role | Role[], route: string): boolean {
-  const routePermissions: Record<string, { resource: Resource; action: Action }> = {
-    '/admin': { resource: 'site_content', action: 'read' },
-    '/admin/apps': { resource: 'apps', action: 'read' },
-    '/admin/projects': { resource: 'projects', action: 'read' },
-    '/admin/blog': { resource: 'blog_posts', action: 'read' },
-    '/admin/contacts': { resource: 'contacts', action: 'read' },
-    '/admin/bookmarks': { resource: 'bookmarks', action: 'read' },
-    '/admin/news': { resource: 'news', action: 'read' },
-    '/admin/metrics': { resource: 'metrics', action: 'read' },
-    '/admin/tasks': { resource: 'tasks', action: 'read' },
-    '/admin/marketing': { resource: 'marketing', action: 'read' },
-    '/admin/site-builder': { resource: 'site_builder', action: 'read' },
-    '/admin/users': { resource: 'users', action: 'read' },
-    '/admin/settings': { resource: 'settings', action: 'read' },
-    '/admin/audit': { resource: 'audit_logs', action: 'read' },
+  const routePermissions: Record<
+    string,
+    { resource: Resource; action: Action }
+  > = {
+    "/admin": { resource: "site_content", action: "read" },
+    "/admin/apps": { resource: "apps", action: "read" },
+    "/admin/projects": { resource: "projects", action: "read" },
+    "/admin/blog": { resource: "blog_posts", action: "read" },
+    "/admin/contacts": { resource: "contacts", action: "read" },
+    "/admin/bookmarks": { resource: "bookmarks", action: "read" },
+    "/admin/news": { resource: "news", action: "read" },
+    "/admin/metrics": { resource: "metrics", action: "read" },
+    "/admin/tasks": { resource: "tasks", action: "read" },
+    "/admin/marketing": { resource: "marketing", action: "read" },
+    "/admin/site-builder": { resource: "site_builder", action: "read" },
+    "/admin/users": { resource: "users", action: "read" },
+    "/admin/settings": { resource: "settings", action: "read" },
+    "/admin/audit": { resource: "audit_logs", action: "read" },
   };
 
   // Find matching route (handles nested routes)
@@ -228,7 +287,7 @@ export function canAccessRoute(role: Role | Role[], route: string): boolean {
 
   if (!matchedRoute) {
     // Unknown route - default to allowing authenticated users
-    return role !== 'guest';
+    return role !== "guest";
   }
 
   const { resource, action } = routePermissions[matchedRoute];
@@ -236,18 +295,49 @@ export function canAccessRoute(role: Role | Role[], route: string): boolean {
 }
 
 /**
- * Get user's role from Clerk metadata
+ * Map Clerk organization role keys to app roles
  */
-export function getUserRole(user: { publicMetadata?: { role?: string } } | null): Role {
-  if (!user) return 'guest';
+const CLERK_ORG_ROLE_MAP: Record<string, Role> = {
+  "org:admin": "admin",
+  "org:editor": "editor",
+  "org:author": "author",
+  "org:viewer": "viewer",
+  "org:member": "viewer",
+};
 
-  const role = user.publicMetadata?.role as Role;
-  if (role && ROLE_DEFINITIONS[role]) {
-    return role;
+/**
+ * Get user's role from org membership (preferred) or Clerk metadata (fallback)
+ *
+ * Resolution priority:
+ * 1. orgRole (mapped from Clerk org membership) — per-org permissions
+ * 2. publicMetadata.role / metadata.role — legacy single-org fallback
+ * 3. 'viewer' default for authenticated users
+ */
+export function getUserRole(
+  user: {
+    publicMetadata?: { role?: string };
+    metadata?: Record<string, unknown>;
+    orgRole?: string | null;
+  } | null,
+): Role {
+  if (!user) return "guest";
+
+  // 1. Org membership role (multi-tenant)
+  if (user.orgRole) {
+    const mapped = CLERK_ORG_ROLE_MAP[user.orgRole];
+    if (mapped) return mapped;
   }
 
-  // Default authenticated users to viewer
-  return 'viewer';
+  // 2. Legacy metadata role (single-org fallback)
+  const metaRole = (user.publicMetadata?.role ?? user.metadata?.role) as
+    | Role
+    | undefined;
+  if (metaRole && ROLE_DEFINITIONS[metaRole]) {
+    return metaRole;
+  }
+
+  // 3. Default authenticated users to viewer
+  return "viewer";
 }
 
 /**
@@ -264,14 +354,16 @@ export interface PermissionCheckResult {
 export function checkPermission(
   role: Role | Role[],
   resource: Resource,
-  action: Action
+  action: Action,
 ): PermissionCheckResult {
   if (hasPermission(role, resource, action)) {
     return { allowed: true };
   }
 
   const roles = Array.isArray(role) ? role : [role];
-  const roleNames = roles.map((r) => ROLE_DEFINITIONS[r]?.displayName || r).join(', ');
+  const roleNames = roles
+    .map((r) => ROLE_DEFINITIONS[r]?.displayName || r)
+    .join(", ");
 
   return {
     allowed: false,
@@ -290,11 +382,11 @@ export function createPermissionGuard(resource: Resource, action: Action) {
 
 // Pre-built permission guards for common checks
 export const guards = {
-  canManageUsers: createPermissionGuard('users', 'manage'),
-  canManageSettings: createPermissionGuard('settings', 'manage'),
-  canPublishContent: createPermissionGuard('blog_posts', 'publish'),
-  canViewMetrics: createPermissionGuard('metrics', 'read'),
-  canManageMarketing: createPermissionGuard('marketing', 'manage'),
-  canEditSiteBuilder: createPermissionGuard('site_builder', 'update'),
-  canViewAuditLogs: createPermissionGuard('audit_logs', 'read'),
+  canManageUsers: createPermissionGuard("users", "manage"),
+  canManageSettings: createPermissionGuard("settings", "manage"),
+  canPublishContent: createPermissionGuard("blog_posts", "publish"),
+  canViewMetrics: createPermissionGuard("metrics", "read"),
+  canManageMarketing: createPermissionGuard("marketing", "manage"),
+  canEditSiteBuilder: createPermissionGuard("site_builder", "update"),
+  canViewAuditLogs: createPermissionGuard("audit_logs", "read"),
 };


### PR DESCRIPTION
## Summary
- Moves role resolution from user-level `publicMetadata.role` to Clerk Organization membership roles, so permissions are scoped per-org
- Adds `OrganizationSwitcher` to admin sidebar so users can switch between organizations
- Updates tenant provisioning to automatically add the admin user as `org:admin` member when creating a new org

## Changes (6 files)
| File | Change |
|------|--------|
| `src/lib/auth/types.ts` | Add `orgRole` field to `AuthUser` interface |
| `src/lib/auth/clerk-adapter.tsx` | Read `useOrganization().membership.role` and pass to `AuthUser` |
| `src/lib/rbac.ts` | Add `CLERK_ORG_ROLE_MAP` + update `getUserRole()` for org-first resolution |
| `src/hooks/usePermissions.ts` | Switch `useRole()` from raw `useUser` to auth adapter's `useAuth` |
| `src/components/AdminLayout.tsx` | Add `OrganizationSwitcher` to sidebar footer, fix email accessor |
| `supabase/functions/provision-tenant/index.ts` | Add `lookupClerkUserByEmail` + `addOrgMembership` helpers |

## Backwards Compatibility
- Users with no org + `publicMetadata.role: 'admin'` still resolve as admin (legacy fallback)
- `orgRole` is optional — other auth adapters (disabled, platform) are unaffected

## Manual Prerequisite
In **Clerk Dashboard > Organizations > Roles**, create custom roles: `org:editor`, `org:author`, `org:viewer` (`org:admin` and `org:member` already exist as defaults)

## Test plan
- [ ] `npm run typecheck && npm run build` passes
- [ ] User with no org + `publicMetadata.role: 'admin'` still gets admin permissions
- [ ] User in org with `org:editor` membership sees editor-level permissions
- [ ] Switching orgs via `OrganizationSwitcher` updates permissions in real-time
- [ ] New tenant provisioning creates org + adds admin as `org:admin` member

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)