### PR TITLE
feat: agent-executor with Claude tool-use, fix workflow fire-and-forget

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1718,6 +1718,21 @@ export type MarketingStats = z.infer<typeof MarketingStatsSchema>;
 // AGENT PLATFORM PHASE 4 SCHEMAS
 // ============================================
 
+// Tool Definitions (maps Claude tools to capabilities and actions)
+export const ToolDefinitionSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  display_name: z.string(),
+  description: z.string(),
+  capability_name: z.string(),
+  input_schema: z.record(z.unknown()),
+  action_name: z.string(),
+  is_active: z.boolean(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
+
 // Capability Definitions
 export const CapabilityDefinitionSchema = z.object({
   name: z.string(),

--- a/supabase/functions/_shared/claude-client.ts
+++ b/supabase/functions/_shared/claude-client.ts
@@ -1,0 +1,173 @@
+/**
+ * Claude API Client for Supabase Edge Functions
+ *
+ * Wraps Anthropic Messages API with tool-use support for the agent-executor.
+ * Sends requests to the Claude API, parses content blocks (text + tool_use),
+ * and returns structured responses.
+ *
+ * Usage:
+ *   import { callClaude, ClaudeTool } from '../_shared/claude-client.ts'
+ *
+ *   const response = await callClaude({
+ *     messages: [{ role: 'user', content: 'Hello' }],
+ *     tools: [{ name: 'search', description: '...', input_schema: {...} }],
+ *   })
+ */
+
+const CLAUDE_API_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+const DEFAULT_MODEL = "claude-sonnet-4-5-20250929";
+const DEFAULT_MAX_TOKENS = 4096;
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export interface ClaudeMessage {
+  role: "user" | "assistant";
+  content: string | ClaudeContentBlock[];
+}
+
+export interface ClaudeTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+export interface ClaudeTextBlock {
+  type: "text";
+  text: string;
+}
+
+export interface ClaudeToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface ClaudeToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+  is_error?: boolean;
+}
+
+export type ClaudeContentBlock =
+  | ClaudeTextBlock
+  | ClaudeToolUseBlock
+  | ClaudeToolResultBlock;
+
+export interface ClaudeResponse {
+  id: string;
+  role: "assistant";
+  content: ClaudeContentBlock[];
+  stop_reason: "end_turn" | "tool_use" | "max_tokens" | "stop_sequence";
+  model: string;
+  usage: { input_tokens: number; output_tokens: number };
+}
+
+export interface CallClaudeOptions {
+  messages: ClaudeMessage[];
+  tools?: ClaudeTool[];
+  model?: string;
+  max_tokens?: number;
+  system?: string;
+}
+
+export class ClaudeApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public responseBody?: unknown,
+  ) {
+    super(message);
+    this.name = "ClaudeApiError";
+  }
+}
+
+// ─── Client ─────────────────────────────────────────────────────────
+
+/**
+ * Call the Claude Messages API.
+ *
+ * Reads ANTHROPIC_API_KEY from environment. Supports tools[] for tool-use flows.
+ * Returns parsed response with content blocks.
+ */
+export async function callClaude(
+  options: CallClaudeOptions,
+): Promise<ClaudeResponse> {
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    throw new ClaudeApiError("ANTHROPIC_API_KEY not configured", 500);
+  }
+
+  const body: Record<string, unknown> = {
+    model: options.model || DEFAULT_MODEL,
+    max_tokens: options.max_tokens || DEFAULT_MAX_TOKENS,
+    messages: options.messages,
+  };
+
+  if (options.system) {
+    body.system = options.system;
+  }
+
+  if (options.tools && options.tools.length > 0) {
+    body.tools = options.tools;
+  }
+
+  const response = await fetch(CLAUDE_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": ANTHROPIC_VERSION,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    let errorBody: unknown;
+    try {
+      errorBody = await response.json();
+    } catch {
+      errorBody = await response.text();
+    }
+    throw new ClaudeApiError(
+      `Claude API error: ${response.status} ${response.statusText}`,
+      response.status,
+      errorBody,
+    );
+  }
+
+  const data = await response.json();
+  return data as ClaudeResponse;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Extract all text content from a Claude response.
+ */
+export function extractText(response: ClaudeResponse): string {
+  return response.content
+    .filter((block): block is ClaudeTextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+}
+
+/**
+ * Extract all tool_use blocks from a Claude response.
+ */
+export function extractToolUses(
+  response: ClaudeResponse,
+): ClaudeToolUseBlock[] {
+  return response.content.filter(
+    (block): block is ClaudeToolUseBlock => block.type === "tool_use",
+  );
+}
+
+/**
+ * Check if Claude wants to use tools (stop_reason === 'tool_use').
+ */
+export function wantsToolUse(response: ClaudeResponse): boolean {
+  return response.stop_reason === "tool_use";
+}

--- a/supabase/functions/_shared/command-polling.ts
+++ b/supabase/functions/_shared/command-polling.ts
@@ -1,0 +1,99 @@
+/**
+ * Command Polling Utility for Supabase Edge Functions
+ *
+ * Polls the `agent_commands` table until a command reaches a terminal state.
+ * Used by workflow-executor to wait for integration_action steps to complete
+ * instead of fire-and-forget dispatch.
+ *
+ * Usage:
+ *   import { pollCommandCompletion } from '../_shared/command-polling.ts'
+ *
+ *   const result = await pollCommandCompletion(commandId, 10000, supabase, logger)
+ *   if (result.status === 'completed') { ... }
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+import { Logger } from "./logger.ts";
+
+const POLL_INTERVAL_MS = 500;
+const MAX_TIMEOUT_MS = 24000; // 1s buffer for edge function 25s limit
+
+const TERMINAL_STATES = new Set(["completed", "failed", "cancelled"]);
+
+export interface PollResult {
+  status: "completed" | "failed" | "cancelled" | "timeout";
+  output?: unknown;
+  error?: string;
+}
+
+/**
+ * Poll an agent_commands row until it reaches a terminal status.
+ *
+ * @param commandId - UUID of the agent_commands row to watch
+ * @param timeoutMs - Maximum time to poll (capped at 24s)
+ * @param supabase  - Service-role Supabase client
+ * @param logger    - Logger instance for structured logging
+ */
+export async function pollCommandCompletion(
+  commandId: string,
+  timeoutMs: number,
+  supabase: ReturnType<typeof createClient>,
+  logger: Logger,
+): Promise<PollResult> {
+  const effectiveTimeout = Math.min(timeoutMs, MAX_TIMEOUT_MS);
+  const deadline = Date.now() + effectiveTimeout;
+
+  logger.info("Polling command completion", {
+    commandId,
+    timeoutMs: effectiveTimeout,
+  });
+
+  while (Date.now() < deadline) {
+    const { data, error } = await supabase
+      .from("agent_commands")
+      .select("status, metadata")
+      .eq("id", commandId)
+      .single();
+
+    if (error) {
+      logger.error("Poll query failed", error as unknown as Error, {
+        commandId,
+      });
+      return { status: "failed", error: `Poll query error: ${error.message}` };
+    }
+
+    if (!data) {
+      return { status: "failed", error: "Command not found" };
+    }
+
+    if (TERMINAL_STATES.has(data.status)) {
+      logger.info("Command reached terminal state", {
+        commandId,
+        status: data.status,
+      });
+      const meta = data.metadata as Record<string, unknown> | null;
+      if (data.status === "completed") {
+        return { status: "completed", output: meta?.result ?? null };
+      }
+      if (data.status === "cancelled") {
+        return { status: "cancelled", error: "Command was cancelled" };
+      }
+      return {
+        status: "failed",
+        error: (meta?.error as string) ?? "Command failed",
+      };
+    }
+
+    // Wait before next poll
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  logger.warn("Command polling timed out", {
+    commandId,
+    timeoutMs: effectiveTimeout,
+  });
+  return {
+    status: "timeout",
+    error: `Polling timed out after ${effectiveTimeout}ms`,
+  };
+}

--- a/supabase/functions/agent-executor/index.ts
+++ b/supabase/functions/agent-executor/index.ts
@@ -1,0 +1,533 @@
+// Supabase Edge Function for agent command execution with Claude tool-use
+// Deploy with: supabase functions deploy agent-executor
+// Invoke: POST /functions/v1/agent-executor
+//
+// Executes agent commands by running a Claude conversation loop with
+// capability-gated tools. Supports both agent-key and scheduler-secret auth.
+//
+// Issues: #266 (fire-and-forget fix), #268 (skill execution)
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+import { authenticateAgent, AgentProfile } from "../_shared/agent-auth.ts";
+import { Logger } from "../_shared/logger.ts";
+import { validateInput, validateFields } from "../_shared/input-validator.ts";
+import { canPerformAction } from "../_shared/capabilities.ts";
+import { CORS_ORIGIN } from "../_shared/cors.ts";
+import {
+  callClaude,
+  extractText,
+  extractToolUses,
+  wantsToolUse,
+  ClaudeMessage,
+  ClaudeTool,
+  ClaudeContentBlock,
+  ClaudeToolResultBlock,
+} from "../_shared/claude-client.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": CORS_ORIGIN,
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-agent-key, x-scheduler-secret",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const MAX_TURNS = 5;
+const EXECUTION_TIMEOUT_MS = 24000; // 1s buffer for 25s edge function limit
+
+interface ToolDefinitionRow {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+  action_name: string;
+}
+
+// ─── Auth ───────────────────────────────────────────────────────────
+
+async function authenticateRequest(
+  req: Request,
+  supabase: ReturnType<typeof createClient>,
+  logger: Logger,
+): Promise<{
+  authorized: boolean;
+  agentId: string | null;
+  capabilities: string[];
+  error?: string;
+  status?: number;
+}> {
+  // Scheduler secret auth (for workflow-executor dispatch)
+  const schedulerSecret = req.headers.get("x-scheduler-secret");
+  if (schedulerSecret) {
+    const expectedSecret = Deno.env.get("SCHEDULER_SECRET");
+    if (!expectedSecret) {
+      return {
+        authorized: false,
+        agentId: null,
+        capabilities: [],
+        error: "Scheduler not configured",
+        status: 500,
+      };
+    }
+    if (schedulerSecret !== expectedSecret) {
+      return {
+        authorized: false,
+        agentId: null,
+        capabilities: [],
+        error: "Invalid scheduler secret",
+        status: 401,
+      };
+    }
+    // Scheduler-dispatched requests carry agent_id in the body; capabilities loaded later
+    return { authorized: true, agentId: null, capabilities: [] };
+  }
+
+  // Agent API key auth
+  const auth = await authenticateAgent(req, supabase, logger);
+  if (!auth.authenticated) {
+    return {
+      authorized: false,
+      agentId: null,
+      capabilities: [],
+      error: auth.error,
+      status: auth.status,
+    };
+  }
+
+  return {
+    authorized: true,
+    agentId: auth.agent!.id,
+    capabilities: auth.agent!.capabilities,
+  };
+}
+
+// ─── Tool Loading ───────────────────────────────────────────────────
+
+async function loadToolsForCapabilities(
+  capabilities: string[],
+  supabase: ReturnType<typeof createClient>,
+  logger: Logger,
+): Promise<{ tools: ClaudeTool[]; toolActionMap: Map<string, string> }> {
+  const { data, error } = await supabase
+    .from("tool_definitions")
+    .select("name, description, input_schema, action_name")
+    .in("capability_name", capabilities)
+    .eq("is_active", true);
+
+  if (error) {
+    logger.error("Failed to load tool definitions", error as unknown as Error);
+    return { tools: [], toolActionMap: new Map() };
+  }
+
+  const rows = (data || []) as ToolDefinitionRow[];
+  const toolActionMap = new Map<string, string>();
+  const tools: ClaudeTool[] = rows.map((row) => {
+    toolActionMap.set(row.name, row.action_name);
+    return {
+      name: row.name,
+      description: row.description,
+      input_schema: row.input_schema,
+    };
+  });
+
+  logger.info("Loaded tools for agent", { count: tools.length, capabilities });
+  return { tools, toolActionMap };
+}
+
+// ─── Tool Execution ─────────────────────────────────────────────────
+
+async function executeTool(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  actionName: string,
+  agentId: string,
+  supabase: ReturnType<typeof createClient>,
+  logger: Logger,
+): Promise<{ result: string; isError: boolean }> {
+  logger.info("Executing tool", { toolName, actionName, agentId });
+
+  try {
+    // Dispatch to API gateway via internal Supabase function call
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+    const response = await fetch(`${supabaseUrl}/functions/v1/api-gateway`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${supabaseServiceKey}`,
+        "x-scheduler-secret": Deno.env.get("SCHEDULER_SECRET") || "",
+      },
+      body: JSON.stringify({
+        action: actionName,
+        agent_id: agentId,
+        parameters: toolInput,
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      logger.warn("Tool execution failed", {
+        toolName,
+        actionName,
+        status: response.status,
+        error: data.error,
+      });
+      return {
+        result: JSON.stringify({ error: data.error || "Action failed" }),
+        isError: true,
+      };
+    }
+
+    return { result: JSON.stringify(data), isError: false };
+  } catch (error) {
+    logger.error("Tool execution error", error as Error, {
+      toolName,
+      actionName,
+    });
+    return {
+      result: JSON.stringify({ error: (error as Error).message }),
+      isError: true,
+    };
+  }
+}
+
+// ─── Agent Execution Loop ───────────────────────────────────────────
+
+async function runAgentLoop(
+  command: string,
+  agentId: string,
+  capabilities: string[],
+  supabase: ReturnType<typeof createClient>,
+  logger: Logger,
+): Promise<{ response: string; toolCalls: number; turns: number }> {
+  const startTime = Date.now();
+
+  // Load tools gated by agent's capabilities
+  const { tools, toolActionMap } = await loadToolsForCapabilities(
+    capabilities,
+    supabase,
+    logger,
+  );
+
+  const systemPrompt = [
+    "You are an AI agent executing a command on behalf of a user.",
+    "Use the provided tools to accomplish the task.",
+    "Be concise and action-oriented.",
+    "If you cannot complete the task with available tools, explain what is missing.",
+  ].join(" ");
+
+  const messages: ClaudeMessage[] = [{ role: "user", content: command }];
+
+  let totalToolCalls = 0;
+
+  for (let turn = 0; turn < MAX_TURNS; turn++) {
+    // Check timeout
+    if (Date.now() - startTime > EXECUTION_TIMEOUT_MS) {
+      logger.warn("Agent execution timed out", { turn, totalToolCalls });
+      return {
+        response: "Execution timed out before completing the task.",
+        toolCalls: totalToolCalls,
+        turns: turn,
+      };
+    }
+
+    const claudeResponse = await callClaude({
+      messages,
+      tools: tools.length > 0 ? tools : undefined,
+      system: systemPrompt,
+    });
+
+    // If Claude responded with text only (no tool use), we're done
+    if (!wantsToolUse(claudeResponse)) {
+      const finalText = extractText(claudeResponse);
+      return {
+        response: finalText,
+        toolCalls: totalToolCalls,
+        turns: turn + 1,
+      };
+    }
+
+    // Claude wants to use tools — process each tool_use block
+    const toolUses = extractToolUses(claudeResponse);
+    totalToolCalls += toolUses.length;
+
+    // Append Claude's response (with tool_use blocks) to conversation
+    messages.push({
+      role: "assistant",
+      content: claudeResponse.content,
+    });
+
+    // Execute tools and collect results
+    const toolResults: ClaudeContentBlock[] = [];
+    for (const toolUse of toolUses) {
+      const actionName = toolActionMap.get(toolUse.name);
+      if (!actionName) {
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: toolUse.id,
+          content: JSON.stringify({ error: `Unknown tool: ${toolUse.name}` }),
+          is_error: true,
+        } as ClaudeToolResultBlock);
+        continue;
+      }
+
+      // Verify capability access
+      if (!canPerformAction(capabilities, actionName)) {
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: toolUse.id,
+          content: JSON.stringify({
+            error: `Insufficient capability for action: ${actionName}`,
+          }),
+          is_error: true,
+        } as ClaudeToolResultBlock);
+        continue;
+      }
+
+      const { result, isError } = await executeTool(
+        toolUse.name,
+        toolUse.input,
+        actionName,
+        agentId,
+        supabase,
+        logger,
+      );
+
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: toolUse.id,
+        content: result,
+        is_error: isError,
+      } as ClaudeToolResultBlock);
+    }
+
+    // Append tool results as a user message
+    messages.push({
+      role: "user",
+      content: toolResults,
+    });
+  }
+
+  // Exhausted turns
+  logger.warn("Agent exhausted max turns", { totalToolCalls });
+  return {
+    response: "Reached maximum conversation turns without completing the task.",
+    toolCalls: totalToolCalls,
+    turns: MAX_TURNS,
+  };
+}
+
+// ─── Main Handler ───────────────────────────────────────────────────
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const logger = Logger.fromRequest(req);
+  logger.logRequest();
+  const start = performance.now();
+
+  try {
+    const validation = await validateInput(req);
+    if (!validation.valid) {
+      return new Response(
+        JSON.stringify({
+          error: "Validation error",
+          message: validation.error,
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const body = validation.data as Record<string, unknown>;
+    const fieldError = validateFields(body, {
+      command: { required: true, type: "string", minLength: 1 },
+    });
+    if (fieldError) {
+      return new Response(
+        JSON.stringify({ error: "Validation error", message: fieldError }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const {
+      command,
+      agent_id: bodyAgentId,
+      command_id: commandId,
+    } = body as {
+      command: string;
+      agent_id?: string;
+      command_id?: string;
+    };
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Authenticate
+    const authResult = await authenticateRequest(req, supabase, logger);
+    if (!authResult.authorized) {
+      const duration = Math.round(performance.now() - start);
+      logger.logResponse(authResult.status || 401, duration);
+      return new Response(JSON.stringify({ error: authResult.error }), {
+        status: authResult.status || 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // Determine agent ID (from auth or body for scheduler-dispatched requests)
+    const agentId = authResult.agentId || (bodyAgentId as string) || null;
+    let capabilities = authResult.capabilities;
+
+    // If scheduler-dispatched, load capabilities from agent_skills
+    if (!authResult.agentId && agentId) {
+      const { data: skills } = await supabase
+        .from("agent_skills")
+        .select("capability_name")
+        .eq("agent_id", agentId);
+
+      capabilities = (skills || []).map(
+        (s: { capability_name: string }) => s.capability_name,
+      );
+    }
+
+    if (!agentId) {
+      return new Response(JSON.stringify({ error: "agent_id is required" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // Update command status to processing (if command_id provided)
+    if (commandId) {
+      await supabase
+        .from("agent_commands")
+        .update({ status: "processing", received_at: new Date().toISOString() })
+        .eq("id", commandId);
+    }
+
+    // Run the agent loop
+    let result: { response: string; toolCalls: number; turns: number };
+    try {
+      result = await runAgentLoop(
+        command,
+        agentId,
+        capabilities,
+        supabase,
+        logger,
+      );
+    } catch (error) {
+      logger.error("Agent loop failed", error as Error);
+      // Mark command as failed
+      if (commandId) {
+        await supabase
+          .from("agent_commands")
+          .update({
+            status: "failed",
+            completed_at: new Date().toISOString(),
+            metadata: { error: (error as Error).message },
+          })
+          .eq("id", commandId);
+      }
+      throw error;
+    }
+
+    // Store response in agent_responses
+    const sessionId = commandId || crypto.randomUUID();
+    const responseMeta = { tool_calls: result.toolCalls, turns: result.turns };
+    await supabase.from("agent_responses").insert({
+      command_id: commandId || null,
+      session_id: sessionId,
+      response_type: "complete",
+      content: result.response,
+      is_streaming: false,
+      metadata: responseMeta,
+    });
+
+    // Update command status to completed (if command_id provided)
+    if (commandId) {
+      const completionMeta = {
+        result: result.response,
+        tool_calls: result.toolCalls,
+      };
+      await supabase
+        .from("agent_commands")
+        .update({
+          status: "completed",
+          completed_at: new Date().toISOString(),
+          metadata: completionMeta,
+        })
+        .eq("id", commandId);
+    }
+
+    // Audit log
+    await supabase.rpc("log_audit_event", {
+      p_actor_type: "agent",
+      p_actor_id: agentId,
+      p_action: "agent.execute",
+      p_resource_type: "agent_command",
+      p_resource_id: commandId || null,
+      p_details: {
+        command: command.substring(0, 200),
+        tool_calls: result.toolCalls,
+        turns: result.turns,
+      },
+    });
+
+    const duration = Math.round(performance.now() - start);
+    logger.logResponse(200, duration);
+
+    return new Response(
+      JSON.stringify({
+        status: "completed",
+        response: result.response,
+        tool_calls: result.toolCalls,
+        turns: result.turns,
+        command_id: commandId || null,
+        duration_ms: duration,
+        correlationId: logger.getCorrelationId(),
+      }),
+      {
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json",
+          ...logger.getResponseHeaders(),
+        },
+      },
+    );
+  } catch (error) {
+    const duration = Math.round(performance.now() - start);
+    logger.error("Agent executor error", error as Error);
+    logger.logResponse(500, duration);
+
+    return new Response(
+      JSON.stringify({
+        error: "Internal server error",
+        correlationId: logger.getCorrelationId(),
+      }),
+      {
+        status: 500,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json",
+          ...logger.getResponseHeaders(),
+        },
+      },
+    );
+  }
+});

--- a/supabase/functions/workflow-executor/index.ts
+++ b/supabase/functions/workflow-executor/index.ts
@@ -7,34 +7,35 @@
 //   wait — setTimeout delay
 //   condition — evaluate expression against previous step results, branch to step ID
 
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0'
-import { authenticateAgent, AgentAuthResult } from '../_shared/agent-auth.ts'
-import { Logger } from '../_shared/logger.ts'
-import { validateInput, validateFields } from '../_shared/input-validator.ts'
-import { CORS_ORIGIN } from '../_shared/cors.ts'
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+import { authenticateAgent, AgentAuthResult } from "../_shared/agent-auth.ts";
+import { Logger } from "../_shared/logger.ts";
+import { validateInput, validateFields } from "../_shared/input-validator.ts";
+import { CORS_ORIGIN } from "../_shared/cors.ts";
+import { pollCommandCompletion } from "../_shared/command-polling.ts";
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': CORS_ORIGIN,
-  'Access-Control-Allow-Headers':
-    'authorization, x-client-info, apikey, content-type, x-agent-key, x-scheduler-secret',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-}
+  "Access-Control-Allow-Origin": CORS_ORIGIN,
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-agent-key, x-scheduler-secret",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
 
 interface WorkflowStep {
-  id: string
-  type: 'agent_command' | 'wait' | 'condition' | 'integration_action'
-  config: Record<string, unknown>
-  timeout_ms?: number
-  retries?: number
-  on_failure?: 'continue' | 'stop' | 'skip'
+  id: string;
+  type: "agent_command" | "wait" | "condition" | "integration_action";
+  config: Record<string, unknown>;
+  timeout_ms?: number;
+  retries?: number;
+  on_failure?: "continue" | "stop" | "skip";
 }
 
 interface StepResult {
-  step_id: string
-  status: 'completed' | 'failed' | 'skipped'
-  output?: unknown
-  error?: string
-  duration_ms: number
+  step_id: string;
+  status: "completed" | "failed" | "skipped";
+  output?: unknown;
+  error?: string;
+  duration_ms: number;
 }
 
 /**
@@ -45,60 +46,63 @@ async function executeStep(
   previousResults: StepResult[],
   supabase: ReturnType<typeof createClient>,
   agentId: string | null,
-  logger: Logger
+  logger: Logger,
 ): Promise<StepResult> {
-  const start = performance.now()
-  const timeoutMs = step.timeout_ms || 30000
-  const maxRetries = step.retries || 0
+  const start = performance.now();
+  const timeoutMs = step.timeout_ms || 30000;
+  const maxRetries = step.retries || 0;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       const result = await Promise.race([
         executeStepInner(step, previousResults, supabase, agentId, logger),
         new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('Step timed out')), timeoutMs)
+          setTimeout(() => reject(new Error("Step timed out")), timeoutMs),
         ),
-      ])
+      ]);
 
       return {
         step_id: step.id,
-        status: 'completed',
+        status: "completed",
         output: result,
         duration_ms: Math.round(performance.now() - start),
-      }
+      };
     } catch (error) {
-      const isLastAttempt = attempt === maxRetries
+      const isLastAttempt = attempt === maxRetries;
       if (!isLastAttempt) {
         // Exponential backoff: 1s, 2s, 4s, ...
-        const backoff = Math.min(1000 * Math.pow(2, attempt), 10000)
-        logger.warn('Step failed, retrying', {
+        const backoff = Math.min(1000 * Math.pow(2, attempt), 10000);
+        logger.warn("Step failed, retrying", {
           stepId: step.id,
           attempt: attempt + 1,
           maxRetries,
           backoffMs: backoff,
-        })
-        await new Promise((resolve) => setTimeout(resolve, backoff))
-        continue
+        });
+        await new Promise((resolve) => setTimeout(resolve, backoff));
+        continue;
       }
 
-      logger.error('Step failed', error as Error, { stepId: step.id, attempts: attempt + 1 })
+      logger.error("Step failed", error as Error, {
+        stepId: step.id,
+        attempts: attempt + 1,
+      });
 
       return {
         step_id: step.id,
-        status: 'failed',
+        status: "failed",
         error: (error as Error).message,
         duration_ms: Math.round(performance.now() - start),
-      }
+      };
     }
   }
 
   // Unreachable, but TypeScript needs it
   return {
     step_id: step.id,
-    status: 'failed',
-    error: 'Unexpected execution path',
+    status: "failed",
+    error: "Unexpected execution path",
     duration_ms: Math.round(performance.now() - start),
-  }
+  };
 }
 
 /**
@@ -109,130 +113,189 @@ async function executeStepInner(
   previousResults: StepResult[],
   supabase: ReturnType<typeof createClient>,
   agentId: string | null,
-  logger: Logger
+  logger: Logger,
 ): Promise<unknown> {
   switch (step.type) {
-    case 'agent_command': {
-      // Dispatch-oriented: insert command and move on
-      const { command, payload } = step.config as { command: string; payload?: unknown }
-      if (!command) throw new Error('agent_command step requires "command" in config')
+    case "agent_command": {
+      // Dispatch to agent-executor and wait for completion (#266, #268)
+      const { command, payload, target_agent_id } = step.config as {
+        command: string;
+        payload?: unknown;
+        target_agent_id?: string;
+      };
+      if (!command)
+        throw new Error('agent_command step requires "command" in config');
 
-      const content = typeof payload === 'string' ? payload : JSON.stringify(payload || {})
+      const content =
+        typeof payload === "string" ? payload : JSON.stringify(payload || {});
+      const commandText = `${command}: ${content}`;
 
-      const { data, error } = await supabase
-        .from('agent_commands')
-        .insert({
-          command_type: 'task',
-          content,
-          status: 'pending',
-          user_id: agentId || 'system',
-          user_email: 'workflow@system',
-          session_id: crypto.randomUUID(),
-          metadata: { workflow_command: command },
-        })
-        .select('id')
-        .single()
+      const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+      const schedulerSecret = Deno.env.get("SCHEDULER_SECRET")!;
 
-      if (error) throw new Error(`Failed to dispatch command: ${error.message}`)
+      const response = await fetch(
+        `${supabaseUrl}/functions/v1/agent-executor`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-scheduler-secret": schedulerSecret,
+          },
+          body: JSON.stringify({
+            agent_id: target_agent_id || agentId || "system",
+            command: commandText,
+          }),
+        },
+      );
 
-      logger.info('Dispatched agent command', { commandId: data.id, command })
-      return { command_id: data.id, command }
-    }
+      const data = await response.json();
 
-    case 'wait': {
-      const delayMs = (step.config.delay_ms as number) || 1000
-      const cappedDelay = Math.min(delayMs, 25000) // Cap at 25s to stay within edge function limits
-      await new Promise((resolve) => setTimeout(resolve, cappedDelay))
-      return { waited_ms: cappedDelay }
-    }
-
-    case 'condition': {
-      const { expression, then_step, else_step } = step.config as {
-        expression: string
-        then_step?: string
-        else_step?: string
+      if (!response.ok) {
+        throw new Error(
+          `Agent executor failed: ${data.error || "Unknown error"}`,
+        );
       }
-      if (!expression) throw new Error('condition step requires "expression" in config')
+
+      logger.info("Agent command executed", {
+        command,
+        toolCalls: data.tool_calls,
+        turns: data.turns,
+      });
+
+      return {
+        command,
+        response: data.response,
+        tool_calls: data.tool_calls,
+        turns: data.turns,
+      };
+    }
+
+    case "wait": {
+      const delayMs = (step.config.delay_ms as number) || 1000;
+      const cappedDelay = Math.min(delayMs, 25000); // Cap at 25s to stay within edge function limits
+      await new Promise((resolve) => setTimeout(resolve, cappedDelay));
+      return { waited_ms: cappedDelay };
+    }
+
+    case "condition": {
+      const { expression, then_step, else_step } = step.config as {
+        expression: string;
+        then_step?: string;
+        else_step?: string;
+      };
+      if (!expression)
+        throw new Error('condition step requires "expression" in config');
 
       // Evaluate condition against previous results
       // Simple evaluation: check if a previous step succeeded/failed
-      const result = evaluateCondition(expression, previousResults)
-      logger.info('Condition evaluated', { expression, result, thenStep: then_step, elseStep: else_step })
+      const result = evaluateCondition(expression, previousResults);
+      logger.info("Condition evaluated", {
+        expression,
+        result,
+        thenStep: then_step,
+        elseStep: else_step,
+      });
 
       return {
         condition_met: result,
         next_step: result ? then_step : else_step,
-      }
+      };
     }
 
-    case 'integration_action': {
+    case "integration_action": {
       const { integration_id, action_name, parameters } = step.config as {
-        integration_id?: string
-        action_name?: string
-        parameters?: Record<string, unknown>
-      }
-      if (!action_name) throw new Error('integration_action step requires "action_name" in config')
+        integration_id?: string;
+        action_name?: string;
+        parameters?: Record<string, unknown>;
+      };
+      if (!action_name)
+        throw new Error(
+          'integration_action step requires "action_name" in config',
+        );
 
       // Resolve integration action definition
-      let actionDef = null
+      let actionDef = null;
       if (integration_id) {
         const { data } = await supabase
-          .from('integration_actions')
-          .select('*')
-          .eq('integration_id', integration_id)
-          .eq('action_name', action_name)
-          .eq('is_active', true)
-          .single()
-        actionDef = data
+          .from("integration_actions")
+          .select("*")
+          .eq("integration_id", integration_id)
+          .eq("action_name", action_name)
+          .eq("is_active", true)
+          .single();
+        actionDef = data;
       }
 
       // Merge default config with provided parameters
       const mergedParams = {
         ...(actionDef?.default_config || {}),
         ...(parameters || {}),
-      }
+      };
 
       // Dispatch as an agent command with integration context in metadata
-      const content = JSON.stringify(mergedParams)
+      const content = JSON.stringify(mergedParams);
 
       const integrationMeta = {
         workflow_integration_action: action_name,
         integration_id: integration_id || null,
         integration_action_id: actionDef?.id || null,
-      }
+      };
 
       const { data, error } = await supabase
-        .from('agent_commands')
+        .from("agent_commands")
         .insert({
-          command_type: 'task',
+          command_type: "task",
           content,
-          status: 'pending',
-          user_id: agentId || 'system',
-          user_email: 'workflow@system',
+          status: "pending",
+          user_id: agentId || "system",
+          user_email: "workflow@system",
           session_id: crypto.randomUUID(),
           metadata: integrationMeta,
         })
-        .select('id')
-        .single()
+        .select("id")
+        .single();
 
-      if (error) throw new Error(`Failed to dispatch integration action: ${error.message}`)
+      if (error)
+        throw new Error(
+          `Failed to dispatch integration action: ${error.message}`,
+        );
 
-      logger.info('Dispatched integration action', {
+      logger.info("Dispatched integration action, polling for completion", {
         commandId: data.id,
         actionName: action_name,
         integrationId: integration_id,
-      })
+      });
+
+      // Poll for completion instead of fire-and-forget (#266)
+      const timeoutMs = step.timeout_ms || 15000;
+      const pollResult = await pollCommandCompletion(
+        data.id,
+        timeoutMs,
+        supabase,
+        logger,
+      );
+
+      if (pollResult.status === "timeout") {
+        throw new Error(`Integration action timed out: ${action_name}`);
+      }
+      if (pollResult.status === "failed" || pollResult.status === "cancelled") {
+        throw new Error(
+          pollResult.error || `Integration action failed: ${action_name}`,
+        );
+      }
 
       return {
         command_id: data.id,
         action_name,
         integration_id,
+        status: pollResult.status,
+        output: pollResult.output,
         parameters: mergedParams,
-      }
+      };
     }
 
     default:
-      throw new Error(`Unknown step type: ${step.type}`)
+      throw new Error(`Unknown step type: ${step.type}`);
   }
 }
 
@@ -243,21 +306,25 @@ async function executeStepInner(
  *   "step_id.status != failed"
  */
 function evaluateCondition(expression: string, results: StepResult[]): boolean {
-  const resultMap = new Map(results.map((r) => [r.step_id, r]))
+  const resultMap = new Map(results.map((r) => [r.step_id, r]));
 
   // Parse "step_id.field op value"
-  const match = expression.match(/^(\w+)\.(status|output)\s*(==|!=)\s*(\w+)$/)
+  const match = expression.match(/^(\w+)\.(status|output)\s*(==|!=)\s*(\w+)$/);
   if (!match) {
     // Default: treat as truthy if expression matches a completed step ID
-    return resultMap.has(expression) && resultMap.get(expression)!.status === 'completed'
+    return (
+      resultMap.has(expression) &&
+      resultMap.get(expression)!.status === "completed"
+    );
   }
 
-  const [, stepId, field, op, value] = match
-  const stepResult = resultMap.get(stepId)
-  if (!stepResult) return false
+  const [, stepId, field, op, value] = match;
+  const stepResult = resultMap.get(stepId);
+  if (!stepResult) return false;
 
-  const actual = field === 'status' ? stepResult.status : String(stepResult.output)
-  return op === '==' ? actual === value : actual !== value
+  const actual =
+    field === "status" ? stepResult.status : String(stepResult.output);
+  return op === "==" ? actual === value : actual !== value;
 }
 
 /**
@@ -267,206 +334,264 @@ async function authenticateRequest(
   req: Request,
   supabase: ReturnType<typeof createClient>,
   logger: Logger,
-  triggerType: string
-): Promise<{ authorized: boolean; agentId: string | null; error?: string; status?: number }> {
+  triggerType: string,
+): Promise<{
+  authorized: boolean;
+  agentId: string | null;
+  error?: string;
+  status?: number;
+}> {
   // Scheduled triggers use a shared secret
-  if (triggerType === 'scheduled') {
-    const schedulerSecret = req.headers.get('x-scheduler-secret')
-    const expectedSecret = Deno.env.get('SCHEDULER_SECRET')
+  if (triggerType === "scheduled") {
+    const schedulerSecret = req.headers.get("x-scheduler-secret");
+    const expectedSecret = Deno.env.get("SCHEDULER_SECRET");
 
     if (!expectedSecret) {
-      logger.error('SCHEDULER_SECRET not configured')
-      return { authorized: false, agentId: null, error: 'Scheduler not configured', status: 500 }
+      logger.error("SCHEDULER_SECRET not configured");
+      return {
+        authorized: false,
+        agentId: null,
+        error: "Scheduler not configured",
+        status: 500,
+      };
     }
 
     if (schedulerSecret !== expectedSecret) {
-      logger.warn('Scheduler auth failed: invalid secret')
-      return { authorized: false, agentId: null, error: 'Invalid scheduler secret', status: 401 }
+      logger.warn("Scheduler auth failed: invalid secret");
+      return {
+        authorized: false,
+        agentId: null,
+        error: "Invalid scheduler secret",
+        status: 401,
+      };
     }
 
-    return { authorized: true, agentId: null }
+    return { authorized: true, agentId: null };
   }
 
   // Manual/webhook triggers use agent auth
-  const auth = await authenticateAgent(req, supabase, logger)
+  const auth = await authenticateAgent(req, supabase, logger);
   if (!auth.authenticated) {
-    return { authorized: false, agentId: null, error: auth.error, status: auth.status }
+    return {
+      authorized: false,
+      agentId: null,
+      error: auth.error,
+      status: auth.status,
+    };
   }
 
-  return { authorized: true, agentId: auth.agent!.id }
+  return { authorized: true, agentId: auth.agent!.id };
 }
 
 Deno.serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders })
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
   }
 
-  if (req.method !== 'POST') {
-    return new Response(
-      JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    )
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 
-  const logger = Logger.fromRequest(req)
-  logger.logRequest()
-  const start = performance.now()
+  const logger = Logger.fromRequest(req);
+  logger.logRequest();
+  const start = performance.now();
 
   try {
     // Validate input
-    const validation = await validateInput(req)
+    const validation = await validateInput(req);
     if (!validation.valid) {
       return new Response(
-        JSON.stringify({ error: 'Validation error', message: validation.error }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({
+          error: "Validation error",
+          message: validation.error,
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
-    const body = validation.data as Record<string, unknown>
+    const body = validation.data as Record<string, unknown>;
     const fieldError = validateFields(body, {
-      workflow_id: { required: true, type: 'string' },
-      trigger_type: { required: true, type: 'string', enum: ['manual', 'scheduled', 'webhook', 'event'] },
-    })
+      workflow_id: { required: true, type: "string" },
+      trigger_type: {
+        required: true,
+        type: "string",
+        enum: ["manual", "scheduled", "webhook", "event"],
+      },
+    });
     if (fieldError) {
       return new Response(
-        JSON.stringify({ error: 'Validation error', message: fieldError }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({ error: "Validation error", message: fieldError }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
     const { workflow_id, trigger_type, trigger_data } = body as {
-      workflow_id: string
-      trigger_type: string
-      trigger_data?: Record<string, unknown>
-    }
+      workflow_id: string;
+      trigger_type: string;
+      trigger_data?: Record<string, unknown>;
+    };
 
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
     // Authenticate
-    const authResult = await authenticateRequest(req, supabase, logger, trigger_type)
+    const authResult = await authenticateRequest(
+      req,
+      supabase,
+      logger,
+      trigger_type,
+    );
     if (!authResult.authorized) {
-      const duration = Math.round(performance.now() - start)
-      logger.logResponse(authResult.status || 401, duration)
-      return new Response(
-        JSON.stringify({ error: authResult.error }),
-        { status: authResult.status || 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+      const duration = Math.round(performance.now() - start);
+      logger.logResponse(authResult.status || 401, duration);
+      return new Response(JSON.stringify({ error: authResult.error }), {
+        status: authResult.status || 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
     // Fetch workflow
     const { data: workflow, error: wfError } = await supabase
-      .from('workflows')
-      .select('*')
-      .eq('id', workflow_id)
-      .eq('is_active', true)
-      .single()
+      .from("workflows")
+      .select("*")
+      .eq("id", workflow_id)
+      .eq("is_active", true)
+      .single();
 
     if (wfError || !workflow) {
       return new Response(
-        JSON.stringify({ error: 'Workflow not found or inactive' }),
-        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({ error: "Workflow not found or inactive" }),
+        {
+          status: 404,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Create workflow run
     const { data: run, error: runError } = await supabase
-      .from('workflow_runs')
+      .from("workflow_runs")
       .insert({
         workflow_id,
-        status: 'running',
+        status: "running",
         trigger_type,
         trigger_data: trigger_data || {},
         started_at: new Date().toISOString(),
       })
-      .select('id')
-      .single()
+      .select("id")
+      .single();
 
     if (runError) {
-      logger.error('Failed to create workflow run', runError as unknown as Error)
+      logger.error(
+        "Failed to create workflow run",
+        runError as unknown as Error,
+      );
       return new Response(
-        JSON.stringify({ error: 'Failed to create workflow run' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
+        JSON.stringify({ error: "Failed to create workflow run" }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
     }
 
-    logger.info('Workflow execution started', { runId: run.id, workflowId: workflow_id })
+    logger.info("Workflow execution started", {
+      runId: run.id,
+      workflowId: workflow_id,
+    });
 
     // Execute steps sequentially
-    const steps = workflow.steps as WorkflowStep[]
-    const stepResults: StepResult[] = []
-    let failed = false
+    const steps = workflow.steps as WorkflowStep[];
+    const stepResults: StepResult[] = [];
+    let failed = false;
 
     for (const step of steps) {
       // Check if a condition step redirected us
       if (stepResults.length > 0) {
-        const lastResult = stepResults[stepResults.length - 1]
-        if (lastResult.status === 'completed' && lastResult.output) {
-          const output = lastResult.output as { next_step?: string }
+        const lastResult = stepResults[stepResults.length - 1];
+        if (lastResult.status === "completed" && lastResult.output) {
+          const output = lastResult.output as { next_step?: string };
           if (output.next_step && output.next_step !== step.id) {
             // Skip steps until we reach the target step
             stepResults.push({
               step_id: step.id,
-              status: 'skipped',
+              status: "skipped",
               duration_ms: 0,
-            })
-            continue
+            });
+            continue;
           }
         }
       }
 
-      const result = await executeStep(step, stepResults, supabase, authResult.agentId, logger)
-      stepResults.push(result)
+      const result = await executeStep(
+        step,
+        stepResults,
+        supabase,
+        authResult.agentId,
+        logger,
+      );
+      stepResults.push(result);
 
       // Update step_results in DB after each step
       await supabase
-        .from('workflow_runs')
+        .from("workflow_runs")
         .update({ step_results: stepResults })
-        .eq('id', run.id)
+        .eq("id", run.id);
 
-      if (result.status === 'failed') {
-        const onFailure = step.on_failure || 'stop'
+      if (result.status === "failed") {
+        const onFailure = step.on_failure || "stop";
 
-        if (onFailure === 'stop') {
-          failed = true
-          break
+        if (onFailure === "stop") {
+          failed = true;
+          break;
         }
         // 'continue' and 'skip' both proceed to next step
       }
     }
 
     // Update final run status
-    const finalStatus = failed ? 'failed' : 'completed'
-    const failedStep = failed ? stepResults.find((r) => r.status === 'failed') : null
+    const finalStatus = failed ? "failed" : "completed";
+    const failedStep = failed
+      ? stepResults.find((r) => r.status === "failed")
+      : null;
 
     await supabase
-      .from('workflow_runs')
+      .from("workflow_runs")
       .update({
         status: finalStatus,
         step_results: stepResults,
         error: failedStep?.error || null,
         completed_at: new Date().toISOString(),
       })
-      .eq('id', run.id)
+      .eq("id", run.id);
 
     // Audit log
-    await supabase.rpc('log_audit_event', {
-      p_actor_type: authResult.agentId ? 'agent' : 'scheduler',
+    await supabase.rpc("log_audit_event", {
+      p_actor_type: authResult.agentId ? "agent" : "scheduler",
       p_actor_id: authResult.agentId,
       p_action: `workflow.${finalStatus}`,
-      p_resource_type: 'workflow_run',
+      p_resource_type: "workflow_run",
       p_resource_id: run.id,
       p_details: {
         workflow_id,
         trigger_type,
         steps_executed: stepResults.length,
-        steps_failed: stepResults.filter((r) => r.status === 'failed').length,
+        steps_failed: stepResults.filter((r) => r.status === "failed").length,
       },
-    })
+    });
 
-    const duration = Math.round(performance.now() - start)
-    logger.logResponse(200, duration)
+    const duration = Math.round(performance.now() - start);
+    logger.logResponse(200, duration);
 
     return new Response(
       JSON.stringify({
@@ -481,29 +606,29 @@ Deno.serve(async (req) => {
         status: 200,
         headers: {
           ...corsHeaders,
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           ...logger.getResponseHeaders(),
         },
-      }
-    )
+      },
+    );
   } catch (error) {
-    const duration = Math.round(performance.now() - start)
-    logger.error('Workflow executor error', error as Error)
-    logger.logResponse(500, duration)
+    const duration = Math.round(performance.now() - start);
+    logger.error("Workflow executor error", error as Error);
+    logger.logResponse(500, duration);
 
     return new Response(
       JSON.stringify({
-        error: 'Internal server error',
+        error: "Internal server error",
         correlationId: logger.getCorrelationId(),
       }),
       {
         status: 500,
         headers: {
           ...corsHeaders,
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
           ...logger.getResponseHeaders(),
         },
-      }
-    )
+      },
+    );
   }
-})
+});

--- a/supabase/migrations/20260301000000_tool_definitions.sql
+++ b/supabase/migrations/20260301000000_tool_definitions.sql
@@ -1,0 +1,136 @@
+-- ============================================
+-- TOOL DEFINITIONS TABLE (#268)
+-- Maps Claude tool-use tools to capability_definitions and ACTION_CAPABILITY_MAP actions.
+-- Each row defines a tool that the agent-executor can expose to Claude based on
+-- an agent's granted capabilities (via agent_skills).
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS tool_definitions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  capability_name TEXT NOT NULL REFERENCES capability_definitions(name) ON DELETE CASCADE,
+  input_schema JSONB NOT NULL,
+  action_name TEXT NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_definitions_capability ON tool_definitions(capability_name);
+CREATE INDEX IF NOT EXISTS idx_tool_definitions_action ON tool_definitions(action_name);
+CREATE INDEX IF NOT EXISTS idx_tool_definitions_active ON tool_definitions(is_active) WHERE is_active = true;
+
+ALTER TABLE tool_definitions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Anyone can read tool definitions" ON tool_definitions;
+CREATE POLICY "Anyone can read tool definitions" ON tool_definitions
+  FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Admins can manage tool definitions" ON tool_definitions;
+CREATE POLICY "Admins can manage tool definitions" ON tool_definitions
+  FOR ALL USING (is_admin());
+
+-- Auto-update updated_at
+CREATE OR REPLACE FUNCTION update_tool_definitions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_tool_definitions_updated_at ON tool_definitions;
+CREATE TRIGGER trg_tool_definitions_updated_at
+  BEFORE UPDATE ON tool_definitions
+  FOR EACH ROW
+  EXECUTE FUNCTION update_tool_definitions_updated_at();
+
+-- ============================================
+-- SEED TOOL DEFINITIONS
+-- One tool per ACTION_CAPABILITY_MAP entry (representative subset).
+-- ============================================
+
+INSERT INTO tool_definitions (name, display_name, description, capability_name, input_schema, action_name) VALUES
+
+-- CRM tools
+('search_contacts', 'Search Contacts', 'Search CRM contacts by name, email, company, or tags', 'crm',
+ '{"type":"object","properties":{"query":{"type":"string","description":"Search query"},"limit":{"type":"integer","description":"Max results","default":10}},"required":["query"]}',
+ 'query.contacts'),
+
+('create_contact', 'Create Contact', 'Create a new CRM contact', 'crm',
+ '{"type":"object","properties":{"first_name":{"type":"string"},"last_name":{"type":"string"},"email":{"type":"string"},"company":{"type":"string"},"contact_type":{"type":"string","enum":["lead","prospect","client","partner","vendor","personal","other"]}},"required":["first_name","last_name"]}',
+ 'crm.create_contact'),
+
+('update_contact', 'Update Contact', 'Update an existing CRM contact', 'crm',
+ '{"type":"object","properties":{"contact_id":{"type":"string","description":"UUID of the contact"},"updates":{"type":"object","description":"Fields to update"}},"required":["contact_id","updates"]}',
+ 'crm.update_contact'),
+
+-- Knowledge base tools
+('search_knowledge_base', 'Search Knowledge Base', 'Search the knowledge base for relevant articles and documents', 'kb',
+ '{"type":"object","properties":{"query":{"type":"string","description":"Search query"},"limit":{"type":"integer","default":5}},"required":["query"]}',
+ 'kb.search'),
+
+('summarize_document', 'Summarize Document', 'Generate a summary of a knowledge base document', 'kb',
+ '{"type":"object","properties":{"document_id":{"type":"string","description":"UUID of the document"}},"required":["document_id"]}',
+ 'kb.summarize'),
+
+-- Email tools
+('send_email', 'Send Email', 'Send an email to a recipient', 'email',
+ '{"type":"object","properties":{"to":{"type":"string","description":"Recipient email"},"subject":{"type":"string"},"body":{"type":"string"},"cc":{"type":"array","items":{"type":"string"}}},"required":["to","subject","body"]}',
+ 'email.send'),
+
+('draft_email', 'Draft Email', 'Create an email draft without sending', 'email',
+ '{"type":"object","properties":{"to":{"type":"string"},"subject":{"type":"string"},"body":{"type":"string"}},"required":["to","subject","body"]}',
+ 'email.draft'),
+
+-- Calendar tools
+('create_calendar_event', 'Create Calendar Event', 'Schedule a new calendar event', 'calendar',
+ '{"type":"object","properties":{"title":{"type":"string"},"start_at":{"type":"string","description":"ISO 8601 start time"},"end_at":{"type":"string","description":"ISO 8601 end time"},"description":{"type":"string"},"location":{"type":"string"}},"required":["title","start_at"]}',
+ 'calendar.create_event'),
+
+('list_calendar_events', 'List Calendar Events', 'List upcoming calendar events within a date range', 'calendar',
+ '{"type":"object","properties":{"start_date":{"type":"string","description":"ISO 8601 start date"},"end_date":{"type":"string","description":"ISO 8601 end date"},"limit":{"type":"integer","default":20}},"required":["start_date"]}',
+ 'calendar.list_events'),
+
+-- Task tools
+('create_task', 'Create Task', 'Create a new task', 'tasks',
+ '{"type":"object","properties":{"title":{"type":"string"},"description":{"type":"string"},"priority":{"type":"string","enum":["low","medium","high","urgent"]},"due_date":{"type":"string","description":"ISO 8601 date"}},"required":["title"]}',
+ 'tasks.create'),
+
+('list_tasks', 'List Tasks', 'List tasks with optional filters', 'tasks',
+ '{"type":"object","properties":{"status":{"type":"string","enum":["todo","in_progress","review","done"]},"priority":{"type":"string","enum":["low","medium","high","urgent"]},"limit":{"type":"integer","default":20}}}',
+ 'tasks.list'),
+
+-- Document tools
+('create_document', 'Create Document', 'Create a new document', 'documents',
+ '{"type":"object","properties":{"title":{"type":"string"},"content":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}}},"required":["title","content"]}',
+ 'documents.create'),
+
+('search_documents', 'Search Documents', 'Search documents by query', 'documents',
+ '{"type":"object","properties":{"query":{"type":"string"},"limit":{"type":"integer","default":10}},"required":["query"]}',
+ 'documents.search'),
+
+-- Research tools
+('web_search', 'Web Search', 'Search the web for information', 'research',
+ '{"type":"object","properties":{"query":{"type":"string","description":"Search query"},"max_results":{"type":"integer","default":5}},"required":["query"]}',
+ 'research.web_search'),
+
+-- Data tools
+('query_data', 'Query Data', 'Run a structured data query', 'data',
+ '{"type":"object","properties":{"table":{"type":"string","description":"Table or view name"},"filters":{"type":"object","description":"Key-value filter conditions"},"limit":{"type":"integer","default":50}},"required":["table"]}',
+ 'data.query')
+
+ON CONFLICT (name) DO NOTHING;
+
+-- ============================================
+-- DONE
+-- ============================================
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Tool definitions migration completed successfully';
+  RAISE NOTICE 'Table created: tool_definitions';
+  RAISE NOTICE 'Seed data: 15 tool definitions mapped to capabilities and actions';
+END $$;

--- a/tests/agent-platform/agent-executor.test.ts
+++ b/tests/agent-platform/agent-executor.test.ts
@@ -1,0 +1,670 @@
+/**
+ * Agent Executor Tests
+ *
+ * Tests the agent-executor edge function logic:
+ * - Tool loading by capability
+ * - Claude conversation loop with mocked API
+ * - Tool execution routing
+ * - Timeout and turn limits
+ * - Error handling
+ *
+ * Issues: #266, #268
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AGENT_OPENCLAW, AGENT_DASHBOARD } from "./fixtures";
+
+// ─── Inline types from agent-executor ───────────────────────────────
+
+interface ClaudeTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+interface ToolDefinitionRow {
+  name: string;
+  display_name: string;
+  description: string;
+  capability_name: string;
+  input_schema: Record<string, unknown>;
+  action_name: string;
+  is_active: boolean;
+}
+
+interface ClaudeTextBlock {
+  type: "text";
+  text: string;
+}
+
+interface ClaudeToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+interface ClaudeToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+  is_error?: boolean;
+}
+
+type ClaudeContentBlock =
+  | ClaudeTextBlock
+  | ClaudeToolUseBlock
+  | ClaudeToolResultBlock;
+
+interface ClaudeResponse {
+  id: string;
+  role: "assistant";
+  content: ClaudeContentBlock[];
+  stop_reason: "end_turn" | "tool_use" | "max_tokens";
+  model: string;
+  usage: { input_tokens: number; output_tokens: number };
+}
+
+interface ClaudeMessage {
+  role: "user" | "assistant";
+  content: string | ClaudeContentBlock[];
+}
+
+// ─── Inline logic from agent-executor ───────────────────────────────
+
+function loadToolsForCapabilities(
+  capabilities: string[],
+  allTools: ToolDefinitionRow[],
+): { tools: ClaudeTool[]; toolActionMap: Map<string, string> } {
+  const toolActionMap = new Map<string, string>();
+  const filtered = allTools.filter(
+    (t) => t.is_active && capabilities.includes(t.capability_name),
+  );
+  const tools: ClaudeTool[] = filtered.map((row) => {
+    toolActionMap.set(row.name, row.action_name);
+    return {
+      name: row.name,
+      description: row.description,
+      input_schema: row.input_schema,
+    };
+  });
+  return { tools, toolActionMap };
+}
+
+function canPerformAction(capabilities: string[], action: string): boolean {
+  const ACTION_CAPABILITY_MAP: Record<string, string> = {
+    "query.contacts": "crm",
+    "crm.create_contact": "crm",
+    "email.send": "email",
+    "tasks.create": "tasks",
+    "research.web_search": "research",
+    "data.query": "data",
+    "documents.search": "documents",
+    "kb.search": "kb",
+  };
+  const required = ACTION_CAPABILITY_MAP[action];
+  if (required === undefined) return false;
+  if (required === "") return true;
+  return capabilities.includes(required);
+}
+
+function extractText(response: ClaudeResponse): string {
+  return response.content
+    .filter((b): b is ClaudeTextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+}
+
+function extractToolUses(response: ClaudeResponse): ClaudeToolUseBlock[] {
+  return response.content.filter(
+    (b): b is ClaudeToolUseBlock => b.type === "tool_use",
+  );
+}
+
+function wantsToolUse(response: ClaudeResponse): boolean {
+  return response.stop_reason === "tool_use";
+}
+
+const MAX_TURNS = 5;
+
+async function runAgentLoop(
+  command: string,
+  capabilities: string[],
+  allTools: ToolDefinitionRow[],
+  claudeFn: (
+    messages: ClaudeMessage[],
+    tools?: ClaudeTool[],
+  ) => Promise<ClaudeResponse>,
+  executeFn: (
+    toolName: string,
+    actionName: string,
+    input: Record<string, unknown>,
+  ) => Promise<{ result: string; isError: boolean }>,
+  timeoutMs: number = 24000,
+): Promise<{ response: string; toolCalls: number; turns: number }> {
+  const startTime = Date.now();
+  const { tools, toolActionMap } = loadToolsForCapabilities(
+    capabilities,
+    allTools,
+  );
+
+  const messages: ClaudeMessage[] = [{ role: "user", content: command }];
+  let totalToolCalls = 0;
+
+  for (let turn = 0; turn < MAX_TURNS; turn++) {
+    if (Date.now() - startTime > timeoutMs) {
+      return {
+        response: "Execution timed out.",
+        toolCalls: totalToolCalls,
+        turns: turn,
+      };
+    }
+
+    const claudeResponse = await claudeFn(
+      messages,
+      tools.length > 0 ? tools : undefined,
+    );
+
+    if (!wantsToolUse(claudeResponse)) {
+      return {
+        response: extractText(claudeResponse),
+        toolCalls: totalToolCalls,
+        turns: turn + 1,
+      };
+    }
+
+    const toolUses = extractToolUses(claudeResponse);
+    totalToolCalls += toolUses.length;
+
+    messages.push({ role: "assistant", content: claudeResponse.content });
+
+    const toolResults: ClaudeContentBlock[] = [];
+    for (const toolUse of toolUses) {
+      const actionName = toolActionMap.get(toolUse.name);
+      if (!actionName) {
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: toolUse.id,
+          content: JSON.stringify({ error: `Unknown tool: ${toolUse.name}` }),
+          is_error: true,
+        });
+        continue;
+      }
+
+      if (!canPerformAction(capabilities, actionName)) {
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: toolUse.id,
+          content: JSON.stringify({ error: `Insufficient capability` }),
+          is_error: true,
+        });
+        continue;
+      }
+
+      const { result, isError } = await executeFn(
+        toolUse.name,
+        actionName,
+        toolUse.input,
+      );
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: toolUse.id,
+        content: result,
+        is_error: isError,
+      });
+    }
+
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  return {
+    response: "Reached maximum turns.",
+    toolCalls: totalToolCalls,
+    turns: MAX_TURNS,
+  };
+}
+
+// ─── Mock Tool Definitions ──────────────────────────────────────────
+
+const MOCK_TOOLS: ToolDefinitionRow[] = [
+  {
+    name: "search_contacts",
+    display_name: "Search Contacts",
+    description: "Search CRM contacts",
+    capability_name: "crm",
+    input_schema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+    action_name: "query.contacts",
+    is_active: true,
+  },
+  {
+    name: "send_email",
+    display_name: "Send Email",
+    description: "Send an email",
+    capability_name: "email",
+    input_schema: {
+      type: "object",
+      properties: { to: { type: "string" }, subject: { type: "string" } },
+    },
+    action_name: "email.send",
+    is_active: true,
+  },
+  {
+    name: "create_task",
+    display_name: "Create Task",
+    description: "Create a task",
+    capability_name: "tasks",
+    input_schema: {
+      type: "object",
+      properties: { title: { type: "string" } },
+      required: ["title"],
+    },
+    action_name: "tasks.create",
+    is_active: true,
+  },
+  {
+    name: "query_data",
+    display_name: "Query Data",
+    description: "Run a data query",
+    capability_name: "data",
+    input_schema: {
+      type: "object",
+      properties: { table: { type: "string" } },
+      required: ["table"],
+    },
+    action_name: "data.query",
+    is_active: true,
+  },
+  {
+    name: "search_documents",
+    display_name: "Search Documents",
+    description: "Search documents",
+    capability_name: "documents",
+    input_schema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+    action_name: "documents.search",
+    is_active: true,
+  },
+  {
+    name: "web_search",
+    display_name: "Web Search",
+    description: "Search the web",
+    capability_name: "research",
+    input_schema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+    action_name: "research.web_search",
+    is_active: true,
+  },
+  {
+    name: "inactive_tool",
+    display_name: "Inactive Tool",
+    description: "Should not be loaded",
+    capability_name: "crm",
+    input_schema: { type: "object", properties: {} },
+    action_name: "crm.search",
+    is_active: false,
+  },
+];
+
+// ─── Helper: create mock Claude responses ───────────────────────────
+
+function makeTextResponse(text: string): ClaudeResponse {
+  return {
+    id: "msg-text",
+    role: "assistant",
+    content: [{ type: "text", text }],
+    stop_reason: "end_turn",
+    model: "claude-sonnet-4-5-20250929",
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
+
+function makeToolUseResponse(
+  toolUses: Array<{ name: string; input: Record<string, unknown> }>,
+): ClaudeResponse {
+  return {
+    id: "msg-tool",
+    role: "assistant",
+    content: toolUses.map((tu, i) => ({
+      type: "tool_use" as const,
+      id: `tu-${i}`,
+      name: tu.name,
+      input: tu.input,
+    })),
+    stop_reason: "tool_use",
+    model: "claude-sonnet-4-5-20250929",
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe("Agent Executor", () => {
+  describe("tool loading by capability", () => {
+    it("loads only tools matching agent capabilities", () => {
+      // AGENT_OPENCLAW has: crm, email, tasks, research, automation
+      const { tools } = loadToolsForCapabilities(
+        AGENT_OPENCLAW.capabilities,
+        MOCK_TOOLS,
+      );
+
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("search_contacts");
+      expect(names).toContain("send_email");
+      expect(names).toContain("create_task");
+      expect(names).toContain("web_search");
+      expect(names).not.toContain("query_data"); // requires 'data'
+      expect(names).not.toContain("search_documents"); // requires 'documents'
+      expect(names).not.toContain("inactive_tool"); // is_active=false
+    });
+
+    it("loads different tools for different agent capabilities", () => {
+      // AGENT_DASHBOARD has: data, meta_analysis, documents
+      const { tools } = loadToolsForCapabilities(
+        AGENT_DASHBOARD.capabilities,
+        MOCK_TOOLS,
+      );
+
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("query_data");
+      expect(names).toContain("search_documents");
+      expect(names).not.toContain("search_contacts"); // requires 'crm'
+      expect(names).not.toContain("send_email"); // requires 'email'
+    });
+
+    it("builds correct tool-action map", () => {
+      const { toolActionMap } = loadToolsForCapabilities(
+        AGENT_OPENCLAW.capabilities,
+        MOCK_TOOLS,
+      );
+
+      expect(toolActionMap.get("search_contacts")).toBe("query.contacts");
+      expect(toolActionMap.get("send_email")).toBe("email.send");
+      expect(toolActionMap.get("create_task")).toBe("tasks.create");
+    });
+
+    it("returns empty tools for agent with no matching capabilities", () => {
+      const { tools, toolActionMap } = loadToolsForCapabilities([], MOCK_TOOLS);
+
+      expect(tools).toHaveLength(0);
+      expect(toolActionMap.size).toBe(0);
+    });
+  });
+
+  describe("Claude conversation loop", () => {
+    const mockExecute = vi.fn(
+      async (
+        toolName: string,
+        actionName: string,
+        input: Record<string, unknown>,
+      ) => ({
+        result: JSON.stringify({
+          success: true,
+          data: { toolName, actionName },
+        }),
+        isError: false,
+      }),
+    );
+
+    beforeEach(() => {
+      mockExecute.mockClear();
+    });
+
+    it("returns text response when Claude does not use tools", async () => {
+      const mockClaude = vi.fn(async () =>
+        makeTextResponse("Hello! How can I help?"),
+      );
+
+      const result = await runAgentLoop(
+        "Say hello",
+        AGENT_OPENCLAW.capabilities,
+        MOCK_TOOLS,
+        mockClaude,
+        mockExecute,
+      );
+
+      expect(result.response).toBe("Hello! How can I help?");
+      expect(result.toolCalls).toBe(0);
+      expect(result.turns).toBe(1);
+      expect(mockClaude).toHaveBeenCalledTimes(1);
+    });
+
+    it("executes tool use and continues conversation", async () => {
+      let callCount = 0;
+      const mockClaude = vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: Claude uses a tool
+          return makeToolUseResponse([
+            { name: "search_contacts", input: { query: "John" } },
+          ]);
+        }
+        // Second call: Claude returns text
+        return makeTextResponse('Found 3 contacts matching "John".');
+      });
+
+      const result = await runAgentLoop(
+        "Find contacts named John",
+        AGENT_OPENCLAW.capabilities,
+        MOCK_TOOLS,
+        mockClaude,
+        mockExecute,
+      );
+
+      expect(result.response).toBe('Found 3 contacts matching "John".');
+      expect(result.toolCalls).toBe(1);
+      expect(result.turns).toBe(2);
+      expect(mockExecute).toHaveBeenCalledWith(
+        "search_contacts",
+        "query.contacts",
+        { query: "John" },
+      );
+    });
+
+    it("handles multiple tool uses in one turn", async () => {
+      let callCount = 0;
+      const mockClaude = vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return makeToolUseResponse([
+            { name: "search_contacts", input: { query: "Alice" } },
+            { name: "create_task", input: { title: "Follow up with Alice" } },
+          ]);
+        }
+        return makeTextResponse(
+          "Done: found Alice and created follow-up task.",
+        );
+      });
+
+      const result = await runAgentLoop(
+        "Find Alice and create a follow-up task",
+        AGENT_OPENCLAW.capabilities,
+        MOCK_TOOLS,
+        mockClaude,
+        mockExecute,
+      );
+
+      expect(result.toolCalls).toBe(2);
+      expect(result.turns).toBe(2);
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+    });
+
+    it("limits turns to MAX_TURNS", async () => {
+      // Claude always requests tool use — should stop after MAX_TURNS
+      const mockClaude = vi.fn(async () =>
+        makeToolUseResponse([
+          { name: "search_contacts", input: { query: "loop" } },
+        ]),
+      );
+
+      const result = await runAgentLoop(
+        "Keep searching forever",
+        AGENT_OPENCLAW.capabilities,
+        MOCK_TOOLS,
+        mockClaude,
+        mockExecute,
+      );
+
+      expect(result.response).toBe("Reached maximum turns.");
+      expect(result.turns).toBe(MAX_TURNS);
+      expect(result.toolCalls).toBe(MAX_TURNS); // one per turn
+    });
+  });
+
+  describe("tool execution routing", () => {
+    it("rejects unknown tool names", async () => {
+      let callCount = 0;
+      const mockClaude = vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return makeToolUseResponse([{ name: "nonexistent_tool", input: {} }]);
+        }
+        return makeTextResponse("Tool not found.");
+      });
+
+      const mockExecute = vi.fn(async () => ({ result: "{}", isError: false }));
+
+      const result = await runAgentLoop(
+        "Use a fake tool",
+        AGENT_OPENCLAW.capabilities,
+        MOCK_TOOLS,
+        mockClaude,
+        mockExecute,
+      );
+
+      // Tool should NOT have been executed — unknown tool error sent back to Claude
+      expect(mockExecute).not.toHaveBeenCalled();
+      expect(result.toolCalls).toBe(1); // counted but not executed
+    });
+
+    it("rejects tool use when agent lacks capability", async () => {
+      // AGENT_DASHBOARD has data, meta_analysis, documents — NOT crm
+      let callCount = 0;
+      const mockClaude = vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Try to use query_data (which Dashboard HAS access to)
+          return makeToolUseResponse([
+            { name: "query_data", input: { table: "metrics" } },
+          ]);
+        }
+        return makeTextResponse("Query complete.");
+      });
+
+      const mockExecute = vi.fn(async () => ({
+        result: JSON.stringify({ rows: [] }),
+        isError: false,
+      }));
+
+      const result = await runAgentLoop(
+        "Query metrics",
+        AGENT_DASHBOARD.capabilities,
+        MOCK_TOOLS,
+        mockClaude,
+        mockExecute,
+      );
+
+      // data.query should work for Dashboard
+      expect(mockExecute).toHaveBeenCalledWith("query_data", "data.query", {
+        table: "metrics",
+      });
+      expect(result.toolCalls).toBe(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles Claude API errors gracefully", async () => {
+      const mockClaude = vi.fn(async () => {
+        throw new Error("Claude API error: 529 Overloaded");
+      });
+
+      const mockExecute = vi.fn(async () => ({ result: "{}", isError: false }));
+
+      await expect(
+        runAgentLoop(
+          "Do something",
+          AGENT_OPENCLAW.capabilities,
+          MOCK_TOOLS,
+          mockClaude,
+          mockExecute,
+        ),
+      ).rejects.toThrow("Claude API error: 529 Overloaded");
+    });
+
+    it("handles tool execution errors without crashing loop", async () => {
+      let callCount = 0;
+      const mockClaude = vi.fn(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return makeToolUseResponse([
+            {
+              name: "send_email",
+              input: { to: "test@example.com", subject: "Hi" },
+            },
+          ]);
+        }
+        return makeTextResponse("Email failed but I handled it.");
+      });
+
+      const failingExecute = vi.fn(async () => ({
+        result: JSON.stringify({ error: "SMTP connection failed" }),
+        isError: true,
+      }));
+
+      const result = await runAgentLoop(
+        "Send an email",
+        AGENT_OPENCLAW.capabilities,
+        MOCK_TOOLS,
+        mockClaude,
+        failingExecute,
+      );
+
+      // Loop should complete — tool error sent back to Claude as tool_result
+      expect(result.response).toBe("Email failed but I handled it.");
+      expect(result.toolCalls).toBe(1);
+      expect(result.turns).toBe(2);
+    });
+
+    it("handles timeout during multi-turn execution", async () => {
+      let callCount = 0;
+      const mockClaude = vi.fn(async () => {
+        callCount++;
+        // First call: use a tool (takes time)
+        if (callCount === 1) {
+          return makeToolUseResponse([
+            { name: "search_contacts", input: { query: "test" } },
+          ]);
+        }
+        // Second call would happen after timeout
+        return makeTextResponse("Should not reach here");
+      });
+
+      const slowExecute = vi.fn(async () => {
+        // Tool execution takes longer than the timeout budget
+        await new Promise((r) => setTimeout(r, 100));
+        return { result: "{}", isError: false };
+      });
+
+      const result = await runAgentLoop(
+        "Do something",
+        AGENT_OPENCLAW.capabilities,
+        MOCK_TOOLS,
+        mockClaude,
+        slowExecute,
+        50, // Short timeout — tool execution will push us past it
+      );
+
+      // After the slow tool execute, the loop should detect timeout on next iteration
+      expect(result.response).toBe("Execution timed out.");
+      expect(result.toolCalls).toBe(1);
+    });
+  });
+});

--- a/tests/agent-platform/schema-validation.test.ts
+++ b/tests/agent-platform/schema-validation.test.ts
@@ -9,14 +9,14 @@
  *
  * Issue: #183
  */
-import { describe, it, expect } from 'vitest'
-import * as fs from 'fs'
-import * as path from 'path'
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
 
 // ─── Migration SQL Parser ─────────────────────────────────────────
 
-const MIGRATIONS_DIR = path.resolve(__dirname, '../../supabase/migrations')
-const EDGE_FUNCTIONS_DIR = path.resolve(__dirname, '../../supabase/functions')
+const MIGRATIONS_DIR = path.resolve(__dirname, "../../supabase/migrations");
+const EDGE_FUNCTIONS_DIR = path.resolve(__dirname, "../../supabase/functions");
 
 /**
  * Parse CREATE TABLE columns from SQL migration files.
@@ -26,41 +26,43 @@ function parseTableColumns(sql: string, tableName: string): string[] {
   // Match CREATE TABLE <name> (...) with potential IF NOT EXISTS
   const tableRegex = new RegExp(
     `CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${tableName}\\s*\\(([^;]+?)\\)\\s*(?:PARTITION|;)`,
-    'is'
-  )
-  const match = sql.match(tableRegex)
-  if (!match) return []
+    "is",
+  );
+  const match = sql.match(tableRegex);
+  if (!match) return [];
 
-  const body = match[1]
-  const columns: string[] = []
+  const body = match[1];
+  const columns: string[] = [];
 
   // Split by top-level commas (not inside parentheses)
-  let depth = 0
-  let current = ''
+  let depth = 0;
+  let current = "";
   for (const char of body) {
-    if (char === '(') depth++
-    else if (char === ')') depth--
-    else if (char === ',' && depth === 0) {
-      columns.push(current.trim())
-      current = ''
-      continue
+    if (char === "(") depth++;
+    else if (char === ")") depth--;
+    else if (char === "," && depth === 0) {
+      columns.push(current.trim());
+      current = "";
+      continue;
     }
-    current += char
+    current += char;
   }
-  if (current.trim()) columns.push(current.trim())
+  if (current.trim()) columns.push(current.trim());
 
   // Extract column names (skip constraints like PRIMARY KEY, CHECK, UNIQUE, FOREIGN KEY)
   return columns
     .map((col) => {
-      const trimmed = col.trim()
-      if (/^(PRIMARY\s+KEY|CHECK|UNIQUE|FOREIGN\s+KEY|CONSTRAINT)/i.test(trimmed)) {
-        return null
+      const trimmed = col.trim();
+      if (
+        /^(PRIMARY\s+KEY|CHECK|UNIQUE|FOREIGN\s+KEY|CONSTRAINT)/i.test(trimmed)
+      ) {
+        return null;
       }
       // Column name is the first word
-      const colMatch = trimmed.match(/^(\w+)\s+/)
-      return colMatch ? colMatch[1] : null
+      const colMatch = trimmed.match(/^(\w+)\s+/);
+      return colMatch ? colMatch[1] : null;
     })
-    .filter((col): col is string => col !== null)
+    .filter((col): col is string => col !== null);
 }
 
 /**
@@ -69,58 +71,60 @@ function parseTableColumns(sql: string, tableName: string): string[] {
 function parseAlterTableColumns(sql: string, tableName: string): string[] {
   const regex = new RegExp(
     `ALTER\\s+TABLE\\s+${tableName}\\s+ADD\\s+COLUMN\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?(\\w+)`,
-    'gi'
-  )
-  const columns: string[] = []
-  let match
+    "gi",
+  );
+  const columns: string[] = [];
+  let match;
   while ((match = regex.exec(sql)) !== null) {
-    columns.push(match[1])
+    columns.push(match[1]);
   }
-  return columns
+  return columns;
 }
 
 /**
  * Parse RPC function names and their parameter names from CREATE FUNCTION statements
  */
 function parseRpcFunctions(sql: string): Map<string, string[]> {
-  const functions = new Map<string, string[]>()
-  const funcRegex = /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(\w+)\s*\(([^)]*)\)/gi
-  let match
+  const functions = new Map<string, string[]>();
+  const funcRegex =
+    /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+(\w+)\s*\(([^)]*)\)/gi;
+  let match;
   while ((match = funcRegex.exec(sql)) !== null) {
-    const name = match[1]
-    const paramsStr = match[2].trim()
+    const name = match[1];
+    const paramsStr = match[2].trim();
     if (!paramsStr) {
-      functions.set(name, [])
-      continue
+      functions.set(name, []);
+      continue;
     }
-    const params = paramsStr.split(',').map((p) => {
-      const parts = p.trim().split(/\s+/)
-      return parts[0] // parameter name
-    })
-    functions.set(name, params)
+    const params = paramsStr.split(",").map((p) => {
+      const parts = p.trim().split(/\s+/);
+      return parts[0]; // parameter name
+    });
+    functions.set(name, params);
   }
-  return functions
+  return functions;
 }
 
 /**
  * Load all migration SQL concatenated
  */
 function loadAllMigrations(): string {
-  const files = fs.readdirSync(MIGRATIONS_DIR)
-    .filter((f) => f.endsWith('.sql'))
-    .sort()
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
   return files
-    .map((f) => fs.readFileSync(path.join(MIGRATIONS_DIR, f), 'utf-8'))
-    .join('\n')
+    .map((f) => fs.readFileSync(path.join(MIGRATIONS_DIR, f), "utf-8"))
+    .join("\n");
 }
 
 /**
  * Get all columns for a table (from CREATE TABLE + ALTER TABLE ADD COLUMN)
  */
 function getTableColumns(allSql: string, tableName: string): string[] {
-  const createCols = parseTableColumns(allSql, tableName)
-  const alterCols = parseAlterTableColumns(allSql, tableName)
-  return [...new Set([...createCols, ...alterCols])]
+  const createCols = parseTableColumns(allSql, tableName);
+  const alterCols = parseAlterTableColumns(allSql, tableName);
+  return [...new Set([...createCols, ...alterCols])];
 }
 
 /**
@@ -129,211 +133,281 @@ function getTableColumns(allSql: string, tableName: string): string[] {
  * Works with multiline chains.
  */
 function extractCodeColumnReferences(
-  functionDir: string
+  functionDir: string,
 ): { table: string; columns: string[]; file: string; line: number }[] {
-  const refs: { table: string; columns: string[]; file: string; line: number }[] = []
+  const refs: {
+    table: string;
+    columns: string[];
+    file: string;
+    line: number;
+  }[] = [];
 
   function scanDir(dir: string) {
-    if (!fs.existsSync(dir)) return
-    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    if (!fs.existsSync(dir)) return;
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name)
+      const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        scanDir(fullPath)
-      } else if (entry.name.endsWith('.ts')) {
-        const content = fs.readFileSync(fullPath, 'utf-8')
+        scanDir(fullPath);
+      } else if (entry.name.endsWith(".ts")) {
+        const content = fs.readFileSync(fullPath, "utf-8");
 
         // Find line number for a character offset
         const getLineNumber = (offset: number): number => {
-          return content.substring(0, offset).split('\n').length
-        }
+          return content.substring(0, offset).split("\n").length;
+        };
 
         // Match .from('tableName') followed by .select('columns') without crossing another .from()
-        const fromSelectRegex = /\.from\(['"](\w+)['"]\)(?:(?!\.from\()[\s\S]){0,500}?\.select\(['"]([^'"]+)['"]\)/g
-        let match
+        const fromSelectRegex =
+          /\.from\(['"](\w+)['"]\)(?:(?!\.from\()[\s\S]){0,500}?\.select\(['"]([^'"]+)['"]\)/g;
+        let match;
         while ((match = fromSelectRegex.exec(content)) !== null) {
-          const table = match[1]
+          const table = match[1];
           const columns = match[2]
-            .split(',')
+            .split(",")
             .map((c) => c.trim().split(/\s+/)[0])
-            .filter((c) => c && !c.includes('(') && !c.includes('*') && !c.includes('.'))
+            .filter(
+              (c) =>
+                c && !c.includes("(") && !c.includes("*") && !c.includes("."),
+            );
           if (columns.length > 0) {
-            refs.push({ table, columns, file: fullPath, line: getLineNumber(match.index) })
+            refs.push({
+              table,
+              columns,
+              file: fullPath,
+              line: getLineNumber(match.index),
+            });
           }
         }
 
         // Match .from('tableName') followed by .insert({...}) without crossing another .from()
-        const fromInsertRegex = /\.from\(['"](\w+)['"]\)(?:(?!\.from\()[\s\S]){0,500}?\.insert\(\{([^}]+)\}/g
+        const fromInsertRegex =
+          /\.from\(['"](\w+)['"]\)(?:(?!\.from\()[\s\S]){0,500}?\.insert\(\{([^}]+)\}/g;
         while ((match = fromInsertRegex.exec(content)) !== null) {
-          const table = match[1]
+          const table = match[1];
           const columns = match[2]
-            .split(',')
+            .split(",")
             .map((pair) => pair.trim().split(/\s*:/)[0].trim())
-            .filter((c) => c && /^\w+$/.test(c))
+            .filter((c) => c && /^\w+$/.test(c));
           if (columns.length > 0) {
-            refs.push({ table, columns, file: fullPath, line: getLineNumber(match.index) })
+            refs.push({
+              table,
+              columns,
+              file: fullPath,
+              line: getLineNumber(match.index),
+            });
           }
         }
 
         // Match .from('tableName') followed by .update({...}) without crossing another .from()
-        const fromUpdateRegex = /\.from\(['"](\w+)['"]\)(?:(?!\.from\()[\s\S]){0,500}?\.update\(\{([^}]+)\}/g
+        const fromUpdateRegex =
+          /\.from\(['"](\w+)['"]\)(?:(?!\.from\()[\s\S]){0,500}?\.update\(\{([^}]+)\}/g;
         while ((match = fromUpdateRegex.exec(content)) !== null) {
-          const table = match[1]
+          const table = match[1];
           const columns = match[2]
-            .split(',')
+            .split(",")
             .map((pair) => pair.trim().split(/\s*:/)[0].trim())
-            .filter((c) => c && /^\w+$/.test(c))
+            .filter((c) => c && /^\w+$/.test(c));
           if (columns.length > 0) {
-            refs.push({ table, columns, file: fullPath, line: getLineNumber(match.index) })
+            refs.push({
+              table,
+              columns,
+              file: fullPath,
+              line: getLineNumber(match.index),
+            });
           }
         }
       }
     }
   }
 
-  scanDir(functionDir)
-  return refs
+  scanDir(functionDir);
+  return refs;
 }
 
 // ─── Tests ─────────────────────────────────────────────────────────
 
-describe('Schema Validation: Migration SQL vs Code', () => {
-  const allSql = loadAllMigrations()
+describe("Schema Validation: Migration SQL vs Code", () => {
+  const allSql = loadAllMigrations();
 
   // Build schema map from migrations
   const KNOWN_TABLES = [
-    'agents', 'workflows', 'workflow_runs', 'integrations',
-    'integration_credentials', 'agent_integrations', 'audit_log',
-    'capability_definitions', 'agent_skills', 'event_types',
-    'event_subscriptions', 'events', 'rate_limit_buckets',
-    'agent_commands', 'agent_responses', 'agent_tasks', 'agent_task_runs',
-  ]
+    "agents",
+    "workflows",
+    "workflow_runs",
+    "integrations",
+    "integration_credentials",
+    "agent_integrations",
+    "audit_log",
+    "capability_definitions",
+    "agent_skills",
+    "event_types",
+    "event_subscriptions",
+    "events",
+    "rate_limit_buckets",
+    "agent_commands",
+    "agent_responses",
+    "agent_tasks",
+    "agent_task_runs",
+    "tool_definitions",
+  ];
 
-  const schemaMap = new Map<string, string[]>()
+  const schemaMap = new Map<string, string[]>();
   for (const table of KNOWN_TABLES) {
-    const cols = getTableColumns(allSql, table)
+    const cols = getTableColumns(allSql, table);
     if (cols.length > 0) {
-      schemaMap.set(table, cols)
+      schemaMap.set(table, cols);
     }
   }
 
-  it('should parse all expected tables from migrations', () => {
-    const parsedTables = Array.from(schemaMap.keys())
+  it("should parse all expected tables from migrations", () => {
+    const parsedTables = Array.from(schemaMap.keys());
     // At minimum these core tables must be found
-    expect(parsedTables).toContain('agents')
-    expect(parsedTables).toContain('workflows')
-    expect(parsedTables).toContain('workflow_runs')
-    expect(parsedTables).toContain('integrations')
-    expect(parsedTables).toContain('integration_credentials')
-    expect(parsedTables).toContain('audit_log')
-  })
+    expect(parsedTables).toContain("agents");
+    expect(parsedTables).toContain("workflows");
+    expect(parsedTables).toContain("workflow_runs");
+    expect(parsedTables).toContain("integrations");
+    expect(parsedTables).toContain("integration_credentials");
+    expect(parsedTables).toContain("audit_log");
+  });
 
-  describe('agents table', () => {
-    it('should have expected columns', () => {
-      const cols = schemaMap.get('agents')!
-      expect(cols).toContain('id')
-      expect(cols).toContain('name')
-      expect(cols).toContain('type')
-      expect(cols).toContain('status')
-      expect(cols).toContain('capabilities')
-      expect(cols).toContain('api_key_hash')
-      expect(cols).toContain('rate_limit_rpm')
-      expect(cols).toContain('metadata')
-      expect(cols).toContain('last_seen_at')
-      expect(cols).toContain('created_at')
-      expect(cols).toContain('updated_at')
+  describe("agents table", () => {
+    it("should have expected columns", () => {
+      const cols = schemaMap.get("agents")!;
+      expect(cols).toContain("id");
+      expect(cols).toContain("name");
+      expect(cols).toContain("type");
+      expect(cols).toContain("status");
+      expect(cols).toContain("capabilities");
+      expect(cols).toContain("api_key_hash");
+      expect(cols).toContain("rate_limit_rpm");
+      expect(cols).toContain("metadata");
+      expect(cols).toContain("last_seen_at");
+      expect(cols).toContain("created_at");
+      expect(cols).toContain("updated_at");
       // Phase 4 addition
-      expect(cols).toContain('signing_secret_encrypted')
-    })
-  })
+      expect(cols).toContain("signing_secret_encrypted");
+    });
+  });
 
-  describe('integration_credentials table', () => {
-    it('should have expected columns', () => {
-      const cols = schemaMap.get('integration_credentials')!
-      expect(cols).toContain('id')
-      expect(cols).toContain('integration_id')
-      expect(cols).toContain('agent_id')
-      expect(cols).toContain('credential_type')
-      expect(cols).toContain('encrypted_data')
-      expect(cols).toContain('encryption_key_id')
-      expect(cols).toContain('expires_at')
-      expect(cols).toContain('last_used_at')
-      expect(cols).toContain('created_at')
-      expect(cols).toContain('updated_at')
-    })
-  })
+  describe("integration_credentials table", () => {
+    it("should have expected columns", () => {
+      const cols = schemaMap.get("integration_credentials")!;
+      expect(cols).toContain("id");
+      expect(cols).toContain("integration_id");
+      expect(cols).toContain("agent_id");
+      expect(cols).toContain("credential_type");
+      expect(cols).toContain("encrypted_data");
+      expect(cols).toContain("encryption_key_id");
+      expect(cols).toContain("expires_at");
+      expect(cols).toContain("last_used_at");
+      expect(cols).toContain("created_at");
+      expect(cols).toContain("updated_at");
+    });
+  });
 
-  describe('workflows table', () => {
-    it('should have expected columns', () => {
-      const cols = schemaMap.get('workflows')!
-      expect(cols).toContain('id')
-      expect(cols).toContain('name')
-      expect(cols).toContain('trigger_type')
-      expect(cols).toContain('trigger_config')
-      expect(cols).toContain('steps')
-      expect(cols).toContain('is_active')
-      expect(cols).toContain('created_by')
-    })
-  })
+  describe("workflows table", () => {
+    it("should have expected columns", () => {
+      const cols = schemaMap.get("workflows")!;
+      expect(cols).toContain("id");
+      expect(cols).toContain("name");
+      expect(cols).toContain("trigger_type");
+      expect(cols).toContain("trigger_config");
+      expect(cols).toContain("steps");
+      expect(cols).toContain("is_active");
+      expect(cols).toContain("created_by");
+    });
+  });
 
-  describe('Mock fixture column names match schema', () => {
-    it('AGENT fixtures should only use valid agents columns', () => {
-      const validCols = new Set(schemaMap.get('agents') || [])
+  describe("Mock fixture column names match schema", () => {
+    it("AGENT fixtures should only use valid agents columns", () => {
+      const validCols = new Set(schemaMap.get("agents") || []);
       const fixtureKeys = Object.keys({
         // Reproduce the fixture shape
-        id: '', name: '', type: '', status: '',
-        capabilities: [], rate_limit_rpm: 0, metadata: {},
-        last_seen_at: null, created_at: '', updated_at: '',
-      })
+        id: "",
+        name: "",
+        type: "",
+        status: "",
+        capabilities: [],
+        rate_limit_rpm: 0,
+        metadata: {},
+        last_seen_at: null,
+        created_at: "",
+        updated_at: "",
+      });
       for (const key of fixtureKeys) {
-        expect(validCols.has(key), `agents fixture key "${key}" not in schema`).toBe(true)
+        expect(
+          validCols.has(key),
+          `agents fixture key "${key}" not in schema`,
+        ).toBe(true);
       }
-    })
+    });
 
-    it('MOCK_CREDENTIAL fixture should only use valid integration_credentials columns', () => {
-      const validCols = new Set(schemaMap.get('integration_credentials') || [])
+    it("MOCK_CREDENTIAL fixture should only use valid integration_credentials columns", () => {
+      const validCols = new Set(schemaMap.get("integration_credentials") || []);
       const fixtureKeys = [
-        'id', 'integration_id', 'agent_id', 'credential_type',
-        'encrypted_data', 'encryption_key_id', 'expires_at',
-        'last_used_at', 'created_at', 'updated_at',
-      ]
+        "id",
+        "integration_id",
+        "agent_id",
+        "credential_type",
+        "encrypted_data",
+        "encryption_key_id",
+        "expires_at",
+        "last_used_at",
+        "created_at",
+        "updated_at",
+      ];
       for (const key of fixtureKeys) {
-        expect(validCols.has(key), `integration_credentials fixture key "${key}" not in schema`).toBe(true)
+        expect(
+          validCols.has(key),
+          `integration_credentials fixture key "${key}" not in schema`,
+        ).toBe(true);
       }
-    })
+    });
 
-    it('WORKFLOW fixtures should only use valid workflows columns', () => {
-      const validCols = new Set(schemaMap.get('workflows') || [])
+    it("WORKFLOW fixtures should only use valid workflows columns", () => {
+      const validCols = new Set(schemaMap.get("workflows") || []);
       const fixtureKeys = [
-        'id', 'name', 'description', 'trigger_type', 'trigger_config',
-        'is_active', 'steps', 'created_by', 'created_at', 'updated_at',
-      ]
+        "id",
+        "name",
+        "description",
+        "trigger_type",
+        "trigger_config",
+        "is_active",
+        "steps",
+        "created_by",
+        "created_at",
+        "updated_at",
+      ];
       for (const key of fixtureKeys) {
-        expect(validCols.has(key), `workflows fixture key "${key}" not in schema`).toBe(true)
+        expect(
+          validCols.has(key),
+          `workflows fixture key "${key}" not in schema`,
+        ).toBe(true);
       }
-    })
-  })
+    });
+  });
 
-  describe('Edge function code references valid columns', () => {
-    const codeRefs = extractCodeColumnReferences(EDGE_FUNCTIONS_DIR)
+  describe("Edge function code references valid columns", () => {
+    const codeRefs = extractCodeColumnReferences(EDGE_FUNCTIONS_DIR);
 
-    it('should find column references in edge functions', () => {
-      expect(codeRefs.length).toBeGreaterThan(0)
-    })
+    it("should find column references in edge functions", () => {
+      expect(codeRefs.length).toBeGreaterThan(0);
+    });
 
-    it('all .select() column references should exist in their table schema', () => {
-      const errors: string[] = []
+    it("all .select() column references should exist in their table schema", () => {
+      const errors: string[] = [];
 
       for (const ref of codeRefs) {
-        const tableCols = schemaMap.get(ref.table)
-        if (!tableCols) continue // Skip tables we don't have schema for
+        const tableCols = schemaMap.get(ref.table);
+        if (!tableCols) continue; // Skip tables we don't have schema for
 
         for (const col of ref.columns) {
           if (!tableCols.includes(col)) {
             errors.push(
               `${path.basename(ref.file)}:${ref.line} references "${ref.table}.${col}" but column doesn't exist. ` +
-              `Valid columns: [${tableCols.join(', ')}]`
-            )
+                `Valid columns: [${tableCols.join(", ")}]`,
+            );
           }
         }
       }
@@ -341,44 +415,44 @@ describe('Schema Validation: Migration SQL vs Code', () => {
       if (errors.length > 0) {
         throw new Error(
           `Found ${errors.length} invalid column reference(s):\n` +
-          errors.map((e) => `  - ${e}`).join('\n')
-        )
+            errors.map((e) => `  - ${e}`).join("\n"),
+        );
       }
-    })
-  })
+    });
+  });
 
-  describe('RPC function signatures', () => {
-    const rpcFunctions = parseRpcFunctions(allSql)
+  describe("RPC function signatures", () => {
+    const rpcFunctions = parseRpcFunctions(allSql);
 
-    it('should find expected RPC functions in migrations', () => {
-      expect(rpcFunctions.has('verify_agent_api_key')).toBe(true)
-      expect(rpcFunctions.has('log_audit_event')).toBe(true)
-      expect(rpcFunctions.has('check_rate_limit')).toBe(true)
-    })
+    it("should find expected RPC functions in migrations", () => {
+      expect(rpcFunctions.has("verify_agent_api_key")).toBe(true);
+      expect(rpcFunctions.has("log_audit_event")).toBe(true);
+      expect(rpcFunctions.has("check_rate_limit")).toBe(true);
+    });
 
-    it('verify_agent_api_key should accept p_api_key parameter', () => {
-      const params = rpcFunctions.get('verify_agent_api_key')
-      expect(params).toBeDefined()
-      expect(params).toContain('p_api_key')
-    })
+    it("verify_agent_api_key should accept p_api_key parameter", () => {
+      const params = rpcFunctions.get("verify_agent_api_key");
+      expect(params).toBeDefined();
+      expect(params).toContain("p_api_key");
+    });
 
-    it('log_audit_event should accept expected parameters', () => {
-      const params = rpcFunctions.get('log_audit_event')
-      expect(params).toBeDefined()
-      expect(params).toContain('p_actor_type')
-      expect(params).toContain('p_actor_id')
-      expect(params).toContain('p_action')
-      expect(params).toContain('p_resource_type')
-      expect(params).toContain('p_resource_id')
-      expect(params).toContain('p_details')
-    })
+    it("log_audit_event should accept expected parameters", () => {
+      const params = rpcFunctions.get("log_audit_event");
+      expect(params).toBeDefined();
+      expect(params).toContain("p_actor_type");
+      expect(params).toContain("p_actor_id");
+      expect(params).toContain("p_action");
+      expect(params).toContain("p_resource_type");
+      expect(params).toContain("p_resource_id");
+      expect(params).toContain("p_details");
+    });
 
-    it('check_rate_limit should accept expected parameters', () => {
-      const params = rpcFunctions.get('check_rate_limit')
-      expect(params).toBeDefined()
-      expect(params).toContain('p_key')
-      expect(params).toContain('p_window_ms')
-      expect(params).toContain('p_max_requests')
-    })
-  })
-})
+    it("check_rate_limit should accept expected parameters", () => {
+      const params = rpcFunctions.get("check_rate_limit");
+      expect(params).toBeDefined();
+      expect(params).toContain("p_key");
+      expect(params).toContain("p_window_ms");
+      expect(params).toContain("p_max_requests");
+    });
+  });
+});

--- a/tests/agent-platform/workflows.test.ts
+++ b/tests/agent-platform/workflows.test.ts
@@ -6,8 +6,12 @@
  * - Failure handling (continue vs stop)
  * - Step timeout handling
  * - Retry with exponential backoff
+ * - Agent command dispatch to agent-executor (#266)
+ * - Integration action polling to completion (#266)
+ * - Polling timeout behavior
+ * - Command failure propagation
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   createMockSupabaseClient,
   AGENT_OPENCLAW,
@@ -15,244 +19,530 @@ import {
   WORKFLOW_WITH_FAILURE,
   WORKFLOW_WITH_STOP,
   WORKFLOW_WITH_TIMEOUT,
-} from './fixtures'
+} from "./fixtures";
 
 // ─── Inline step execution logic from workflow-executor ─────────────
 
 interface WorkflowStep {
-  id: string
-  type: 'agent_command' | 'wait' | 'condition'
-  config: Record<string, unknown>
-  timeout_ms?: number
-  retries?: number
-  on_failure?: 'continue' | 'stop' | 'skip'
+  id: string;
+  type: "agent_command" | "wait" | "condition" | "integration_action";
+  config: Record<string, unknown>;
+  timeout_ms?: number;
+  retries?: number;
+  on_failure?: "continue" | "stop" | "skip";
 }
 
 interface StepResult {
-  step_id: string
-  status: 'completed' | 'failed' | 'skipped'
-  output?: unknown
-  error?: string
-  duration_ms: number
+  step_id: string;
+  status: "completed" | "failed" | "skipped";
+  output?: unknown;
+  error?: string;
+  duration_ms: number;
+}
+
+interface PollResult {
+  status: "completed" | "failed" | "cancelled" | "timeout";
+  output?: unknown;
+  error?: string;
 }
 
 function evaluateCondition(expression: string, results: StepResult[]): boolean {
-  const resultMap = new Map(results.map((r) => [r.step_id, r]))
-  const match = expression.match(/^(\w+)\.(status|output)\s*(==|!=)\s*(\w+)$/)
+  const resultMap = new Map(results.map((r) => [r.step_id, r]));
+  const match = expression.match(/^(\w+)\.(status|output)\s*(==|!=)\s*(\w+)$/);
   if (!match) {
-    return resultMap.has(expression) && resultMap.get(expression)!.status === 'completed'
+    return (
+      resultMap.has(expression) &&
+      resultMap.get(expression)!.status === "completed"
+    );
   }
-  const [, stepId, field, op, value] = match
-  const stepResult = resultMap.get(stepId)
-  if (!stepResult) return false
-  const actual = field === 'status' ? stepResult.status : String(stepResult.output)
-  return op === '==' ? actual === value : actual !== value
+  const [, stepId, field, op, value] = match;
+  const stepResult = resultMap.get(stepId);
+  if (!stepResult) return false;
+  const actual =
+    field === "status" ? stepResult.status : String(stepResult.output);
+  return op === "==" ? actual === value : actual !== value;
 }
 
 async function executeStep(
   step: WorkflowStep,
   previousResults: StepResult[],
-  insertFn: (cmd: string, payload: unknown) => Promise<{ id: string } | null>
+  dispatchFn: (cmd: string, payload: unknown) => Promise<{ id: string } | null>,
+  agentExecutorFn?: (
+    command: string,
+    agentId: string,
+  ) => Promise<Record<string, unknown>>,
+  pollFn?: (commandId: string, timeoutMs: number) => Promise<PollResult>,
 ): Promise<StepResult> {
-  const start = Date.now()
-  const timeoutMs = step.timeout_ms || 30000
-  const maxRetries = step.retries || 0
+  const start = Date.now();
+  const timeoutMs = step.timeout_ms || 30000;
+  const maxRetries = step.retries || 0;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       const result = await Promise.race<unknown>([
-        executeStepInner(step, previousResults, insertFn),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('Step timed out')), timeoutMs)
+        executeStepInner(
+          step,
+          previousResults,
+          dispatchFn,
+          agentExecutorFn,
+          pollFn,
         ),
-      ])
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("Step timed out")), timeoutMs),
+        ),
+      ]);
       return {
         step_id: step.id,
-        status: 'completed',
+        status: "completed",
         output: result,
         duration_ms: Date.now() - start,
-      }
+      };
     } catch (error) {
       if (attempt === maxRetries) {
         return {
           step_id: step.id,
-          status: 'failed',
+          status: "failed",
           error: (error as Error).message,
           duration_ms: Date.now() - start,
-        }
+        };
       }
       // Exponential backoff (very short for tests)
-      await new Promise((r) => setTimeout(r, 10 * Math.pow(2, attempt)))
+      await new Promise((r) => setTimeout(r, 10 * Math.pow(2, attempt)));
     }
   }
 
-  return { step_id: step.id, status: 'failed', error: 'Unreachable', duration_ms: Date.now() - start }
+  return {
+    step_id: step.id,
+    status: "failed",
+    error: "Unreachable",
+    duration_ms: Date.now() - start,
+  };
 }
 
 async function executeStepInner(
   step: WorkflowStep,
   previousResults: StepResult[],
-  insertFn: (cmd: string, payload: unknown) => Promise<{ id: string } | null>
+  dispatchFn: (cmd: string, payload: unknown) => Promise<{ id: string } | null>,
+  agentExecutorFn?: (
+    command: string,
+    agentId: string,
+  ) => Promise<Record<string, unknown>>,
+  pollFn?: (commandId: string, timeoutMs: number) => Promise<PollResult>,
 ): Promise<unknown> {
   switch (step.type) {
-    case 'agent_command': {
-      const { command, payload } = step.config as { command: string; payload?: unknown }
-      if (!command) throw new Error('agent_command step requires "command" in config')
-      const result = await insertFn(command, payload || {})
-      if (!result) throw new Error('Failed to dispatch command')
-      return { command_id: result.id, command }
-    }
-    case 'wait': {
-      const delayMs = Math.min((step.config.delay_ms as number) || 1000, 25000)
-      await new Promise((r) => setTimeout(r, delayMs))
-      return { waited_ms: delayMs }
-    }
-    case 'condition': {
-      const { expression, then_step, else_step } = step.config as {
-        expression: string; then_step?: string; else_step?: string
+    case "agent_command": {
+      // Dispatch to agent-executor (#266, #268)
+      const { command, payload, target_agent_id } = step.config as {
+        command: string;
+        payload?: unknown;
+        target_agent_id?: string;
+      };
+      if (!command)
+        throw new Error('agent_command step requires "command" in config');
+
+      if (agentExecutorFn) {
+        const content =
+          typeof payload === "string" ? payload : JSON.stringify(payload || {});
+        const data = await agentExecutorFn(
+          `${command}: ${content}`,
+          target_agent_id || "system",
+        );
+        return {
+          command,
+          response: data.response,
+          tool_calls: data.tool_calls,
+        };
       }
-      if (!expression) throw new Error('condition step requires "expression"')
-      const result = evaluateCondition(expression, previousResults)
-      return { condition_met: result, next_step: result ? then_step : else_step }
+
+      // Fallback: legacy insert-based dispatch
+      const result = await dispatchFn(command, payload || {});
+      if (!result) throw new Error("Failed to dispatch command");
+      return { command_id: result.id, command };
+    }
+    case "wait": {
+      const delayMs = Math.min((step.config.delay_ms as number) || 1000, 25000);
+      await new Promise((r) => setTimeout(r, delayMs));
+      return { waited_ms: delayMs };
+    }
+    case "condition": {
+      const { expression, then_step, else_step } = step.config as {
+        expression: string;
+        then_step?: string;
+        else_step?: string;
+      };
+      if (!expression) throw new Error('condition step requires "expression"');
+      const result = evaluateCondition(expression, previousResults);
+      return {
+        condition_met: result,
+        next_step: result ? then_step : else_step,
+      };
+    }
+    case "integration_action": {
+      const { action_name, parameters } = step.config as {
+        action_name?: string;
+        parameters?: Record<string, unknown>;
+      };
+      if (!action_name)
+        throw new Error(
+          'integration_action step requires "action_name" in config',
+        );
+
+      // Insert command
+      const result = await dispatchFn(action_name, parameters || {});
+      if (!result)
+        throw new Error(
+          `Failed to dispatch integration action: ${action_name}`,
+        );
+
+      // Poll for completion (#266)
+      if (pollFn) {
+        const timeoutMs = step.timeout_ms || 15000;
+        const pollResult = await pollFn(result.id, timeoutMs);
+
+        if (pollResult.status === "timeout") {
+          throw new Error(`Integration action timed out: ${action_name}`);
+        }
+        if (
+          pollResult.status === "failed" ||
+          pollResult.status === "cancelled"
+        ) {
+          throw new Error(
+            pollResult.error || `Integration action failed: ${action_name}`,
+          );
+        }
+
+        return {
+          command_id: result.id,
+          action_name,
+          status: pollResult.status,
+          output: pollResult.output,
+        };
+      }
+
+      return { command_id: result.id, action_name };
     }
     default:
-      throw new Error(`Unknown step type: ${step.type}`)
+      throw new Error(`Unknown step type: ${step.type}`);
   }
 }
 
-describe('Workflows', () => {
-  let supabase: ReturnType<typeof createMockSupabaseClient>
-  let commandInsertCount: number
+describe("Workflows", () => {
+  let supabase: ReturnType<typeof createMockSupabaseClient>;
+  let commandInsertCount: number;
 
   const mockInsert = async (cmd: string, payload: unknown) => {
-    commandInsertCount++
-    return { id: `cmd-${commandInsertCount}` }
-  }
+    commandInsertCount++;
+    return { id: `cmd-${commandInsertCount}` };
+  };
 
-  const failingInsert = async (_cmd: string, _payload: unknown): Promise<{ id: string } | null> => {
-    return null // Simulates a DB insert failure
-  }
+  const failingInsert = async (
+    _cmd: string,
+    _payload: unknown,
+  ): Promise<{ id: string } | null> => {
+    return null; // Simulates a DB insert failure
+  };
 
   beforeEach(() => {
-    supabase = createMockSupabaseClient()
-    commandInsertCount = 0
-  })
+    supabase = createMockSupabaseClient();
+    commandInsertCount = 0;
+  });
 
-  it('creates workflow with steps and records to DB', async () => {
-    supabase._setQueryResult({ id: WORKFLOW_SIMPLE.id })
+  it("creates workflow with steps and records to DB", async () => {
+    supabase._setQueryResult({ id: WORKFLOW_SIMPLE.id });
 
-    await supabase.from('workflows').insert({
-      name: WORKFLOW_SIMPLE.name,
-      trigger_type: WORKFLOW_SIMPLE.trigger_type,
-      steps: WORKFLOW_SIMPLE.steps,
-      is_active: true,
-    }).select('id').single()
+    await supabase
+      .from("workflows")
+      .insert({
+        name: WORKFLOW_SIMPLE.name,
+        trigger_type: WORKFLOW_SIMPLE.trigger_type,
+        steps: WORKFLOW_SIMPLE.steps,
+        is_active: true,
+      })
+      .select("id")
+      .single();
 
-    expect(supabase.from).toHaveBeenCalledWith('workflows')
-  })
+    expect(supabase.from).toHaveBeenCalledWith("workflows");
+  });
 
-  it('executes workflow steps to completion', async () => {
-    const steps = WORKFLOW_SIMPLE.steps as WorkflowStep[]
-    const results: StepResult[] = []
+  it("executes workflow steps to completion", async () => {
+    const steps = WORKFLOW_SIMPLE.steps as WorkflowStep[];
+    const results: StepResult[] = [];
 
     for (const step of steps) {
-      const result = await executeStep(step, results, mockInsert)
-      results.push(result)
+      const result = await executeStep(step, results, mockInsert);
+      results.push(result);
     }
 
-    expect(results).toHaveLength(2)
-    expect(results[0].status).toBe('completed')
-    expect(results[0].step_id).toBe('step-1')
-    expect((results[0].output as { command: string }).command).toBe('greet')
+    expect(results).toHaveLength(2);
+    expect(results[0].status).toBe("completed");
+    expect(results[0].step_id).toBe("step-1");
+    expect((results[0].output as { command: string }).command).toBe("greet");
 
-    expect(results[1].status).toBe('completed')
-    expect(results[1].step_id).toBe('step-2')
-  })
+    expect(results[1].status).toBe("completed");
+    expect(results[1].step_id).toBe("step-2");
+  });
 
-  it('on_failure=continue proceeds past failed step', async () => {
-    const steps = WORKFLOW_WITH_FAILURE.steps as WorkflowStep[]
-    const results: StepResult[] = []
+  it("on_failure=continue proceeds past failed step", async () => {
+    const steps = WORKFLOW_WITH_FAILURE.steps as WorkflowStep[];
+    const results: StepResult[] = [];
 
     for (const step of steps) {
-      const result = await executeStep(step, results, failingInsert)
-      results.push(result)
+      const result = await executeStep(step, results, failingInsert);
+      results.push(result);
 
-      if (result.status === 'failed') {
-        const onFailure = step.on_failure || 'stop'
-        if (onFailure === 'stop') break
+      if (result.status === "failed") {
+        const onFailure = step.on_failure || "stop";
+        if (onFailure === "stop") break;
         // 'continue' — keep going
       }
     }
 
     // Both steps should be executed
-    expect(results).toHaveLength(2)
-    expect(results[0].status).toBe('failed')
-    expect(results[0].error).toBe('Failed to dispatch command')
-    expect(results[1].status).toBe('completed') // wait step succeeds
-  })
+    expect(results).toHaveLength(2);
+    expect(results[0].status).toBe("failed");
+    expect(results[0].error).toBe("Failed to dispatch command");
+    expect(results[1].status).toBe("completed"); // wait step succeeds
+  });
 
-  it('on_failure=stop halts on failure', async () => {
-    const steps = WORKFLOW_WITH_STOP.steps as WorkflowStep[]
-    const results: StepResult[] = []
+  it("on_failure=stop halts on failure", async () => {
+    const steps = WORKFLOW_WITH_STOP.steps as WorkflowStep[];
+    const results: StepResult[] = [];
 
     for (const step of steps) {
-      const result = await executeStep(step, results, failingInsert)
-      results.push(result)
+      const result = await executeStep(step, results, failingInsert);
+      results.push(result);
 
-      if (result.status === 'failed') {
-        const onFailure = step.on_failure || 'stop'
-        if (onFailure === 'stop') break
+      if (result.status === "failed") {
+        const onFailure = step.on_failure || "stop";
+        if (onFailure === "stop") break;
       }
     }
 
     // Only the first step should run; second is never reached
-    expect(results).toHaveLength(1)
-    expect(results[0].status).toBe('failed')
-  })
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe("failed");
+  });
 
-  it('step timeout marks step as failed', async () => {
+  it("step timeout marks step as failed", async () => {
     const step: WorkflowStep = {
-      id: 'step-slow',
-      type: 'agent_command',
-      config: { command: 'slow_task' },
+      id: "step-slow",
+      type: "agent_command",
+      config: { command: "slow_task" },
       timeout_ms: 50,
-    }
+    };
 
     // Insert function that takes longer than the timeout
     const slowInsert = async () => {
-      await new Promise((r) => setTimeout(r, 200))
-      return { id: 'cmd-slow' }
-    }
+      await new Promise((r) => setTimeout(r, 200));
+      return { id: "cmd-slow" };
+    };
 
-    const result = await executeStep(step, [], slowInsert)
+    const result = await executeStep(step, [], slowInsert);
 
-    expect(result.status).toBe('failed')
-    expect(result.error).toBe('Step timed out')
-    expect(result.step_id).toBe('step-slow')
-  })
+    expect(result.status).toBe("failed");
+    expect(result.error).toBe("Step timed out");
+    expect(result.step_id).toBe("step-slow");
+  });
 
-  it('retries with exponential backoff', async () => {
-    let attemptCount = 0
+  it("retries with exponential backoff", async () => {
+    let attemptCount = 0;
     const flakyInsert = async () => {
-      attemptCount++
+      attemptCount++;
       if (attemptCount < 3) {
-        return null // Fail first 2 attempts
+        return null; // Fail first 2 attempts
       }
-      return { id: 'cmd-retry-success' }
-    }
+      return { id: "cmd-retry-success" };
+    };
 
     const step: WorkflowStep = {
-      id: 'step-retry',
-      type: 'agent_command',
-      config: { command: 'flaky_task' },
+      id: "step-retry",
+      type: "agent_command",
+      config: { command: "flaky_task" },
       timeout_ms: 5000,
       retries: 3,
-    }
+    };
 
-    const result = await executeStep(step, [], flakyInsert)
+    const result = await executeStep(step, [], flakyInsert);
 
-    expect(result.status).toBe('completed')
-    expect(attemptCount).toBe(3) // Failed twice, succeeded on third
-    expect((result.output as { command_id: string }).command_id).toBe('cmd-retry-success')
-  })
-})
+    expect(result.status).toBe("completed");
+    expect(attemptCount).toBe(3); // Failed twice, succeeded on third
+    expect((result.output as { command_id: string }).command_id).toBe(
+      "cmd-retry-success",
+    );
+  });
+
+  // ─── New tests for #266 / #268 ─────────────────────────────────────
+
+  describe("agent_command dispatch (#266)", () => {
+    it("dispatches to agent-executor and returns response", async () => {
+      const mockExecutor = vi.fn(async (command: string, agentId: string) => ({
+        response: "Task completed successfully",
+        tool_calls: 2,
+        turns: 1,
+      }));
+
+      const step: WorkflowStep = {
+        id: "step-agent",
+        type: "agent_command",
+        config: { command: "analyze_data", payload: { query: "sales" } },
+        timeout_ms: 5000,
+      };
+
+      const result = await executeStep(step, [], mockInsert, mockExecutor);
+
+      expect(result.status).toBe("completed");
+      expect(result.step_id).toBe("step-agent");
+      const output = result.output as {
+        command: string;
+        response: string;
+        tool_calls: number;
+      };
+      expect(output.command).toBe("analyze_data");
+      expect(output.response).toBe("Task completed successfully");
+      expect(output.tool_calls).toBe(2);
+
+      expect(mockExecutor).toHaveBeenCalledWith(
+        'analyze_data: {"query":"sales"}',
+        "system",
+      );
+    });
+
+    it("propagates agent-executor failures", async () => {
+      const failingExecutor = vi.fn(async () => {
+        throw new Error("Agent executor failed: API timeout");
+      });
+
+      const step: WorkflowStep = {
+        id: "step-fail-agent",
+        type: "agent_command",
+        config: { command: "failing_task" },
+        timeout_ms: 5000,
+      };
+
+      const result = await executeStep(step, [], mockInsert, failingExecutor);
+
+      expect(result.status).toBe("failed");
+      expect(result.error).toBe("Agent executor failed: API timeout");
+    });
+  });
+
+  describe("integration_action polling (#266)", () => {
+    it("polls integration_action to completion", async () => {
+      const mockPoll = vi.fn(
+        async (commandId: string, timeoutMs: number): Promise<PollResult> => ({
+          status: "completed",
+          output: { records_updated: 5 },
+        }),
+      );
+
+      const step: WorkflowStep = {
+        id: "step-integration",
+        type: "integration_action",
+        config: { action_name: "sync_contacts", parameters: { source: "crm" } },
+        timeout_ms: 10000,
+      };
+
+      const result = await executeStep(
+        step,
+        [],
+        mockInsert,
+        undefined,
+        mockPoll,
+      );
+
+      expect(result.status).toBe("completed");
+      const output = result.output as {
+        command_id: string;
+        action_name: string;
+        status: string;
+        output: unknown;
+      };
+      expect(output.action_name).toBe("sync_contacts");
+      expect(output.status).toBe("completed");
+      expect(output.output).toEqual({ records_updated: 5 });
+
+      expect(mockPoll).toHaveBeenCalledWith("cmd-1", 10000);
+    });
+
+    it("fails on polling timeout", async () => {
+      const mockPoll = vi.fn(
+        async (): Promise<PollResult> => ({
+          status: "timeout",
+          error: "Polling timed out after 10000ms",
+        }),
+      );
+
+      const step: WorkflowStep = {
+        id: "step-timeout",
+        type: "integration_action",
+        config: { action_name: "slow_action" },
+        timeout_ms: 10000,
+      };
+
+      const result = await executeStep(
+        step,
+        [],
+        mockInsert,
+        undefined,
+        mockPoll,
+      );
+
+      expect(result.status).toBe("failed");
+      expect(result.error).toBe("Integration action timed out: slow_action");
+    });
+
+    it("propagates command failure from polling", async () => {
+      const mockPoll = vi.fn(
+        async (): Promise<PollResult> => ({
+          status: "failed",
+          error: "External API returned 503",
+        }),
+      );
+
+      const step: WorkflowStep = {
+        id: "step-fail-poll",
+        type: "integration_action",
+        config: { action_name: "flaky_api_call" },
+        timeout_ms: 10000,
+      };
+
+      const result = await executeStep(
+        step,
+        [],
+        mockInsert,
+        undefined,
+        mockPoll,
+      );
+
+      expect(result.status).toBe("failed");
+      expect(result.error).toBe("External API returned 503");
+    });
+
+    it("propagates cancelled command from polling", async () => {
+      const mockPoll = vi.fn(
+        async (): Promise<PollResult> => ({
+          status: "cancelled",
+          error: "Command was cancelled",
+        }),
+      );
+
+      const step: WorkflowStep = {
+        id: "step-cancel-poll",
+        type: "integration_action",
+        config: { action_name: "cancelled_action" },
+        timeout_ms: 10000,
+      };
+
+      const result = await executeStep(
+        step,
+        [],
+        mockInsert,
+        undefined,
+        mockPoll,
+      );
+
+      expect(result.status).toBe("failed");
+      expect(result.error).toBe("Command was cancelled");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **New `agent-executor` edge function** — runs a Claude conversation loop (max 5 turns, 24s timeout) with capability-gated tools loaded from `tool_definitions` table. Routes tool calls through the API gateway.
- **Fix #266** — workflow `agent_command` steps now dispatch synchronously to `agent-executor` instead of fire-and-forget insert. `integration_action` steps poll `agent_commands` via new `pollCommandCompletion()` utility until terminal status.
- **Fix #268** — agents can now invoke skills via Claude tool-use. Tools are filtered by the agent's granted capabilities (`agent_skills` → `capability_definitions` → `tool_definitions`).
- **New shared utilities** — `command-polling.ts` (500ms poll, 24s cap) and `claude-client.ts` (Messages API wrapper with `tools[]` support).
- **New `tool_definitions` migration** — table + 15 seed tools mapped to existing capabilities and `ACTION_CAPABILITY_MAP` actions.
- **`ToolDefinitionSchema`** added to frontend Zod schemas for future admin UI.

## Test plan

- [x] All 65 agent-platform tests pass (`npx vitest tests/agent-platform/`)
- [x] All 157 tests pass across full suite (`npx vitest`)
- [ ] Deploy `agent-executor` edge function and verify end-to-end with a workflow containing `agent_command` steps
- [ ] Verify `integration_action` step polling returns actual result instead of fire-and-forget
- [ ] Verify capability-based tool filtering (agent only sees tools matching granted capabilities)
- [ ] Run `tool_definitions` migration against staging Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)