### PR TITLE
fix: main site can never be blocked by tenant resolution

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,7 +156,8 @@ function PageLoader() {
   );
 }
 
-// Gate that blocks rendering until tenant is resolved
+// Gate that blocks rendering only for tenant subdomain resolution.
+// The main site ALWAYS renders — errors only block explicit tenant subdomains.
 function TenantGate({ children }: { children: React.ReactNode }) {
   const { status, error } = useTenant();
 
@@ -164,6 +165,8 @@ function TenantGate({ children }: { children: React.ReactNode }) {
     return <PageLoader />;
   }
 
+  // "not_found" only fires for explicit subdomain slugs (e.g. unknown.mejohnc.org).
+  // The main site and custom-domain fallbacks never reach this state.
   if (status === "not_found") {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center p-4">
@@ -186,6 +189,8 @@ function TenantGate({ children }: { children: React.ReactNode }) {
     );
   }
 
+  // "error" only fires for explicit subdomain slugs whose RPC failed.
+  // The main site never gets here.
   if (status === "error") {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center p-4">
@@ -207,6 +212,7 @@ function TenantGate({ children }: { children: React.ReactNode }) {
     );
   }
 
+  // "main_site" and "resolved" both render the app.
   return <>{children}</>;
 }
 

--- a/src/lib/tenant.tsx
+++ b/src/lib/tenant.tsx
@@ -195,8 +195,9 @@ export function TenantProvider({ children }: { children: ReactNode }) {
     const client = createSupabaseClient();
 
     if (!client) {
-      setStatus("error");
-      setError("Supabase not configured");
+      // No Supabase? Main site still works — only tenants need it.
+      setStatus("main_site");
+      setTenant(null);
       return;
     }
 
@@ -216,13 +217,27 @@ export function TenantProvider({ children }: { children: ReactNode }) {
         if (cancelled) return;
 
         if (rpcError) {
-          setStatus("error");
-          setError(rpcError.message);
+          // Subdomain slugs are explicit tenant requests — show the error.
+          // Custom domains that fail to resolve fall back to main site.
+          if (resolved.type === "slug") {
+            setStatus("error");
+            setError(rpcError.message);
+          } else {
+            setStatus("main_site");
+            setTenant(null);
+          }
           return;
         }
 
         if (!data || (Array.isArray(data) && data.length === 0)) {
-          setStatus("not_found");
+          // Subdomain slugs that don't resolve → workspace not found.
+          // Custom domains that don't resolve → this IS the main site.
+          if (resolved.type === "slug") {
+            setStatus("not_found");
+          } else {
+            setStatus("main_site");
+            setTenant(null);
+          }
           return;
         }
 


### PR DESCRIPTION
## Summary
The platform owner's site should never go down because of tenant code. Previously, any failure in tenant resolution (RPC error, schema issue, env misconfiguration) blocked the **entire** app — including the main site and admin routes.

**Before**: Unknown hostname → custom_domain RPC → fails → "Connection Error" or "Workspace Not Found" for the entire site, including /admin

**After**: Unknown hostname → custom_domain RPC → fails → **falls back to main_site** and renders normally

Changes:
- Custom domain lookups that fail or return empty fall back to `main_site` instead of erroring
- Only explicit subdomain slugs (`unknown.mejohnc.org`) show "Workspace Not Found"
- Missing Supabase config falls back to `main_site` instead of blocking the app
- TenantGate comments clarify which states can reach it

## Test plan
- [ ] mejohnc.org loads (main site)
- [ ] mejohnc.org/admin loads (admin dashboard)
- [ ] unknown.mejohnc.org shows "Workspace Not Found" (correct for bad subdomains)
- [ ] Valid tenant subdomain still resolves normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)