### PR TITLE
fix: supabase db push --include-all for out-of-order migrations

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -26,7 +26,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Push migrations
-        run: supabase db push
+        run: supabase db push --include-all
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}


### PR DESCRIPTION
## Summary
- Adds `--include-all` flag to `supabase db push` in the Database Migrations workflow
- Fixes CI failures when feature branches merge migrations out of timestamp order (which is normal with concurrent development)

## Root Cause
The `20260301000000_tool_definitions.sql` migration was merged after `20260302000001_blog_posts_tenant_id.sql` was already applied on the remote database, causing `supabase db push` to refuse the out-of-order file.

## Test plan
- [ ] Merge this PR and verify the Database Migrations workflow passes on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)