### PR TITLE
fix: admin panel crash — missing sections prop on desktop sidebar

### DIFF
--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -660,6 +660,7 @@ const AdminLayout = ({ children }: AdminLayoutProps) => {
               signOut={signOut}
               expandedSections={expandedSections}
               toggleSection={toggleSection}
+              sections={effectiveSections}
             />
           </div>
         </motion.aside>


### PR DESCRIPTION
## Summary
The desktop `SidebarContent` was missing the `sections` prop, causing `sections.map()` to crash with `undefined` — triggering the "Admin Error" screen.

The mobile sidebar had `sections={effectiveSections}` but the desktop one did not. One-line fix.

## Test plan
- [ ] `/admin` loads without "Admin Error"
- [ ] Desktop sidebar shows all navigation sections
- [ ] Mobile sidebar still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)