### PR TITLE
feat: add multi-language / i18n support

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,77 @@
+import { useState, useRef, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronDown, Check } from "lucide-react";
+import { useI18n, SUPPORTED_LOCALES, Locale } from "@/lib/i18n";
+
+export function LanguageSwitcher() {
+  const { locale, setLocale } = useI18n();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const currentLang = SUPPORTED_LOCALES.find((l) => l.code === locale);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
+  const handleSelectLanguage = (code: Locale) => {
+    setLocale(code);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-3 py-2 bg-card border border-border rounded-lg hover:bg-accent transition-colors"
+      >
+        <span className="text-xl">{currentLang?.flag}</span>
+        <span className="text-sm font-medium">{currentLang?.label}</span>
+        <ChevronDown
+          className={`w-4 h-4 text-muted-foreground transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.15 }}
+            className="absolute top-full left-0 mt-2 w-48 bg-card border border-border rounded-lg shadow-lg overflow-hidden z-50"
+          >
+            {SUPPORTED_LOCALES.map((lang) => (
+              <button
+                key={lang.code}
+                onClick={() => handleSelectLanguage(lang.code)}
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-accent transition-colors text-left"
+              >
+                <span className="text-xl">{lang.flag}</span>
+                <span className="text-sm font-medium flex-1">{lang.label}</span>
+                {locale === lang.code && (
+                  <Check className="w-4 h-4 text-primary" />
+                )}
+              </button>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -1,0 +1,268 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  ReactNode,
+} from "react";
+
+export type Locale = "en" | "es" | "fr" | "de" | "pt";
+
+export const SUPPORTED_LOCALES: {
+  code: Locale;
+  label: string;
+  flag: string;
+}[] = [
+  { code: "en", label: "English", flag: "🇺🇸" },
+  { code: "es", label: "Español", flag: "🇪🇸" },
+  { code: "fr", label: "Français", flag: "🇫🇷" },
+  { code: "de", label: "Deutsch", flag: "🇩🇪" },
+  { code: "pt", label: "Português", flag: "🇧🇷" },
+];
+
+type TranslationKey = string;
+type Translations = Record<TranslationKey, string>;
+type LocaleTranslations = Record<Locale, Translations>;
+
+// English as the base/fallback language
+const translations: LocaleTranslations = {
+  en: {
+    // Common
+    "common.save": "Save",
+    "common.cancel": "Cancel",
+    "common.delete": "Delete",
+    "common.edit": "Edit",
+    "common.create": "Create",
+    "common.search": "Search",
+    "common.filter": "Filter",
+    "common.loading": "Loading...",
+    "common.noResults": "No results found",
+    "common.confirm": "Confirm",
+    "common.back": "Back",
+    "common.next": "Next",
+    "common.close": "Close",
+    "common.copy": "Copy",
+    "common.copied": "Copied!",
+    // Auth
+    "auth.signIn": "Sign In",
+    "auth.signOut": "Sign Out",
+    "auth.welcome": "Welcome",
+    // Navigation
+    "nav.dashboard": "Dashboard",
+    "nav.tasks": "Tasks",
+    "nav.contacts": "Contacts",
+    "nav.blog": "Blog",
+    "nav.settings": "Settings",
+    "nav.agents": "Agents",
+    "nav.workflows": "Workflows",
+    "nav.prompts": "Prompts",
+    "nav.infrastructure": "Infrastructure",
+    "nav.metrics": "Metrics",
+    "nav.calendar": "Calendar",
+    // Desktop
+    "desktop.missionControl": "Mission Control",
+    "desktop.noOpenWindows": "No open windows",
+    "desktop.newFolder": "New Folder",
+    "desktop.changeWallpaper": "Change Wallpaper...",
+    "desktop.refresh": "Refresh",
+    "desktop.switchClassic": "Switch to Classic Mode",
+    "desktop.viewSite": "View Site",
+    "desktop.aboutWorkspace": "About this workspace",
+    "desktop.maxWindows":
+      "Maximum of 10 windows open. Close a window to open a new one.",
+    // Tasks
+    "tasks.title": "Tasks",
+    "tasks.newTask": "New Task",
+    "tasks.noTasks": "No tasks yet",
+    "tasks.createFirst": "Create your first task to get started.",
+    // Settings
+    "settings.title": "Settings",
+    "settings.language": "Language",
+    "settings.theme": "Theme",
+    "settings.notifications": "Notifications",
+  },
+  es: {
+    "common.save": "Guardar",
+    "common.cancel": "Cancelar",
+    "common.delete": "Eliminar",
+    "common.edit": "Editar",
+    "common.create": "Crear",
+    "common.search": "Buscar",
+    "common.filter": "Filtrar",
+    "common.loading": "Cargando...",
+    "common.noResults": "No se encontraron resultados",
+    "common.confirm": "Confirmar",
+    "common.back": "Atrás",
+    "common.next": "Siguiente",
+    "common.close": "Cerrar",
+    "common.copy": "Copiar",
+    "common.copied": "¡Copiado!",
+    "auth.signIn": "Iniciar sesión",
+    "auth.signOut": "Cerrar sesión",
+    "auth.welcome": "Bienvenido",
+    "nav.dashboard": "Panel",
+    "nav.tasks": "Tareas",
+    "nav.contacts": "Contactos",
+    "nav.blog": "Blog",
+    "nav.settings": "Configuración",
+    "nav.agents": "Agentes",
+    "nav.workflows": "Flujos de trabajo",
+    "nav.prompts": "Prompts",
+    "nav.infrastructure": "Infraestructura",
+    "nav.metrics": "Métricas",
+    "nav.calendar": "Calendario",
+    "desktop.missionControl": "Centro de control",
+    "desktop.noOpenWindows": "No hay ventanas abiertas",
+    "desktop.newFolder": "Nueva carpeta",
+    "desktop.changeWallpaper": "Cambiar fondo...",
+    "desktop.refresh": "Actualizar",
+    "desktop.switchClassic": "Cambiar a modo clásico",
+    "desktop.viewSite": "Ver sitio",
+    "desktop.aboutWorkspace": "Sobre este espacio",
+    "desktop.maxWindows":
+      "Máximo de 10 ventanas abiertas. Cierra una ventana para abrir una nueva.",
+    "tasks.title": "Tareas",
+    "tasks.newTask": "Nueva tarea",
+    "tasks.noTasks": "Aún no hay tareas",
+    "tasks.createFirst": "Crea tu primera tarea para empezar.",
+    "settings.title": "Configuración",
+    "settings.language": "Idioma",
+    "settings.theme": "Tema",
+    "settings.notifications": "Notificaciones",
+  },
+  fr: {
+    "common.save": "Enregistrer",
+    "common.cancel": "Annuler",
+    "common.delete": "Supprimer",
+    "common.edit": "Modifier",
+    "common.create": "Créer",
+    "common.search": "Rechercher",
+    "common.filter": "Filtrer",
+    "common.loading": "Chargement...",
+    "common.noResults": "Aucun résultat",
+    "common.confirm": "Confirmer",
+    "common.back": "Retour",
+    "common.next": "Suivant",
+    "common.close": "Fermer",
+    "common.copy": "Copier",
+    "common.copied": "Copié !",
+    "auth.signIn": "Se connecter",
+    "auth.signOut": "Se déconnecter",
+    "auth.welcome": "Bienvenue",
+    "nav.dashboard": "Tableau de bord",
+    "nav.tasks": "Tâches",
+    "nav.contacts": "Contacts",
+    "nav.blog": "Blog",
+    "nav.settings": "Paramètres",
+    "nav.agents": "Agents",
+    "nav.workflows": "Flux de travail",
+    "nav.prompts": "Prompts",
+    "nav.infrastructure": "Infrastructure",
+    "nav.metrics": "Métriques",
+    "nav.calendar": "Calendrier",
+    "desktop.missionControl": "Centre de contrôle",
+    "desktop.noOpenWindows": "Aucune fenêtre ouverte",
+    "tasks.title": "Tâches",
+    "tasks.newTask": "Nouvelle tâche",
+    "settings.title": "Paramètres",
+    "settings.language": "Langue",
+    "settings.theme": "Thème",
+    "settings.notifications": "Notifications",
+  },
+  de: {
+    "common.save": "Speichern",
+    "common.cancel": "Abbrechen",
+    "common.delete": "Löschen",
+    "common.edit": "Bearbeiten",
+    "common.create": "Erstellen",
+    "common.search": "Suchen",
+    "common.loading": "Laden...",
+    "common.noResults": "Keine Ergebnisse gefunden",
+    "auth.signIn": "Anmelden",
+    "auth.signOut": "Abmelden",
+    "auth.welcome": "Willkommen",
+    "nav.dashboard": "Dashboard",
+    "nav.tasks": "Aufgaben",
+    "nav.contacts": "Kontakte",
+    "nav.settings": "Einstellungen",
+    "tasks.title": "Aufgaben",
+    "tasks.newTask": "Neue Aufgabe",
+    "settings.title": "Einstellungen",
+    "settings.language": "Sprache",
+  },
+  pt: {
+    "common.save": "Salvar",
+    "common.cancel": "Cancelar",
+    "common.delete": "Excluir",
+    "common.edit": "Editar",
+    "common.create": "Criar",
+    "common.search": "Pesquisar",
+    "common.loading": "Carregando...",
+    "common.noResults": "Nenhum resultado encontrado",
+    "auth.signIn": "Entrar",
+    "auth.signOut": "Sair",
+    "auth.welcome": "Bem-vindo",
+    "nav.dashboard": "Painel",
+    "nav.tasks": "Tarefas",
+    "nav.contacts": "Contatos",
+    "nav.settings": "Configurações",
+    "tasks.title": "Tarefas",
+    "tasks.newTask": "Nova tarefa",
+    "settings.title": "Configurações",
+    "settings.language": "Idioma",
+  },
+};
+
+interface I18nContextType {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string, vars?: Record<string, string>) => string;
+}
+
+const I18nContext = createContext<I18nContextType | undefined>(undefined);
+
+const STORAGE_KEY = "app-locale";
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<Locale>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && translations[stored as Locale]) return stored as Locale;
+    // Try browser language
+    const browserLang = navigator.language.split("-")[0] as Locale;
+    if (translations[browserLang]) return browserLang;
+    return "en";
+  });
+
+  const setLocale = useCallback((newLocale: Locale) => {
+    setLocaleState(newLocale);
+    localStorage.setItem(STORAGE_KEY, newLocale);
+    document.documentElement.lang = newLocale;
+  }, []);
+
+  const t = useCallback(
+    (key: string, vars?: Record<string, string>): string => {
+      let text = translations[locale]?.[key] || translations.en[key] || key;
+      if (vars) {
+        Object.entries(vars).forEach(([k, v]) => {
+          text = text.replace(`{{${k}}}`, v);
+        });
+      }
+      return text;
+    },
+    [locale],
+  );
+
+  return (
+    <I18nContext.Provider value={{ locale, setLocale, t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+  if (!context) {
+    throw new Error("useI18n must be used within an I18nProvider");
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,21 +1,24 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App.tsx';
-import ErrorBoundary from './components/ErrorBoundary.tsx';
-import { initSentry } from './lib/sentry.ts';
-import { initAnalytics } from './lib/analytics.ts';
-import { initWebVitals } from './lib/web-vitals.ts';
-import './index.css';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+import ErrorBoundary from "./components/ErrorBoundary.tsx";
+import { I18nProvider } from "./lib/i18n.tsx";
+import { initSentry } from "./lib/sentry.ts";
+import { initAnalytics } from "./lib/analytics.ts";
+import { initWebVitals } from "./lib/web-vitals.ts";
+import "./index.css";
 
 // Initialize error tracking, analytics, and performance monitoring
 initSentry();
 initAnalytics();
 initWebVitals();
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ErrorBoundary>
-      <App />
+      <I18nProvider>
+        <App />
+      </I18nProvider>
     </ErrorBoundary>
-  </StrictMode>
+  </StrictMode>,
 );

--- a/src/pages/admin/settings/PlatformSettings.tsx
+++ b/src/pages/admin/settings/PlatformSettings.tsx
@@ -18,10 +18,12 @@ import {
   Code2,
   Palette,
   Zap,
+  Languages,
 } from "lucide-react";
 import AdminLayout from "@/components/AdminLayout";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { useAuth } from "@/lib/auth";
 import { useSession } from "@clerk/clerk-react";
 import {
@@ -33,6 +35,7 @@ import { getAnalyticsSettings, saveAnalyticsSettings } from "@/lib/analytics";
 import { useSEO, clearSEOCache } from "@/lib/seo";
 import { getSiteContent, upsertSiteContent } from "@/lib/supabase-queries";
 import { captureException } from "@/lib/sentry";
+import { useI18n } from "@/lib/i18n";
 
 interface SEOSettings {
   siteName: string;
@@ -155,6 +158,7 @@ const PlatformSettings = () => {
   const { user } = useAuth();
   const { session } = useSession();
   const { supabase } = useAuthenticatedSupabase();
+  const { t } = useI18n();
 
   // Visibility toggles
   const [showSupabaseKey, setShowSupabaseKey] = useState(false);
@@ -586,6 +590,27 @@ const PlatformSettings = () => {
                 </Button>
                 <StatusBadge status={gaStatus} message={gaMessage} />
               </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Language Settings */}
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-3 flex items-center gap-2">
+            <Languages className="w-5 h-5 text-primary" />
+            {t("settings.language")}
+          </h2>
+          <div className="bg-card border border-border rounded-lg p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-medium text-foreground mb-1">
+                  Interface Language
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Choose your preferred language for the platform interface
+                </p>
+              </div>
+              <LanguageSwitcher />
             </div>
           </div>
         </section>

--- a/src/pages/admin/settings/TenantSettings.tsx
+++ b/src/pages/admin/settings/TenantSettings.tsx
@@ -4,9 +4,11 @@ import { Settings, RotateCcw, Loader2 } from "lucide-react";
 import AdminLayout from "@/components/AdminLayout";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { useSEO } from "@/lib/seo";
 import { useTenant } from "@/lib/tenant";
 import { useTenantSettings } from "@/hooks/useTenantSettings";
+import { useI18n } from "@/lib/i18n";
 import BrandSection from "./sections/BrandSection";
 import ThemeSection from "./sections/ThemeSection";
 import AppsSection from "./sections/AppsSection";
@@ -19,6 +21,7 @@ const TenantSettings = () => {
   const { refreshTenant } = useTenant();
   const { saveOnboardingComplete, saveOnboardingStep, isSaving } =
     useTenantSettings();
+  const { t } = useI18n();
   const [resetting, setResetting] = useState(false);
 
   const handleRerunWizard = async () => {
@@ -72,6 +75,7 @@ const TenantSettings = () => {
             <TabsTrigger value="domain">Domain</TabsTrigger>
             <TabsTrigger value="email">Email</TabsTrigger>
             <TabsTrigger value="plan">Plan</TabsTrigger>
+            <TabsTrigger value="language">Language</TabsTrigger>
           </TabsList>
 
           <TabsContent value="brand">
@@ -91,6 +95,19 @@ const TenantSettings = () => {
           </TabsContent>
           <TabsContent value="plan">
             <PlanSection />
+          </TabsContent>
+          <TabsContent value="language">
+            <div className="bg-card border border-border rounded-lg p-6">
+              <h3 className="text-lg font-semibold text-foreground mb-2">
+                {t("settings.language")}
+              </h3>
+              <p className="text-sm text-muted-foreground mb-6">
+                Choose your preferred language for the interface
+              </p>
+              <div className="flex items-center gap-4">
+                <LanguageSwitcher />
+              </div>
+            </div>
           </TabsContent>
         </Tabs>
       </motion.div>


### PR DESCRIPTION
## Summary
- Adds I18nProvider with React Context for internationalization
- Supports 5 languages: English, Spanish, French, German, Portuguese
- LanguageSwitcher component with flag emojis and localStorage persistence
- Language settings integrated into Platform Settings and Tenant Settings pages

Closes #324

## Test plan
- [ ] Verify language switcher appears in both settings pages
- [ ] Verify switching languages updates UI strings
- [ ] Verify language preference persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)