### PR TITLE
fix: set base domain to mejohnc.org so main site loads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,13 +13,13 @@ VITE_CLERK_PUBLISHABLE_KEY=
 VITE_GHOST_URL=
 VITE_GHOST_CONTENT_API_KEY=
 
-# Platform Identity (white-label defaults)
-VITE_PLATFORM_NAME=Business OS
-VITE_SITE_URL=https://businessos.app
+# Platform Identity
+VITE_PLATFORM_NAME=MeJohnC
+VITE_SITE_URL=https://mejohnc.org
 VITE_SITE_DESCRIPTION=Your website and business tools in one platform.
-VITE_BASE_DOMAIN=businessos.app
+VITE_BASE_DOMAIN=mejohnc.org
 VITE_STORAGE_BUCKET=uploads
-VITE_CORS_ORIGINS=https://businessos.app
+VITE_CORS_ORIGINS=https://mejohnc.org
 VITE_GITHUB_OWNER=
 VITE_GITHUB_REPO=
 VITE_GITHUB_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           VITE_GHOST_URL: ${{ secrets.VITE_GHOST_URL }}
           VITE_GHOST_CONTENT_API_KEY: ${{ secrets.VITE_GHOST_CONTENT_API_KEY }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_BASE_DOMAIN: mejohnc.org
+          VITE_SITE_URL: https://mejohnc.org
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
@@ -111,6 +113,8 @@ jobs:
           VITE_GHOST_URL: ${{ secrets.VITE_GHOST_URL }}
           VITE_GHOST_CONTENT_API_KEY: ${{ secrets.VITE_GHOST_CONTENT_API_KEY }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          VITE_BASE_DOMAIN: mejohnc.org
+          VITE_SITE_URL: https://mejohnc.org
 
       - name: Upload bundle analysis
         uses: actions/upload-artifact@v7

--- a/netlify.toml
+++ b/netlify.toml
@@ -75,8 +75,10 @@
   node_bundler = "esbuild"
 
 # Context-specific settings
-[context.production]
-  environment = { NODE_ENV = "production" }
+[context.production.environment]
+  NODE_ENV = "production"
+  VITE_BASE_DOMAIN = "mejohnc.org"
+  VITE_SITE_URL = "https://mejohnc.org"
 
 [context.deploy-preview]
   environment = { NODE_ENV = "preview" }

--- a/netlify/functions/domain-provision.ts
+++ b/netlify/functions/domain-provision.ts
@@ -31,7 +31,7 @@ interface RequestBody {
 const CUSTOM_DOMAIN_PLANS = ["business", "professional", "enterprise"];
 const DOMAIN_PROCUREMENT_PLANS = ["professional", "enterprise"];
 
-const BASE_DOMAIN = process.env.VITE_BASE_DOMAIN || "businessos.app";
+const BASE_DOMAIN = process.env.VITE_BASE_DOMAIN || "mejohnc.org";
 
 function json(statusCode: number, body: Record<string, unknown>) {
   return {

--- a/src/lib/email-service.ts
+++ b/src/lib/email-service.ts
@@ -56,8 +56,7 @@ class EmailService {
   constructor() {
     this.provider = this.getProvider();
     this.apiKey = this.getApiKey();
-    this.fromEmail =
-      import.meta.env.VITE_EMAIL_FROM || "noreply@businessos.app";
+    this.fromEmail = import.meta.env.VITE_EMAIL_FROM || "noreply@mejohnc.org";
   }
 
   private getProvider(): EmailProvider {

--- a/src/lib/seo.tsx
+++ b/src/lib/seo.tsx
@@ -24,8 +24,8 @@ interface SEOSettings {
 
 // Default fallback values
 const DEFAULT_SEO: SEOSettings = {
-  siteName: import.meta.env.VITE_PLATFORM_NAME || "Business OS",
-  siteUrl: import.meta.env.VITE_SITE_URL || "https://businessos.app",
+  siteName: import.meta.env.VITE_PLATFORM_NAME || "MeJohnC",
+  siteUrl: import.meta.env.VITE_SITE_URL || "https://mejohnc.org",
   defaultDescription:
     import.meta.env.VITE_SITE_DESCRIPTION ||
     "Your website and business tools in one platform.",

--- a/src/lib/tenant-brand.ts
+++ b/src/lib/tenant-brand.ts
@@ -22,9 +22,9 @@ export interface TenantBrand {
 
 /** Platform-level defaults (used for main site / fallback) */
 const PLATFORM_DEFAULTS: TenantBrand = {
-  name: import.meta.env.VITE_PLATFORM_NAME || "Business OS",
-  siteUrl: import.meta.env.VITE_SITE_URL || "https://businessos.app",
-  fromEmail: import.meta.env.VITE_EMAIL_FROM || "noreply@businessos.app",
+  name: import.meta.env.VITE_PLATFORM_NAME || "MeJohnC",
+  siteUrl: import.meta.env.VITE_SITE_URL || "https://mejohnc.org",
+  fromEmail: import.meta.env.VITE_EMAIL_FROM || "noreply@mejohnc.org",
   storageBucket: import.meta.env.VITE_STORAGE_BUCKET || "uploads",
   corsOrigins: (import.meta.env.VITE_CORS_ORIGINS || "")
     .split(",")

--- a/src/lib/tenant.tsx
+++ b/src/lib/tenant.tsx
@@ -42,7 +42,7 @@ interface TenantContextValue {
 }
 
 const DEFAULT_TENANT_ID = "00000000-0000-0000-0000-000000000001";
-const BASE_DOMAIN = import.meta.env.VITE_BASE_DOMAIN || "businessos.app";
+const BASE_DOMAIN = import.meta.env.VITE_BASE_DOMAIN || "mejohnc.org";
 const RESERVED_SUBDOMAINS = new Set(["www", "app", ""]);
 
 // --- Context ---

--- a/src/pages/admin/settings/PlatformSettings.tsx
+++ b/src/pages/admin/settings/PlatformSettings.tsx
@@ -49,8 +49,8 @@ interface SEOSettings {
 }
 
 const defaultSEO: SEOSettings = {
-  siteName: import.meta.env.VITE_PLATFORM_NAME || "Business OS",
-  siteUrl: import.meta.env.VITE_SITE_URL || "https://businessos.app",
+  siteName: import.meta.env.VITE_PLATFORM_NAME || "MeJohnC",
+  siteUrl: import.meta.env.VITE_SITE_URL || "https://mejohnc.org",
   defaultDescription:
     import.meta.env.VITE_SITE_DESCRIPTION ||
     "Your website and business tools in one platform.",

--- a/src/pages/admin/settings/sections/DomainSection.tsx
+++ b/src/pages/admin/settings/sections/DomainSection.tsx
@@ -19,7 +19,7 @@ import { useAuth } from "@/lib/auth";
 import { useBilling } from "@/hooks/useBilling";
 import type { DomainVerificationStatus } from "@/lib/tenant-settings";
 
-const BASE_DOMAIN = import.meta.env.VITE_BASE_DOMAIN || "businessos.app";
+const BASE_DOMAIN = import.meta.env.VITE_BASE_DOMAIN || "mejohnc.org";
 
 async function domainApi(
   action: string,


### PR DESCRIPTION
## Summary
- **Root cause**: `VITE_BASE_DOMAIN` was never set in any build config, defaulting to `businessos.app`. When visiting `mejohnc.org`, the hostname resolver treated it as a custom-domain tenant lookup, found no tenant, and showed "Workspace Not Found"
- Sets `VITE_BASE_DOMAIN=mejohnc.org` and `VITE_SITE_URL=https://mejohnc.org` in `netlify.toml` (production) and `ci.yml` (CI builds)
- Replaces all hardcoded `businessos.app` fallbacks with `mejohnc.org` across 8 source files

## Test plan
- [ ] mejohnc.org loads the landing page (not "Workspace Not Found")
- [ ] www.mejohnc.org also loads correctly
- [ ] Admin pages, SEO metadata, and email defaults reference mejohnc.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)