### PR TITLE
fix: grant USAGE on app schema for PostgREST access

### DIFF
--- a/supabase/migrations/20260309000001_grant_app_schema_usage.sql
+++ b/supabase/migrations/20260309000001_grant_app_schema_usage.sql
@@ -1,0 +1,12 @@
+-- =====================================================================
+-- MIGRATION: Grant USAGE on app schema to PostgREST roles
+--
+-- The app schema is now exposed via PostgREST (config.toml + Management
+-- API), but PostgreSQL requires USAGE privilege on a schema before any
+-- objects inside it can be accessed.  Without this, all .schema("app")
+-- RPC calls fail with "permission denied for schema app".
+-- =====================================================================
+
+GRANT USAGE ON SCHEMA app TO anon;
+GRANT USAGE ON SCHEMA app TO authenticated;
+GRANT USAGE ON SCHEMA app TO service_role;


### PR DESCRIPTION
## Summary
- Follow-up to #394 — exposing the `app` schema via PostgREST requires PostgreSQL `USAGE` privilege on the schema itself, otherwise all calls fail with `"permission denied for schema app"`
- Grants `USAGE ON SCHEMA app` to `anon`, `authenticated`, and `service_role`

## Test plan
- [ ] Main site loads without "permission denied for schema app" error
- [ ] Tenant resolution (subdomain + custom domain) works
- [ ] Authenticated RPC calls (settings, billing, admin) succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)