### PR TITLE
fix: route app-schema RPC calls through PostgREST

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'supabase/migrations/**'
+      - 'supabase/config.toml'
       - '.github/workflows/migrate.yml'
   workflow_dispatch:
 
@@ -30,3 +31,11 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
+      - name: Sync PostgREST exposed schemas
+        run: |
+          curl -sf -X PATCH \
+            "https://api.supabase.com/v1/projects/${{ secrets.SUPABASE_PROJECT_REF }}/postgrest" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ACCESS_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"db_schema": "public,graphql_public,app"}'

--- a/netlify/functions/ai-proxy.ts
+++ b/netlify/functions/ai-proxy.ts
@@ -129,13 +129,12 @@ const handler: Handler = async (event: HandlerEvent) => {
       // Get current usage count
       const periodStart = settings.current_period_start as string | undefined;
       if (periodStart) {
-        const { data: count } = await supabase.rpc(
-          "get_tenant_ai_usage_count",
-          {
+        const { data: count } = await supabase
+          .schema("app")
+          .rpc("get_tenant_ai_usage_count", {
             p_tenant_id: tenantId,
             p_period_start: periodStart,
-          },
-        );
+          });
         usageCount = typeof count === "number" ? count : 0;
       }
 

--- a/netlify/functions/domain-provision.ts
+++ b/netlify/functions/domain-provision.ts
@@ -132,9 +132,11 @@ async function initiateByo(
     provisioned_via: "byo",
   };
 
-  const { error: rpcError } = await supabase.rpc("update_tenant_settings", {
-    p_domain: domainSettings,
-  });
+  const { error: rpcError } = await supabase
+    .schema("app")
+    .rpc("update_tenant_settings", {
+      p_domain: domainSettings,
+    });
 
   // update_tenant_settings requires authenticated + is_admin, but we're service_role
   // so call it directly if the RPC doesn't work
@@ -148,13 +150,12 @@ async function initiateByo(
       .eq("id", tenantId);
 
     // Direct JSONB merge
-    const { error: directErr } = await supabase.rpc(
-      "set_tenant_custom_domain",
-      {
+    const { error: directErr } = await supabase
+      .schema("app")
+      .rpc("set_tenant_custom_domain", {
         p_tenant_id: tenantId,
         p_domain: null, // don't set column yet — not verified
-      },
-    );
+      });
 
     // Update settings directly
     const { data: tenant } = await supabase
@@ -349,10 +350,12 @@ async function provisionNetlify(
   }
 
   // Set the indexed column via RPC
-  const { error: rpcErr } = await supabase.rpc("set_tenant_custom_domain", {
-    p_tenant_id: tenantId,
-    p_domain: customDomain,
-  });
+  const { error: rpcErr } = await supabase
+    .schema("app")
+    .rpc("set_tenant_custom_domain", {
+      p_tenant_id: tenantId,
+      p_domain: customDomain,
+    });
 
   if (rpcErr) {
     return json(500, { error: "Failed to set custom domain on tenant record" });
@@ -482,7 +485,7 @@ async function purchaseDomain(
   }
 
   // 4. Set tenant custom domain column + JSONB
-  await supabase.rpc("set_tenant_custom_domain", {
+  await supabase.schema("app").rpc("set_tenant_custom_domain", {
     p_tenant_id: tenantId,
     p_domain: domain,
   });
@@ -578,7 +581,7 @@ async function removeDomain(
   }
 
   // Clear custom_domain column via RPC
-  await supabase.rpc("set_tenant_custom_domain", {
+  await supabase.schema("app").rpc("set_tenant_custom_domain", {
     p_tenant_id: tenantId,
     p_domain: null,
   });

--- a/netlify/functions/stripe-checkout.ts
+++ b/netlify/functions/stripe-checkout.ts
@@ -124,10 +124,12 @@ const handler: Handler = async (event: HandlerEvent) => {
       customerId = customer.id;
 
       // Link customer ID to tenant via RPC
-      const { error: linkError } = await supabase.rpc("link_stripe_customer", {
-        p_tenant_id: tenant.id,
-        p_stripe_customer_id: customerId,
-      });
+      const { error: linkError } = await supabase
+        .schema("app")
+        .rpc("link_stripe_customer", {
+          p_tenant_id: tenant.id,
+          p_stripe_customer_id: customerId,
+        });
 
       if (linkError) {
         return {

--- a/netlify/functions/stripe-webhook.ts
+++ b/netlify/functions/stripe-webhook.ts
@@ -116,7 +116,7 @@ const handler: Handler = async (event: HandlerEvent) => {
         const priceId = subscription.items.data[0]?.price.id || "";
         const plan = mapPriceToPlan(priceId);
 
-        await supabase.rpc("update_tenant_billing", {
+        await supabase.schema("app").rpc("update_tenant_billing", {
           p_stripe_customer_id: customerId,
           p_stripe_subscription_id: subscriptionId,
           p_plan: plan,
@@ -142,7 +142,7 @@ const handler: Handler = async (event: HandlerEvent) => {
         const priceId = subscription.items.data[0]?.price.id || "";
         const plan = mapPriceToPlan(priceId);
 
-        await supabase.rpc("update_tenant_billing", {
+        await supabase.schema("app").rpc("update_tenant_billing", {
           p_stripe_customer_id: customerId,
           p_stripe_subscription_id: subscription.id,
           p_plan: plan,
@@ -165,7 +165,7 @@ const handler: Handler = async (event: HandlerEvent) => {
             ? subscription.customer
             : subscription.customer.id;
 
-        await supabase.rpc("update_tenant_billing", {
+        await supabase.schema("app").rpc("update_tenant_billing", {
           p_stripe_customer_id: customerId,
           p_stripe_subscription_id: subscription.id,
           p_plan: "free",
@@ -201,7 +201,7 @@ const handler: Handler = async (event: HandlerEvent) => {
         const priceId = subscription.items.data[0]?.price.id || "";
         const plan = mapPriceToPlan(priceId);
 
-        await supabase.rpc("update_tenant_billing", {
+        await supabase.schema("app").rpc("update_tenant_billing", {
           p_stripe_customer_id: customerId,
           p_stripe_subscription_id: subscriptionId,
           p_plan: plan,

--- a/src/hooks/useAIUsage.ts
+++ b/src/hooks/useAIUsage.ts
@@ -40,6 +40,7 @@ export function useAIUsage(): AIUsageState {
     setLoading(true);
 
     supabase
+      .schema("app")
       .rpc("get_tenant_ai_usage_count", {
         p_tenant_id: tenant.id,
         p_period_start: periodStart,

--- a/src/hooks/useTenantSettings.ts
+++ b/src/hooks/useTenantSettings.ts
@@ -44,7 +44,9 @@ export function useTenantSettings(): UseTenantSettingsResult {
   } = useMutation(
     async (params: Record<string, unknown>) => {
       if (!supabase) throw new Error("Supabase not available");
-      const { error } = await supabase.rpc("update_tenant_settings", params);
+      const { error } = await supabase
+        .schema("app")
+        .rpc("update_tenant_settings", params);
       if (error) throw error;
     },
     {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -300,6 +300,7 @@ export function useTenantSupabase(): {
     if (!supabase || !tenantId || contextSetRef.current) return;
 
     supabase
+      .schema("app")
       .rpc("set_tenant_context", { tenant_id: tenantId })
       .then(({ error }) => {
         if (error) {

--- a/src/lib/tenant.tsx
+++ b/src/lib/tenant.tsx
@@ -160,6 +160,7 @@ export function TenantProvider({ children }: { children: ReactNode }) {
 
       let cancelled = false;
       client
+        .schema("app")
         .rpc("resolve_tenant_by_slug", { p_slug: devSlug })
         .then(({ data, error: rpcError }) => {
           if (cancelled) return;
@@ -208,24 +209,27 @@ export function TenantProvider({ children }: { children: ReactNode }) {
         ? { p_slug: resolved.value }
         : { p_domain: resolved.value };
 
-    client.rpc(rpcName, rpcParams).then(({ data, error: rpcError }) => {
-      if (cancelled) return;
+    client
+      .schema("app")
+      .rpc(rpcName, rpcParams)
+      .then(({ data, error: rpcError }) => {
+        if (cancelled) return;
 
-      if (rpcError) {
-        setStatus("error");
-        setError(rpcError.message);
-        return;
-      }
+        if (rpcError) {
+          setStatus("error");
+          setError(rpcError.message);
+          return;
+        }
 
-      if (!data || (Array.isArray(data) && data.length === 0)) {
-        setStatus("not_found");
-        return;
-      }
+        if (!data || (Array.isArray(data) && data.length === 0)) {
+          setStatus("not_found");
+          return;
+        }
 
-      const row = Array.isArray(data) ? data[0] : data;
-      setTenant(row as Tenant);
-      setStatus("resolved");
-    });
+        const row = Array.isArray(data) ? data[0] : data;
+        setTenant(row as Tenant);
+        setStatus("resolved");
+      });
 
     return () => {
       cancelled = true;

--- a/src/pages/admin/platform/Dashboard.tsx
+++ b/src/pages/admin/platform/Dashboard.tsx
@@ -32,7 +32,9 @@ const PlatformDashboard = () => {
     async function fetchStats() {
       if (!supabase) return;
       try {
-        const { data, error } = await supabase.rpc("get_platform_stats");
+        const { data, error } = await supabase
+          .schema("app")
+          .rpc("get_platform_stats");
         if (error) throw error;
         setStats(data as PlatformStats);
       } catch (err) {

--- a/src/pages/admin/platform/TenantDetail.tsx
+++ b/src/pages/admin/platform/TenantDetail.tsx
@@ -53,10 +53,12 @@ const TenantDetailPage = () => {
     if (!supabase || !tenant) return;
     setIsToggling(true);
     try {
-      const { error } = await supabase.rpc("toggle_tenant_status", {
-        p_tenant_id: tenant.id,
-        p_is_active: !tenant.is_active,
-      });
+      const { error } = await supabase
+        .schema("app")
+        .rpc("toggle_tenant_status", {
+          p_tenant_id: tenant.id,
+          p_is_active: !tenant.is_active,
+        });
       if (error) throw error;
       setTenant({ ...tenant, is_active: !tenant.is_active });
     } catch (err) {

--- a/src/pages/admin/platform/TenantList.tsx
+++ b/src/pages/admin/platform/TenantList.tsx
@@ -31,7 +31,7 @@ const TenantListPage = () => {
     if (!supabase) return;
     setIsLoading(true);
     try {
-      const { data, error } = await supabase.rpc("list_tenants", {
+      const { data, error } = await supabase.schema("app").rpc("list_tenants", {
         p_search: search || null,
         p_limit: PAGE_SIZE,
         p_offset: page * PAGE_SIZE,
@@ -55,10 +55,12 @@ const TenantListPage = () => {
     if (!supabase) return;
     setTogglingId(tenantId);
     try {
-      const { error } = await supabase.rpc("toggle_tenant_status", {
-        p_tenant_id: tenantId,
-        p_is_active: !isActive,
-      });
+      const { error } = await supabase
+        .schema("app")
+        .rpc("toggle_tenant_status", {
+          p_tenant_id: tenantId,
+          p_is_active: !isActive,
+        });
       if (error) throw error;
       setTenants((prev) =>
         prev.map((t) =>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -10,7 +10,7 @@ enabled = true
 port = 54321
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
-schemas = ["public", "graphql_public"]
+schemas = ["public", "graphql_public", "app"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["public", "extensions"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size


### PR DESCRIPTION
## Summary
- **Root cause**: All tenant RPC functions (`resolve_tenant_by_slug`, `resolve_tenant_by_domain`, `set_tenant_context`, etc.) are defined in the `app` schema, but PostgREST only exposed `public` — causing `"Could not find function public.resolve.tenantByDomainPNumDomain in the schema cache"` errors
- Adds `"app"` to exposed schemas in `supabase/config.toml`
- Adds `.schema("app")` before all `.rpc()` calls targeting `app`-schema functions across 11 client/server files
- Adds a PostgREST config sync step to `migrate.yml` via the Supabase Management API so production schema exposure stays in sync with `config.toml`

## Files changed (13)
| Category | Files |
|---|---|
| Config | `supabase/config.toml`, `.github/workflows/migrate.yml` |
| Client | `src/lib/tenant.tsx`, `src/lib/supabase.ts`, `src/hooks/useTenantSettings.ts`, `src/hooks/useAIUsage.ts` |
| Admin pages | `src/pages/admin/platform/Dashboard.tsx`, `TenantList.tsx`, `TenantDetail.tsx` |
| Netlify functions | `netlify/functions/stripe-webhook.ts`, `stripe-checkout.ts`, `domain-provision.ts`, `ai-proxy.ts` |

## Test plan
- [ ] Verify main site loads without schema cache error
- [ ] Verify tenant resolution works for subdomain and custom domain routes
- [ ] Verify Stripe webhook billing updates still succeed
- [ ] Verify `migrate.yml` workflow passes (PostgREST config sync step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)