### PR TITLE
fix: desktop windows now movable/resizable, dock pins persist

### DIFF
--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -535,6 +535,11 @@ const AdminLayout = ({ children }: AdminLayoutProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname]);
 
+  // Inside desktop OS shell — skip admin chrome, DesktopShell handles auth
+  if (location.pathname.startsWith("/admin/desktop")) {
+    return <>{children}</>;
+  }
+
   if (!isLoaded) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">

--- a/src/components/desktop/OnboardingWizard.tsx
+++ b/src/components/desktop/OnboardingWizard.tsx
@@ -205,6 +205,11 @@ export default function OnboardingWizard({
         } else if (currentStep === 2) {
           await saveEnabledApps(enabledApps);
           await saveDockPinned(dockPinned);
+          // Also persist to localStorage as fallback (main site has no tenant to save to)
+          localStorage.setItem(
+            "desktop-onboarding-dock-pins",
+            JSON.stringify(dockPinned),
+          );
         } else if (currentStep === 3) {
           await sendInvites();
         }

--- a/src/components/desktop/apps/FileExplorer.tsx
+++ b/src/components/desktop/apps/FileExplorer.tsx
@@ -274,7 +274,7 @@ export default function FileExplorer() {
     <div
       ref={containerRef}
       tabIndex={-1}
-      className="flex flex-col h-full -m-8 bg-background outline-none"
+      className="flex flex-col h-full bg-background outline-none"
     >
       <FileExplorerToolbar
         currentPath={fs.currentPath}

--- a/src/hooks/useDesktopWorkspace.ts
+++ b/src/hooks/useDesktopWorkspace.ts
@@ -161,6 +161,27 @@ export function useDesktopWorkspace({
           if (appIds.length > 0) {
             setDockItems(appIds);
           }
+        } else {
+          // Check localStorage for dock pins set during onboarding (main site fallback)
+          const onboardingPins = localStorage.getItem(
+            "desktop-onboarding-dock-pins",
+          );
+          if (onboardingPins) {
+            try {
+              const pins = JSON.parse(onboardingPins) as string[];
+              const validPins = pins.filter((id) => !!getApp(id));
+              if (validPins.length > 0) {
+                setDockItems(validPins);
+                // Save to workspace so they persist properly going forward
+                saveWorkspace(ws.id, {
+                  dock_items: validPins.map((appId) => ({ appId })),
+                }).catch(() => {});
+              }
+            } catch {
+              // Invalid JSON, ignore
+            }
+            localStorage.removeItem("desktop-onboarding-dock-pins");
+          }
         }
 
         // Restore window states (handles both legacy array and versioned format)


### PR DESCRIPTION
## Summary
- **Admin pages in desktop windows were static/unmovable** — every admin page wraps itself in `AdminLayout` which rendered a full sidebar+header shell inside each window. AdminLayout now detects `/admin/desktop` route and returns just `{children}`, letting the Window component's drag/resize/minimize/maximize work properly.
- **FileExplorer had `-m-8` hack** pushing content outside window bounds, causing the toolbar to overlap the title bar. Removed.
- **Onboarding dock pins didn't persist for main site** — the wizard saved pins via tenant RPC which fails silently when there's no tenant. Now also saves to localStorage, and the workspace hook picks them up on first load and persists them to the workspace.

## Test plan
- [ ] Open any app in desktop OS (Blog, Tasks, AI Manager, etc.) — should have stoplight buttons, be draggable, resizable, minimizable
- [ ] Open File Explorer — toolbar should be below the title bar, content properly contained
- [ ] Complete onboarding wizard, pin several apps — all pinned apps should appear in the dock after launch
- [ ] Close/reopen desktop — dock pins should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)