### PR TITLE
fix: update mobile status bar clock every second

### DIFF
--- a/src/components/desktop/MobileShell.tsx
+++ b/src/components/desktop/MobileShell.tsx
@@ -1,4 +1,11 @@
-import { useState, useCallback, useMemo, Suspense, lazy } from "react";
+import {
+  useState,
+  useCallback,
+  useMemo,
+  useEffect,
+  Suspense,
+  lazy,
+} from "react";
 import { useWindowManagerContext, useWorkspaceContext } from "./WindowManager";
 import { getApp, getAppsForTenant } from "./apps/AppRegistry";
 import { ArrowLeft, Search, Clock } from "lucide-react";
@@ -15,11 +22,17 @@ function MobileStatusBar({
   currentAppName: string | null;
   onSpotlightOpen: () => void;
 }) {
-  const now = new Date();
-  const timeString = now.toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  const formatTime = () =>
+    new Date().toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  const [timeString, setTimeString] = useState(formatTime);
+
+  useEffect(() => {
+    const interval = setInterval(() => setTimeString(formatTime()), 1_000);
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <div className="h-14 bg-card/80 backdrop-blur-md border-b border-border flex items-center justify-between px-4 sticky top-0 z-10">


### PR DESCRIPTION
## Summary
- Mobile status bar clock was computed once on render and never updated
- Added `useState` + `useEffect` with `setInterval` to update every second
- Matches the desktop `MenuBar.tsx` clock pattern

## Test plan
- [ ] View the mobile layout and verify the clock updates in real time
- [ ] Wait 60+ seconds and confirm the minute changes

Fixes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)