### PR TITLE
fix: restore full desktop OS functionality for main site owner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,6 +108,13 @@ const AdminAuditLog = lazy(() => import("./pages/admin/AuditLog"));
 const AdminComplianceDashboard = lazy(
   () => import("./pages/admin/ComplianceDashboard"),
 );
+const AdminAgentWarRoom = lazy(() => import("./pages/admin/AgentWarRoom"));
+const AdminApiAccess = lazy(() => import("./pages/admin/ApiAccess"));
+const AdminDataManagement = lazy(() => import("./pages/admin/DataManagement"));
+const AdminDedicatedInstance = lazy(
+  () => import("./pages/admin/DedicatedInstance"),
+);
+const AdminPartnerProgram = lazy(() => import("./pages/admin/PartnerProgram"));
 
 // Note: These routes are now dynamically loaded from feature modules:
 // - Tasks (/admin/tasks/*) - from tasks module
@@ -609,6 +616,20 @@ function AdminRoutes() {
             path="/admin/compliance"
             element={<AdminComplianceDashboard />}
           />
+          <Route path="/admin/war-room" element={<AdminAgentWarRoom />} />
+          <Route path="/admin/api-access" element={<AdminApiAccess />} />
+          <Route
+            path="/admin/data-management"
+            element={<AdminDataManagement />}
+          />
+          <Route
+            path="/admin/dedicated-instance"
+            element={<AdminDedicatedInstance />}
+          />
+          <Route
+            path="/admin/partner-program"
+            element={<AdminPartnerProgram />}
+          />
 
           {/* Platform admin routes (super-admin, main site only) */}
           <Route
@@ -638,6 +659,9 @@ function AdminRoutes() {
 
           {/* Dynamic feature module routes */}
           {renderFeatureRoutes()}
+
+          {/* 404 catch-all: redirect unknown admin paths to dashboard */}
+          <Route path="/admin/*" element={<Navigate to="/admin" replace />} />
         </Routes>
       </Suspense>
     </ErrorBoundary>

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -38,6 +38,10 @@ import {
   Building2,
   LayoutGrid,
   ShieldCheck,
+  Radar,
+  Shield,
+  Database,
+  Handshake,
 } from "lucide-react";
 import { useAuth } from "@/lib/auth";
 import { useTenant } from "@/lib/tenant";
@@ -110,8 +114,20 @@ const sidebarSections: SidebarSection[] = [
     items: [
       { label: "Infrastructure", path: "/admin/infrastructure", icon: Server },
       { label: "APIs", path: "/admin/apis", icon: Cable },
+      { label: "API Access", path: "/admin/api-access", icon: Shield },
       { label: "Configs", path: "/admin/configs", icon: FileCode2 },
       { label: "Compliance", path: "/admin/compliance", icon: ShieldCheck },
+      { label: "Partners", path: "/admin/partner-program", icon: Handshake },
+      {
+        label: "Dedicated Instance",
+        path: "/admin/dedicated-instance",
+        icon: Server,
+      },
+      {
+        label: "Data Management",
+        path: "/admin/data-management",
+        icon: Database,
+      },
       { label: "Style Guide", path: "/admin/style", icon: Palette },
     ],
   },
@@ -123,6 +139,7 @@ const sidebarSections: SidebarSection[] = [
       { label: "Workflows", path: "/admin/workflows", icon: GitBranch },
       { label: "Scheduler", path: "/admin/scheduler", icon: Clock },
       { label: "Integrations", path: "/admin/integrations", icon: Plug },
+      { label: "War Room", path: "/admin/war-room", icon: Radar },
       { label: "Audit Log", path: "/admin/audit", icon: FileSearch },
     ],
   },

--- a/src/components/desktop/DesktopShell.tsx
+++ b/src/components/desktop/DesktopShell.tsx
@@ -138,6 +138,8 @@ function DesktopShellContent() {
   );
 }
 
+const MAIN_SITE_ONBOARDING_KEY = "desktop-onboarding-complete";
+
 export default function DesktopShell() {
   const { isSignedIn, isLoaded, user } = useAuth();
   const { tenant, status, isMainSite, refreshTenant } = useTenant();
@@ -153,6 +155,23 @@ export default function DesktopShell() {
 
   if (!isSignedIn || !user) {
     return <Navigate to="/admin/login" replace />;
+  }
+
+  // Show onboarding wizard for main site owner on first desktop visit
+  if (isMainSite && !wizardDismissed) {
+    const alreadyCompleted =
+      localStorage.getItem(MAIN_SITE_ONBOARDING_KEY) === "true";
+    if (!alreadyCompleted) {
+      return (
+        <OnboardingWizard
+          initialStep={0}
+          onComplete={() => {
+            localStorage.setItem(MAIN_SITE_ONBOARDING_KEY, "true");
+            setWizardDismissed(true);
+          }}
+        />
+      );
+    }
   }
 
   // Show onboarding wizard for tenant users who haven't completed setup

--- a/src/components/desktop/Spotlight.tsx
+++ b/src/components/desktop/Spotlight.tsx
@@ -31,6 +31,16 @@ import {
   User,
   Sparkles,
   Palette,
+  Terminal,
+  Activity,
+  StickyNote,
+  Database,
+  Radar,
+  Hammer,
+  Calendar,
+  Shield,
+  ShieldCheck,
+  Handshake,
 } from "lucide-react";
 import { useReducedMotion } from "@/lib/reduced-motion";
 import { useWindowManagerContext } from "./WindowManager";
@@ -69,6 +79,16 @@ const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
   Palette,
   FolderOpen,
   Package,
+  Terminal,
+  Activity,
+  StickyNote,
+  Database,
+  Radar,
+  Hammer,
+  Calendar,
+  Shield,
+  ShieldCheck,
+  Handshake,
 };
 
 interface SpotlightProps {

--- a/src/hooks/useBilling.ts
+++ b/src/hooks/useBilling.ts
@@ -21,15 +21,18 @@ interface BillingState {
 }
 
 export function useBilling(): BillingState {
-  const { tenant } = useTenant();
+  const { tenant, isMainSite } = useTenant();
 
   return useMemo(() => {
-    const plan = parsePlanFromSettings(tenant?.settings);
+    // Main site owner gets full access to all apps/features
+    const plan: PlanTier = isMainSite
+      ? "enterprise"
+      : parsePlanFromSettings(tenant?.settings);
     return {
       plan,
       limits: getPlanLimits(plan),
       isPastDue: isSubscriptionPastDue(tenant?.settings),
       isFreePlan: plan === "free",
     };
-  }, [tenant?.settings]);
+  }, [tenant?.settings, isMainSite]);
 }


### PR DESCRIPTION
## Summary
- **Main site owner was locked to free plan** — `parsePlanFromSettings(null)` defaulted to `"free"`, hiding 21 of 29 desktop apps. Fixed by returning `"enterprise"` when `isMainSite` is true in `useBilling`.
- **No onboarding wizard for main site** — wizard was explicitly excluded with `!isMainSite`. Now shows on first desktop visit using localStorage state.
- **5 admin pages had no routes** — AgentWarRoom, ApiAccess, DataManagement, DedicatedInstance, PartnerProgram were registered in the desktop AppRegistry but unreachable via sidebar/URL. Added routes and sidebar entries.
- **Spotlight missing 10 icons** — Terminal, Activity, StickyNote, Database, Radar, Hammer, Calendar, Shield, ShieldCheck, Handshake now render properly in search results.
- **No 404 fallback** — invalid `/admin/*` paths showed blank page. Added catch-all redirect to dashboard.

## Test plan
- [ ] Navigate to `/admin/desktop` — should see onboarding wizard on first visit
- [ ] Complete or skip wizard — desktop OS loads with all 29 apps available in dock/spotlight
- [ ] Open Spotlight (Cmd+Space) and search for "Terminal", "War Room" etc. — icons render correctly
- [ ] Navigate to `/admin/war-room`, `/admin/api-access`, `/admin/data-management`, `/admin/dedicated-instance`, `/admin/partner-program` — all load
- [ ] Verify sidebar shows new entries under Platform and Agent Platform sections
- [ ] Navigate to `/admin/nonexistent` — redirects to dashboard
- [ ] Verify tenant subdomain users still see proper plan-gated experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)