### PR TITLE
feat: add per-tenant email templates with white-label branding

### DIFF
--- a/src/lib/email-service.ts
+++ b/src/lib/email-service.ts
@@ -8,6 +8,17 @@
  */
 
 import { captureException } from "./sentry";
+import type { EmailBranding } from "./email-templates";
+import {
+  renderWelcomeEmail,
+  renderUnsubscribeEmail,
+  renderTestEmail,
+  renderNotificationEmail,
+  getTenantBranding,
+} from "./email-templates";
+
+// Re-export for convenience
+export { getTenantBranding };
 
 export type EmailProvider = "resend" | "sendgrid" | "console";
 
@@ -240,26 +251,59 @@ class EmailService {
 
   /**
    * Send a transactional email from a template
-   * @param templateId - Template ID to use
+   * @param templateId - Template ID (welcome, notification, unsubscribe, test)
    * @param to - Recipient email(s)
    * @param variables - Template variables
+   * @param branding - Optional tenant branding
    * @param options - Additional email options
    */
   async sendFromTemplate(
     templateId: string,
     to: string | string[],
     variables: Record<string, string>,
+    branding?: EmailBranding,
     options?: Partial<EmailOptions>,
   ): Promise<EmailResponse> {
-    // This would fetch the template from the database and render it
-    // For now, this is a placeholder - log params to satisfy linter
-    console.debug("sendFromTemplate called with:", {
-      templateId,
+    const defaultBranding: EmailBranding = {
+      brandName: import.meta.env.VITE_PLATFORM_NAME || "Business OS",
+      primaryColor: "#6366f1",
+      footerText: "Powered by Business OS",
+    };
+
+    const brand = branding || defaultBranding;
+    let rendered: { subject: string; html: string; text: string };
+
+    switch (templateId) {
+      case "welcome":
+        rendered = renderWelcomeEmail(brand, variables.name);
+        break;
+      case "notification":
+        rendered = renderNotificationEmail(
+          brand,
+          variables.title || "Notification",
+          variables.message || "",
+          variables.actionUrl,
+          variables.actionLabel,
+        );
+        break;
+      case "unsubscribe":
+        rendered = renderUnsubscribeEmail(brand, variables.resubscribeUrl);
+        break;
+      case "test":
+        rendered = renderTestEmail(brand, this.provider);
+        break;
+      default:
+        throw new Error(`Unknown template ID: ${templateId}`);
+    }
+
+    return this.send({
       to,
-      variables,
-      options,
+      from: brand.fromEmail || options?.from,
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+      ...options,
     });
-    throw new Error("Template rendering not implemented yet");
   }
 
   /**
@@ -324,50 +368,75 @@ class EmailService {
 // Singleton instance
 export const emailService = new EmailService();
 
+// Re-export EmailBranding for convenience
+export type { EmailBranding };
+
 // Helper functions for common email types
 export async function sendWelcomeEmail(
   to: string,
   firstName?: string,
+  branding?: EmailBranding,
 ): Promise<EmailResponse> {
-  const name = firstName || "there";
+  const defaultBranding: EmailBranding = {
+    brandName: import.meta.env.VITE_PLATFORM_NAME || "Business OS",
+    primaryColor: "#6366f1",
+    footerText: "Powered by Business OS",
+  };
+
+  const brand = branding || defaultBranding;
+  const rendered = renderWelcomeEmail(brand, firstName);
+
   return emailService.send({
     to,
-    subject: `Welcome to ${import.meta.env.VITE_PLATFORM_NAME || "Business OS"}!`,
-    html: `
-      <h1>Welcome ${name}!</h1>
-      <p>Thanks for subscribing to our newsletter.</p>
-      <p>You'll receive updates about new content, projects, and insights.</p>
-      <p>Best regards,<br>John</p>
-    `,
-    text: `Welcome ${name}!\n\nThanks for subscribing to our newsletter.\nYou'll receive updates about new content, projects, and insights.\n\nBest regards,\nJohn`,
+    from: brand.fromEmail,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
   });
 }
 
 export async function sendUnsubscribeConfirmation(
   to: string,
+  branding?: EmailBranding,
 ): Promise<EmailResponse> {
+  const defaultBranding: EmailBranding = {
+    brandName: import.meta.env.VITE_PLATFORM_NAME || "Business OS",
+    primaryColor: "#6366f1",
+    footerText: "Powered by Business OS",
+  };
+
+  const brand = branding || defaultBranding;
+  const resubscribeUrl = `${import.meta.env.VITE_SITE_URL}/subscribe`;
+  const rendered = renderUnsubscribeEmail(brand, resubscribeUrl);
+
   return emailService.send({
     to,
-    subject: "Unsubscribe Confirmation",
-    html: `
-      <h1>You've been unsubscribed</h1>
-      <p>We're sorry to see you go. You've been removed from our mailing list.</p>
-      <p>If this was a mistake, you can <a href="${import.meta.env.VITE_SITE_URL}/subscribe">re-subscribe here</a>.</p>
-    `,
-    text: `You've been unsubscribed\n\nWe're sorry to see you go. You've been removed from our mailing list.\n\nIf this was a mistake, you can re-subscribe at ${import.meta.env.VITE_SITE_URL}/subscribe`,
+    from: brand.fromEmail,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
   });
 }
 
-export async function sendTestEmail(to: string): Promise<EmailResponse> {
+export async function sendTestEmail(
+  to: string,
+  branding?: EmailBranding,
+): Promise<EmailResponse> {
+  const defaultBranding: EmailBranding = {
+    brandName: import.meta.env.VITE_PLATFORM_NAME || "Business OS",
+    primaryColor: "#6366f1",
+    footerText: "Powered by Business OS",
+  };
+
+  const brand = branding || defaultBranding;
+  const provider = emailService.getProviderInfo().provider;
+  const rendered = renderTestEmail(brand, provider);
+
   return emailService.send({
     to,
-    subject: `Test Email from ${import.meta.env.VITE_PLATFORM_NAME || "Business OS"}`,
-    html: `
-      <h1>Test Email</h1>
-      <p>This is a test email from the marketing system.</p>
-      <p>If you received this, your email configuration is working correctly!</p>
-      <p>Provider: <strong>${emailService.getProviderInfo().provider}</strong></p>
-    `,
-    text: `Test Email\n\nThis is a test email from the marketing system.\nIf you received this, your email configuration is working correctly!\n\nProvider: ${emailService.getProviderInfo().provider}`,
+    from: brand.fromEmail,
+    subject: rendered.subject,
+    html: rendered.html,
+    text: rendered.text,
   });
 }

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -1,0 +1,205 @@
+/**
+ * Email Template System for White-Label Support
+ * Issue: #317
+ *
+ * Provides tenant-aware email templates with customizable branding.
+ *
+ * @example Basic usage with default branding
+ * ```ts
+ * import { sendWelcomeEmail } from './email-service';
+ * await sendWelcomeEmail('user@example.com', 'John');
+ * ```
+ *
+ * @example With tenant branding
+ * ```ts
+ * import { sendWelcomeEmail, getTenantBranding } from './email-service';
+ * import { useTenantSettings } from '@/hooks/useTenantSettings';
+ *
+ * const { settings } = useTenantSettings();
+ * const branding = getTenantBranding(settings);
+ * await sendWelcomeEmail('user@example.com', 'John', branding);
+ * ```
+ *
+ * @example Using template system directly
+ * ```ts
+ * import { emailService } from './email-service';
+ * await emailService.sendFromTemplate(
+ *   'welcome',
+ *   'user@example.com',
+ *   { name: 'John' },
+ *   branding
+ * );
+ * ```
+ */
+
+import type { TenantSettings } from "./tenant-settings";
+
+export interface EmailBranding {
+  brandName: string;
+  logoUrl?: string;
+  primaryColor: string;
+  accentColor?: string;
+  footerText?: string;
+  fromEmail?: string;
+  fromName?: string;
+}
+
+const DEFAULT_BRANDING: EmailBranding = {
+  brandName: "Business OS",
+  primaryColor: "#6366f1",
+  footerText: "Powered by Business OS",
+};
+
+/**
+ * Convert tenant settings to email branding configuration
+ */
+export function getTenantBranding(
+  tenantSettings?: TenantSettings | null,
+): EmailBranding {
+  if (!tenantSettings) return DEFAULT_BRANDING;
+
+  return {
+    brandName: tenantSettings.branding.name || DEFAULT_BRANDING.brandName,
+    logoUrl: tenantSettings.branding.logo_url || undefined,
+    primaryColor:
+      tenantSettings.branding.primary_color || DEFAULT_BRANDING.primaryColor,
+    accentColor: tenantSettings.branding.accent_color || undefined,
+    footerText: DEFAULT_BRANDING.footerText,
+    fromEmail: tenantSettings.email.from_address || undefined,
+    fromName: tenantSettings.email.from_name || undefined,
+  };
+}
+
+/**
+ * Base email layout with tenant branding
+ * Responsive HTML email template with modern styling
+ */
+export function renderEmailLayout(
+  branding: EmailBranding,
+  body: string,
+): string {
+  const logo = branding.logoUrl
+    ? `<img src="${branding.logoUrl}" alt="${branding.brandName}" style="max-height:40px;margin-bottom:16px;" />`
+    : `<h2 style="color:${branding.primaryColor};margin:0 0 16px;">${branding.brandName}</h2>`;
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 16px;">
+    <tr><td align="center">
+      <table width="100%" style="max-width:560px;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+        <tr><td style="padding:32px 32px 0;">
+          ${logo}
+        </td></tr>
+        <tr><td style="padding:16px 32px 32px;color:#18181b;font-size:15px;line-height:1.6;">
+          ${body}
+        </td></tr>
+        <tr><td style="padding:16px 32px;border-top:1px solid #e4e4e7;color:#71717a;font-size:12px;text-align:center;">
+          ${branding.footerText || ""}
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}
+
+/**
+ * Welcome email template
+ * Sent when a user first signs up or subscribes
+ */
+export function renderWelcomeEmail(
+  branding: EmailBranding,
+  name?: string,
+): { subject: string; html: string; text: string } {
+  const displayName = name || "there";
+  return {
+    subject: `Welcome to ${branding.brandName}!`,
+    html: renderEmailLayout(
+      branding,
+      `
+      <h1 style="margin:0 0 8px;font-size:22px;color:#18181b;">Welcome, ${displayName}!</h1>
+      <p>Thanks for joining <strong>${branding.brandName}</strong>.</p>
+      <p>You're all set to get started. If you have any questions, just reply to this email.</p>
+      <p style="margin-top:24px;">Best regards,<br><strong>${branding.fromName || branding.brandName} Team</strong></p>
+    `,
+    ),
+    text: `Welcome, ${displayName}!\n\nThanks for joining ${branding.brandName}.\nYou're all set to get started.\n\nBest regards,\n${branding.fromName || branding.brandName} Team`,
+  };
+}
+
+/**
+ * Generic notification email template
+ * Used for various transactional notifications
+ */
+export function renderNotificationEmail(
+  branding: EmailBranding,
+  title: string,
+  message: string,
+  actionUrl?: string,
+  actionLabel?: string,
+): { subject: string; html: string; text: string } {
+  const button = actionUrl
+    ? `<p style="margin-top:24px;"><a href="${actionUrl}" style="display:inline-block;padding:10px 24px;background:${branding.primaryColor};color:#ffffff;border-radius:8px;text-decoration:none;font-weight:600;font-size:14px;">${actionLabel || "View Details"}</a></p>`
+    : "";
+  return {
+    subject: `${branding.brandName}: ${title}`,
+    html: renderEmailLayout(
+      branding,
+      `
+      <h1 style="margin:0 0 8px;font-size:20px;color:#18181b;">${title}</h1>
+      <p>${message}</p>
+      ${button}
+    `,
+    ),
+    text: `${title}\n\n${message}${actionUrl ? `\n\n${actionLabel || "View Details"}: ${actionUrl}` : ""}`,
+  };
+}
+
+/**
+ * Unsubscribe confirmation email template
+ * Sent when a user unsubscribes from communications
+ */
+export function renderUnsubscribeEmail(
+  branding: EmailBranding,
+  resubscribeUrl?: string,
+): { subject: string; html: string; text: string } {
+  return {
+    subject: "Unsubscribe Confirmation",
+    html: renderEmailLayout(
+      branding,
+      `
+      <h1 style="margin:0 0 8px;font-size:20px;color:#18181b;">You've been unsubscribed</h1>
+      <p>We're sorry to see you go. You've been removed from the mailing list.</p>
+      ${resubscribeUrl ? `<p>If this was a mistake, <a href="${resubscribeUrl}" style="color:${branding.primaryColor};">re-subscribe here</a>.</p>` : ""}
+    `,
+    ),
+    text: `You've been unsubscribed\n\nWe're sorry to see you go.${resubscribeUrl ? `\n\nRe-subscribe: ${resubscribeUrl}` : ""}`,
+  };
+}
+
+/**
+ * Test email template
+ * Used to verify email configuration
+ */
+export function renderTestEmail(
+  branding: EmailBranding,
+  provider: string,
+): { subject: string; html: string; text: string } {
+  return {
+    subject: `Test Email from ${branding.brandName}`,
+    html: renderEmailLayout(
+      branding,
+      `
+      <h1 style="margin:0 0 8px;font-size:20px;color:#18181b;">Test Email</h1>
+      <p>This is a test email from the marketing system.</p>
+      <p>If you received this, your email configuration is working correctly!</p>
+      <p style="margin-top:16px;padding:12px;background:#f4f4f5;border-radius:8px;font-family:monospace;font-size:13px;">
+        <strong>Provider:</strong> ${provider}
+      </p>
+    `,
+    ),
+    text: `Test Email\n\nThis is a test email from the marketing system.\nIf you received this, your email configuration is working correctly!\n\nProvider: ${provider}`,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds tenant-aware email template system with custom branding (logo, colors, from address)
- Template types: welcome, notification, unsubscribe, test
- Responsive HTML email layouts with plain text alternatives
- Integrates with existing email service for tenant branding extraction

Closes #317

## Test plan
- [ ] Verify email templates render correctly with tenant branding
- [ ] Verify plain text alternative generation
- [ ] Verify email service integration with new template system

🤖 Generated with [Claude Code](https://claude.com/claude-code)