### PR TITLE
feat: Signal wealth-compounding workspace scaffold

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,6 +154,17 @@ const PublicPage = lazy(() => import("./pages/PublicPage"));
 // Public generative UI panels
 const PanelPage = lazy(() => import("./pages/PanelPage"));
 
+// Signal workspace pages
+const SignalDashboard = lazy(() => import("./pages/signal/Dashboard"));
+const SignalPortfolio = lazy(() => import("./pages/signal/Portfolio"));
+const SignalWatchlist = lazy(() => import("./pages/signal/Watchlist"));
+const SignalFeed = lazy(() => import("./pages/signal/SignalFeed"));
+const SignalFirings = lazy(() => import("./pages/signal/Firings"));
+const SignalCatalysts = lazy(() => import("./pages/signal/Catalysts"));
+const SignalDiscipline = lazy(() => import("./pages/signal/Discipline"));
+const SignalJournal = lazy(() => import("./pages/signal/Journal"));
+const SignalSettings = lazy(() => import("./pages/signal/Settings"));
+
 // Minimal loading fallback
 function PageLoader() {
   return (
@@ -221,6 +232,36 @@ function TenantGate({ children }: { children: React.ReactNode }) {
 
   // "main_site" and "resolved" both render the app.
   return <>{children}</>;
+}
+
+// Route-specific error fallback for Signal workspace
+function SignalErrorFallback() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-2xl font-bold text-foreground mb-2">
+          Signal error
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          Something went wrong in Signal. Your data is safe.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <a
+            href="/signal"
+            className="px-4 py-2 bg-primary text-primary-foreground rounded-lg font-medium hover:opacity-90 transition-opacity"
+          >
+            Go to dashboard
+          </a>
+          <a
+            href="/admin"
+            className="px-4 py-2 border border-border text-foreground rounded-lg font-medium hover:bg-muted transition-colors"
+          >
+            Admin panel
+          </a>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 // Route-specific error fallback for admin section
@@ -668,9 +709,31 @@ function AdminRoutes() {
   );
 }
 
+function SignalRoutes() {
+  return (
+    <ErrorBoundary fallback={<SignalErrorFallback />}>
+      <Suspense fallback={<PageLoader />}>
+        <Routes>
+          <Route path="/signal" element={<SignalDashboard />} />
+          <Route path="/signal/portfolio" element={<SignalPortfolio />} />
+          <Route path="/signal/watchlist" element={<SignalWatchlist />} />
+          <Route path="/signal/signals" element={<SignalFeed />} />
+          <Route path="/signal/firings" element={<SignalFirings />} />
+          <Route path="/signal/catalysts" element={<SignalCatalysts />} />
+          <Route path="/signal/discipline" element={<SignalDiscipline />} />
+          <Route path="/signal/journal" element={<SignalJournal />} />
+          <Route path="/signal/settings" element={<SignalSettings />} />
+          <Route path="/signal/*" element={<Navigate to="/signal" replace />} />
+        </Routes>
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
 function AppContent() {
   const location = useLocation();
   const isAdminRoute = location.pathname.startsWith("/admin");
+  const isSignalRoute = location.pathname.startsWith("/signal");
   const isCustomPage = location.pathname.startsWith("/p/");
   const isPanelPage = location.pathname.startsWith("/panel/");
   const isRecoveryTracker = location.pathname === "/recovery-tracker";
@@ -678,6 +741,10 @@ function AppContent() {
   // Don't track admin routes in analytics
   if (isAdminRoute) {
     return <AdminRoutes />;
+  }
+
+  if (isSignalRoute) {
+    return <SignalRoutes />;
   }
 
   // Custom pages, panels, and standalone apps don't need the default Layout

--- a/src/components/SignalLayout.tsx
+++ b/src/components/SignalLayout.tsx
@@ -1,0 +1,415 @@
+import { ReactNode, useState, useEffect, useCallback } from "react";
+import { Link, useLocation, Navigate } from "react-router-dom";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import {
+  LayoutDashboard,
+  Briefcase,
+  Eye,
+  Radio,
+  Zap,
+  Calendar,
+  Shield,
+  BookOpen,
+  Settings,
+  ArrowLeft,
+  Menu,
+  X,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  Bell,
+} from "lucide-react";
+import { useAuth } from "@/lib/auth";
+import { ThemeToggleMinimal } from "./ThemeToggle";
+import { BREAKPOINTS } from "@/lib/constants";
+
+interface SignalLayoutProps {
+  children: ReactNode;
+  alertCount?: number;
+}
+
+interface NavItem {
+  label: string;
+  path: string;
+  icon: typeof LayoutDashboard;
+}
+
+interface NavSection {
+  id: string;
+  label: string;
+  items: NavItem[];
+}
+
+const pinnedItem: NavItem = {
+  label: "Dashboard",
+  path: "/signal",
+  icon: LayoutDashboard,
+};
+
+const navSections: NavSection[] = [
+  {
+    id: "portfolio",
+    label: "Portfolio",
+    items: [
+      { label: "Holdings", path: "/signal/portfolio", icon: Briefcase },
+      { label: "Watchlist", path: "/signal/watchlist", icon: Eye },
+      { label: "Catalysts", path: "/signal/catalysts", icon: Calendar },
+    ],
+  },
+  {
+    id: "intelligence",
+    label: "Intelligence",
+    items: [
+      { label: "Signals", path: "/signal/signals", icon: Radio },
+      { label: "Firings", path: "/signal/firings", icon: Zap },
+    ],
+  },
+  {
+    id: "discipline",
+    label: "Discipline",
+    items: [
+      { label: "Rules", path: "/signal/discipline", icon: Shield },
+      { label: "Journal", path: "/signal/journal", icon: BookOpen },
+    ],
+  },
+];
+
+const SIDEBAR_WIDTH = 220;
+const SIGNAL_SIDEBAR_KEY = "signal_sidebar_collapsed";
+const SIGNAL_SECTIONS_KEY = "signal_sidebar_sections";
+
+const spring = { type: "spring" as const, stiffness: 400, damping: 40 };
+
+function loadSections(): Record<string, boolean> {
+  try {
+    const s = localStorage.getItem(SIGNAL_SECTIONS_KEY);
+    if (s) return JSON.parse(s);
+  } catch {
+    /* ignore */
+  }
+  return Object.fromEntries(navSections.map((s) => [s.id, true]));
+}
+
+function NavLink({
+  item,
+  active,
+  onClick,
+  badge,
+}: {
+  item: NavItem;
+  active: boolean;
+  onClick: () => void;
+  badge?: number;
+}) {
+  const Icon = item.icon;
+  return (
+    <Link
+      to={item.path}
+      onClick={onClick}
+      className={`flex items-center gap-2.5 px-3 py-1.5 rounded-md transition-colors duration-150 whitespace-nowrap ${
+        active
+          ? "bg-primary/10 text-primary"
+          : "text-muted-foreground hover:text-foreground hover:bg-muted"
+      }`}
+    >
+      <Icon className="w-3.5 h-3.5 flex-shrink-0" />
+      <span className="text-xs font-medium">{item.label}</span>
+      {badge !== undefined && badge > 0 && (
+        <span className="ml-auto text-[10px] font-mono bg-destructive/15 text-destructive px-1.5 py-0.5 rounded-full">
+          {badge}
+        </span>
+      )}
+    </Link>
+  );
+}
+
+function SidebarContent({
+  location,
+  onNavClick,
+  expanded,
+  toggleSection,
+  alertCount,
+}: {
+  location: ReturnType<typeof useLocation>;
+  onNavClick: () => void;
+  expanded: Record<string, boolean>;
+  toggleSection: (id: string) => void;
+  alertCount?: number;
+}) {
+  const isActive = (path: string) =>
+    path === "/signal"
+      ? location.pathname === "/signal"
+      : location.pathname.startsWith(path);
+
+  return (
+    <>
+      <nav className="flex-1 px-2 py-3 overflow-y-auto space-y-0.5">
+        <NavLink
+          item={pinnedItem}
+          active={isActive("/signal")}
+          onClick={onNavClick}
+        />
+
+        <div className="pt-2" />
+
+        {navSections.map((section) => {
+          const isExpanded = expanded[section.id] ?? true;
+          return (
+            <div key={section.id}>
+              <button
+                onClick={() => toggleSection(section.id)}
+                className="w-full flex items-center justify-between px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 hover:text-muted-foreground transition-colors"
+                aria-expanded={isExpanded}
+              >
+                <span>{section.label}</span>
+                {isExpanded ? (
+                  <ChevronDown className="w-3 h-3" />
+                ) : (
+                  <ChevronRight className="w-3 h-3" />
+                )}
+              </button>
+              <AnimatePresence initial={false}>
+                {isExpanded && (
+                  <motion.div
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: "auto", opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: 0.15, ease: "easeInOut" }}
+                    className="overflow-hidden"
+                  >
+                    <div className="space-y-0.5 pb-1">
+                      {section.items.map((item) => (
+                        <NavLink
+                          key={item.path}
+                          item={item}
+                          active={isActive(item.path)}
+                          onClick={onNavClick}
+                          badge={
+                            item.path === "/signal/firings"
+                              ? alertCount
+                              : undefined
+                          }
+                        />
+                      ))}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          );
+        })}
+
+        <div className="border-t border-border my-2" />
+
+        <NavLink
+          item={{ label: "Settings", path: "/signal/settings", icon: Settings }}
+          active={isActive("/signal/settings")}
+          onClick={onNavClick}
+        />
+      </nav>
+
+      <div className="px-2 py-3 border-t border-border flex-shrink-0">
+        <Link
+          to="/admin"
+          className="flex items-center gap-2.5 px-3 py-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors whitespace-nowrap"
+        >
+          <ArrowLeft className="w-3.5 h-3.5 flex-shrink-0" />
+          <span className="text-xs font-medium">Admin panel</span>
+        </Link>
+      </div>
+    </>
+  );
+}
+
+export default function SignalLayout({
+  children,
+  alertCount,
+}: SignalLayoutProps) {
+  const location = useLocation();
+  const { user, isSignedIn, isLoaded } = useAuth();
+  const prefersReducedMotion = useReducedMotion();
+
+  const [sidebarOpen, setSidebarOpen] = useState(() => {
+    if (typeof window === "undefined") return true;
+    const stored = localStorage.getItem(SIGNAL_SIDEBAR_KEY);
+    if (stored !== null) return stored !== "true";
+    return window.innerWidth >= BREAKPOINTS.md;
+  });
+
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== "undefined" && window.innerWidth < BREAKPOINTS.md,
+  );
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarOpen((prev) => {
+      const next = !prev;
+      localStorage.setItem(SIGNAL_SIDEBAR_KEY, (!next).toString());
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    let t: ReturnType<typeof setTimeout>;
+    const onResize = () => {
+      clearTimeout(t);
+      t = setTimeout(
+        () => setIsMobile(window.innerWidth < BREAKPOINTS.md),
+        100,
+      );
+    };
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      clearTimeout(t);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isMobile && sidebarOpen) setSidebarOpen(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
+
+  const [expandedSections, setExpandedSections] =
+    useState<Record<string, boolean>>(loadSections);
+
+  const toggleSection = useCallback((id: string) => {
+    setExpandedSections((prev) => {
+      const next = { ...prev, [id]: !prev[id] };
+      try {
+        localStorage.setItem(SIGNAL_SECTIONS_KEY, JSON.stringify(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
+
+  const desktopVariants = prefersReducedMotion
+    ? {
+        open: { width: SIDEBAR_WIDTH, opacity: 1 },
+        closed: { width: 0, opacity: 0 },
+      }
+    : {
+        open: { width: SIDEBAR_WIDTH, opacity: 1, transition: spring },
+        closed: { width: 0, opacity: 0, transition: spring },
+      };
+
+  const mobileVariants = prefersReducedMotion
+    ? { open: { x: 0, opacity: 1 }, closed: { x: -SIDEBAR_WIDTH, opacity: 0 } }
+    : {
+        open: { x: 0, opacity: 1, transition: spring },
+        closed: { x: -SIDEBAR_WIDTH, opacity: 0, transition: spring },
+      };
+
+  if (!isLoaded) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!isSignedIn || !user) {
+    return <Navigate to="/admin/login" replace />;
+  }
+
+  const handleNavClick = () => {
+    if (isMobile) setSidebarOpen(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="fixed top-0 left-0 right-0 h-12 bg-card border-b border-border z-50">
+        <div className="h-full flex items-center justify-between px-4">
+          <button
+            onClick={toggleSidebar}
+            aria-expanded={sidebarOpen}
+            aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
+            className="flex items-center gap-2 font-mono text-sm text-foreground hover:text-primary transition-colors"
+          >
+            <span className="md:hidden">
+              {sidebarOpen ? (
+                <X className="w-4 h-4" />
+              ) : (
+                <Menu className="w-4 h-4" />
+              )}
+            </span>
+            <span className="hidden md:inline">signal_</span>
+          </button>
+
+          <div className="flex items-center gap-3">
+            {alertCount !== undefined && alertCount > 0 && (
+              <Link
+                to="/signal/firings"
+                className="relative p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                aria-label={`${alertCount} active firings`}
+              >
+                <Bell className="w-4 h-4" />
+                <span className="absolute top-0.5 right-0.5 w-2 h-2 bg-destructive rounded-full" />
+              </Link>
+            )}
+            <ThemeToggleMinimal />
+          </div>
+        </div>
+      </header>
+
+      <div className="pt-12 flex min-h-screen">
+        <AnimatePresence>
+          {sidebarOpen && isMobile && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setSidebarOpen(false)}
+              className="fixed inset-0 top-12 bg-black/50 z-40 md:hidden"
+              aria-hidden="true"
+            />
+          )}
+        </AnimatePresence>
+
+        <AnimatePresence>
+          {sidebarOpen && isMobile && (
+            <motion.aside
+              initial="closed"
+              animate="open"
+              exit="closed"
+              variants={mobileVariants}
+              style={{ width: SIDEBAR_WIDTH }}
+              className="fixed top-12 left-0 bottom-0 bg-card border-r border-border flex flex-col z-40 md:hidden overflow-hidden"
+            >
+              <SidebarContent
+                location={location}
+                onNavClick={handleNavClick}
+                expanded={expandedSections}
+                toggleSection={toggleSection}
+                alertCount={alertCount}
+              />
+            </motion.aside>
+          )}
+        </AnimatePresence>
+
+        <motion.aside
+          initial={false}
+          animate={sidebarOpen ? "open" : "closed"}
+          variants={desktopVariants}
+          className="hidden md:flex sticky top-12 h-[calc(100vh-3rem)] bg-card border-r border-border flex-col flex-shrink-0 overflow-hidden will-change-[width]"
+        >
+          <div
+            className="h-full flex flex-col"
+            style={{ width: SIDEBAR_WIDTH }}
+          >
+            <SidebarContent
+              location={location}
+              onNavClick={handleNavClick}
+              expanded={expandedSections}
+              toggleSection={toggleSection}
+              alertCount={alertCount}
+            />
+          </div>
+        </motion.aside>
+
+        <main className="flex-1 min-w-0 overflow-auto">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/signal/Catalysts.tsx
+++ b/src/pages/signal/Catalysts.tsx
@@ -1,0 +1,262 @@
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Calendar, Plus, X, ChevronDown } from "lucide-react";
+import SignalLayout from "@/components/SignalLayout";
+import { useSEO } from "@/lib/seo";
+
+type CatalystType =
+  | "earnings"
+  | "macro"
+  | "policy"
+  | "custom"
+  | "expected_announcement";
+type Impact = "low" | "medium" | "high";
+
+const typeColors: Record<CatalystType, string> = {
+  earnings: "bg-blue-500/15 text-blue-500",
+  macro: "bg-violet-500/15 text-violet-500",
+  policy: "bg-amber-500/15 text-amber-500",
+  custom: "bg-slate-500/15 text-slate-400",
+  expected_announcement: "bg-emerald-500/15 text-emerald-500",
+};
+
+const impactDot: Record<Impact, string> = {
+  low: "bg-slate-400",
+  medium: "bg-amber-500",
+  high: "bg-red-500",
+};
+
+const macroEvents = [
+  {
+    date: "2026-05-13",
+    label: "CPI — April",
+    type: "macro" as const,
+    impact: "high" as const,
+  },
+  {
+    date: "2026-05-22",
+    label: "FOMC minutes",
+    type: "macro" as const,
+    impact: "high" as const,
+  },
+  {
+    date: "2026-06-06",
+    label: "NFP report",
+    type: "macro" as const,
+    impact: "medium" as const,
+  },
+  {
+    date: "2026-06-17",
+    label: "FOMC decision",
+    type: "macro" as const,
+    impact: "high" as const,
+  },
+];
+
+export default function Catalysts() {
+  useSEO({ title: "Signal — Catalysts", noIndex: true });
+  const [showAdd, setShowAdd] = useState(false);
+  const [form, setForm] = useState({
+    ticker: "",
+    type: "custom" as CatalystType,
+    scheduledFor: "",
+    impact: "medium" as Impact,
+    description: "",
+  });
+
+  return (
+    <SignalLayout>
+      <div className="p-6 max-w-4xl space-y-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-medium">Catalyst calendar</h1>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Earnings, macro events, and custom catalysts
+            </p>
+          </div>
+          <button
+            onClick={() => setShowAdd((v) => !v)}
+            className="flex items-center gap-2 px-3 py-1.5 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:opacity-90 transition-opacity"
+          >
+            {showAdd ? (
+              <X className="w-3.5 h-3.5" />
+            ) : (
+              <Plus className="w-3.5 h-3.5" />
+            )}
+            {showAdd ? "Cancel" : "Add catalyst"}
+          </button>
+        </div>
+
+        <AnimatePresence>
+          {showAdd && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              className="overflow-hidden"
+            >
+              <div className="bg-card border border-border rounded-lg p-5">
+                <h2 className="text-sm font-medium mb-4">New catalyst</h2>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Ticker (optional)
+                    </label>
+                    <input
+                      type="text"
+                      value={form.ticker}
+                      onChange={(e) =>
+                        setForm((p) => ({
+                          ...p,
+                          ticker: e.target.value.toUpperCase(),
+                        }))
+                      }
+                      placeholder="NVDA"
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Type
+                    </label>
+                    <div className="relative">
+                      <select
+                        value={form.type}
+                        onChange={(e) =>
+                          setForm((p) => ({
+                            ...p,
+                            type: e.target.value as CatalystType,
+                          }))
+                        }
+                        className="w-full appearance-none px-3 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary pr-8"
+                      >
+                        <option value="earnings">Earnings</option>
+                        <option value="macro">Macro</option>
+                        <option value="policy">Policy</option>
+                        <option value="expected_announcement">
+                          Expected announcement
+                        </option>
+                        <option value="custom">Custom</option>
+                      </select>
+                      <ChevronDown className="absolute right-2.5 top-2.5 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Date
+                    </label>
+                    <input
+                      type="date"
+                      value={form.scheduledFor}
+                      onChange={(e) =>
+                        setForm((p) => ({ ...p, scheduledFor: e.target.value }))
+                      }
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Impact
+                    </label>
+                    <div className="relative">
+                      <select
+                        value={form.impact}
+                        onChange={(e) =>
+                          setForm((p) => ({
+                            ...p,
+                            impact: e.target.value as Impact,
+                          }))
+                        }
+                        className="w-full appearance-none px-3 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary pr-8"
+                      >
+                        <option value="low">Low</option>
+                        <option value="medium">Medium</option>
+                        <option value="high">High</option>
+                      </select>
+                      <ChevronDown className="absolute right-2.5 top-2.5 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+                    </div>
+                  </div>
+                  <div className="md:col-span-2">
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Description
+                    </label>
+                    <input
+                      type="text"
+                      value={form.description}
+                      onChange={(e) =>
+                        setForm((p) => ({ ...p, description: e.target.value }))
+                      }
+                      placeholder="What are you expecting?"
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                </div>
+                <div className="flex items-center gap-3 mt-4">
+                  <button
+                    disabled
+                    className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-xs font-medium opacity-50 cursor-not-allowed"
+                  >
+                    Save catalyst
+                  </button>
+                  <p className="text-[11px] text-muted-foreground">
+                    Connect Supabase to persist catalysts
+                  </p>
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Macro calendar */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="px-4 py-3 border-b border-border">
+            <h2 className="text-sm font-medium">Macro events</h2>
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              Sourced from public macro calendar
+            </p>
+          </div>
+          <div className="divide-y divide-border">
+            {macroEvents.map((e) => (
+              <div key={e.label} className="flex items-center gap-4 px-4 py-3">
+                <div className="w-16 flex-shrink-0">
+                  <p className="text-[11px] font-mono text-muted-foreground">
+                    {e.date}
+                  </p>
+                </div>
+                <span
+                  className={`text-[10px] font-mono px-2 py-0.5 rounded-full flex-shrink-0 ${typeColors[e.type]}`}
+                >
+                  {e.type}
+                </span>
+                <p className="text-xs flex-1">{e.label}</p>
+                <div
+                  className={`w-2 h-2 rounded-full flex-shrink-0 ${impactDot[e.impact]}`}
+                  title={`${e.impact} impact`}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Custom + earnings catalysts */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <div className="flex items-center gap-2">
+              <Calendar className="w-4 h-4 text-muted-foreground" />
+              <h2 className="text-sm font-medium">Earnings &amp; custom</h2>
+            </div>
+          </div>
+          <div className="px-4 py-10 text-center">
+            <p className="text-xs text-muted-foreground">
+              No earnings dates loaded
+            </p>
+            <p className="text-[11px] text-muted-foreground/60 mt-1">
+              Add tickers to your portfolio or watchlist to auto-populate
+              earnings dates
+            </p>
+          </div>
+        </div>
+      </div>
+    </SignalLayout>
+  );
+}

--- a/src/pages/signal/Dashboard.tsx
+++ b/src/pages/signal/Dashboard.tsx
@@ -1,0 +1,272 @@
+import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
+import { Zap, Calendar, CheckSquare, ArrowRight, Plus } from "lucide-react";
+import SignalLayout from "@/components/SignalLayout";
+import { useSEO } from "@/lib/seo";
+
+const tierColors: Record<string, string> = {
+  anchor: "text-blue-500 bg-blue-500/10",
+  capex_flow: "text-violet-500 bg-violet-500/10",
+  moonshot: "text-orange-500 bg-orange-500/10",
+  cash: "text-slate-400 bg-slate-500/10",
+};
+
+const tiers = ["anchor", "capex_flow", "moonshot", "cash"];
+
+const checklistItems = [
+  "Review active firings",
+  "Check concentration limits",
+  "Scan upcoming catalysts",
+  "Plan Friday deployment",
+  "Update journal",
+];
+
+const metrics = [
+  { label: "Today P/L", value: "$0", sub: "+0.00%", delta: 0 },
+  { label: "YTD return", value: "0.00%", delta: 0 },
+  { label: "vs SPY", value: "0.00%", sub: "year to date", delta: 0 },
+  { label: "Next deploy", value: "Friday", sub: "$0 queued" },
+];
+
+export default function Dashboard() {
+  useSEO({ title: "Signal — Dashboard", noIndex: true });
+
+  return (
+    <SignalLayout>
+      <div className="p-6 space-y-5 max-w-5xl">
+        {/* Portfolio header */}
+        <div className="flex items-end justify-between">
+          <div>
+            <p className="text-[11px] text-muted-foreground uppercase tracking-wider mb-1">
+              Portfolio value
+            </p>
+            <div className="flex items-baseline gap-3">
+              <span className="text-4xl font-mono font-medium tabular-nums">
+                $0
+              </span>
+              <span className="text-sm font-mono text-muted-foreground tabular-nums">
+                cash $0
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground font-mono mt-1">
+              today +$0.00 &nbsp;(0.00%)
+            </p>
+          </div>
+          <Link
+            to="/signal/portfolio"
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:opacity-90 transition-opacity"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add position
+          </Link>
+        </div>
+
+        {/* Metric grid */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {metrics.map((m, i) => (
+            <motion.div
+              key={m.label}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.05 }}
+              className="bg-card border border-border rounded-lg p-4"
+            >
+              <p className="text-[11px] text-muted-foreground uppercase tracking-wider mb-2">
+                {m.label}
+              </p>
+              <p
+                className={`text-xl font-mono tabular-nums ${
+                  m.delta !== undefined
+                    ? m.delta > 0
+                      ? "text-emerald-500"
+                      : m.delta < 0
+                        ? "text-red-500"
+                        : "text-foreground"
+                    : "text-foreground"
+                }`}
+              >
+                {m.value}
+              </p>
+              {m.sub && (
+                <p className="text-[11px] text-muted-foreground font-mono mt-0.5">
+                  {m.sub}
+                </p>
+              )}
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Holdings by tier */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <h2 className="text-sm font-medium">Holdings</h2>
+            <Link
+              to="/signal/portfolio"
+              className="text-[11px] text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
+            >
+              all positions <ArrowRight className="w-3 h-3" />
+            </Link>
+          </div>
+          {tiers.map((tier) => (
+            <div
+              key={tier}
+              className="px-4 py-3 border-b border-border last:border-0"
+            >
+              <div className="flex items-center justify-between">
+                <span
+                  className={`text-[10px] font-mono px-2 py-0.5 rounded-full ${tierColors[tier]}`}
+                >
+                  {tier.replace("_", " ")}
+                </span>
+                <span className="text-xs text-muted-foreground font-mono">
+                  $0 · 0%
+                </span>
+              </div>
+              <p className="text-[11px] text-muted-foreground/60 mt-2">
+                No positions — add your first holding
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Checklist + active alerts */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="bg-card border border-border rounded-lg overflow-hidden">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+              <div className="flex items-center gap-2">
+                <CheckSquare className="w-4 h-4 text-muted-foreground" />
+                <h2 className="text-sm font-medium">This week</h2>
+              </div>
+              <span className="text-[11px] font-mono text-muted-foreground">
+                0 / {checklistItems.length}
+              </span>
+            </div>
+            <div className="divide-y divide-border">
+              {checklistItems.map((item, i) => (
+                <div key={i} className="flex items-center gap-3 px-4 py-2.5">
+                  <div className="w-3.5 h-3.5 rounded border border-border flex-shrink-0" />
+                  <span className="text-xs text-muted-foreground">{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="bg-card border border-border rounded-lg overflow-hidden">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+              <div className="flex items-center gap-2">
+                <Zap className="w-4 h-4 text-muted-foreground" />
+                <h2 className="text-sm font-medium">Active alerts</h2>
+              </div>
+              <Link
+                to="/signal/firings"
+                className="text-[11px] text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
+              >
+                all <ArrowRight className="w-3 h-3" />
+              </Link>
+            </div>
+            <div className="px-4 py-10 text-center">
+              <p className="text-xs text-muted-foreground">No active firings</p>
+              <p className="text-[11px] text-muted-foreground/50 mt-1">
+                Signal engine not yet running
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Upcoming catalysts */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <div className="flex items-center gap-2">
+              <Calendar className="w-4 h-4 text-muted-foreground" />
+              <h2 className="text-sm font-medium">Upcoming catalysts</h2>
+            </div>
+            <Link
+              to="/signal/catalysts"
+              className="text-[11px] text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
+            >
+              calendar <ArrowRight className="w-3 h-3" />
+            </Link>
+          </div>
+          <div className="px-4 py-8 text-center">
+            <p className="text-xs text-muted-foreground">No catalysts added</p>
+            <p className="text-[11px] text-muted-foreground/50 mt-1">
+              Add positions to auto-populate earnings dates
+            </p>
+          </div>
+        </div>
+
+        {/* Smart money feed */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <h2 className="text-sm font-medium">Smart money feed</h2>
+            <Link
+              to="/signal/firings"
+              className="text-[11px] text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
+            >
+              all firings <ArrowRight className="w-3 h-3" />
+            </Link>
+          </div>
+          <div className="px-4 py-8 text-center">
+            <p className="text-xs text-muted-foreground">
+              Signal ingestion not yet configured
+            </p>
+            <Link
+              to="/signal/settings"
+              className="text-[11px] text-primary hover:underline mt-2 inline-block"
+            >
+              Configure signal sources →
+            </Link>
+          </div>
+        </div>
+
+        {/* Friday deployment plan */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <div>
+              <h2 className="text-sm font-medium">Friday deployment plan</h2>
+              <p className="text-[11px] text-muted-foreground">
+                $0 available to deploy
+              </p>
+            </div>
+            <Link
+              to="/signal/discipline"
+              className="text-[11px] text-muted-foreground hover:text-foreground flex items-center gap-1 transition-colors"
+            >
+              configure <ArrowRight className="w-3 h-3" />
+            </Link>
+          </div>
+          <div className="px-4 py-4 grid grid-cols-2 md:grid-cols-4 gap-3">
+            {tiers.map((tier) => (
+              <div key={tier} className="text-center">
+                <span
+                  className={`text-[10px] font-mono px-2 py-0.5 rounded-full inline-block ${tierColors[tier]} mb-2`}
+                >
+                  {tier.replace("_", " ")}
+                </span>
+                <p className="text-sm font-mono tabular-nums">$0</p>
+                <p className="text-[10px] text-muted-foreground">0% target</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Action bar */}
+        <div className="flex items-center gap-3 pb-8">
+          <Link
+            to="/signal/portfolio"
+            className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:opacity-90 transition-opacity"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add position
+          </Link>
+          <Link
+            to="/signal/journal"
+            className="flex items-center gap-2 px-4 py-2 border border-border text-foreground rounded-lg text-xs font-medium hover:bg-muted transition-colors"
+          >
+            Write note
+          </Link>
+        </div>
+      </div>
+    </SignalLayout>
+  );
+}

--- a/src/pages/signal/Discipline.tsx
+++ b/src/pages/signal/Discipline.tsx
@@ -1,0 +1,211 @@
+import { useState } from "react";
+import { Shield, AlertTriangle, CheckSquare } from "lucide-react";
+import SignalLayout from "@/components/SignalLayout";
+import { useSEO } from "@/lib/seo";
+
+interface Rule {
+  id: string;
+  type: string;
+  label: string;
+  description: string;
+  config: string;
+  enabled: boolean;
+}
+
+const defaultRules: Rule[] = [
+  {
+    id: "concentration",
+    type: "concentration",
+    label: "Concentration limit",
+    description:
+      "Alert if any single position exceeds this percentage of total portfolio value.",
+    config: "25%",
+    enabled: true,
+  },
+  {
+    id: "parabolic",
+    type: "parabolic",
+    label: "Parabolic move",
+    description:
+      "Alert if a position gains this much in this many days. Prompts to skip next tranche.",
+    config: "+15% in 5 days",
+    enabled: true,
+  },
+  {
+    id: "drawdown",
+    type: "drawdown",
+    label: "Drawdown stop",
+    description: "Alert if a position falls this far from cost basis.",
+    config: "-20% from cost",
+    enabled: true,
+  },
+  {
+    id: "tier_balance",
+    type: "tier_balance",
+    label: "Tier balance",
+    description:
+      "Alert if any tier deviates from its target allocation by this amount.",
+    config: "±10 percentage points",
+    enabled: false,
+  },
+];
+
+const checklistTemplate = [
+  "Review active pattern firings",
+  "Check position concentration",
+  "Scan upcoming earnings (next 7 days)",
+  "Review any parabolic movers",
+  "Plan this week's capital deployment",
+];
+
+export default function Discipline() {
+  useSEO({ title: "Signal — Discipline", noIndex: true });
+  const [rules, setRules] = useState(defaultRules);
+  const [checked, setChecked] = useState<Record<number, boolean>>({});
+
+  const toggleRule = (id: string) =>
+    setRules((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, enabled: !r.enabled } : r)),
+    );
+
+  const toggleCheck = (i: number) =>
+    setChecked((prev) => ({ ...prev, [i]: !prev[i] }));
+
+  const doneCount = Object.values(checked).filter(Boolean).length;
+
+  return (
+    <SignalLayout>
+      <div className="p-6 max-w-4xl space-y-6">
+        <div>
+          <h1 className="text-lg font-medium">Discipline</h1>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Rules that enforce position sizing and emotional guardrails
+          </p>
+        </div>
+
+        {/* Discipline rules */}
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <Shield className="w-4 h-4 text-muted-foreground" />
+            <h2 className="text-sm font-medium">Active rules</h2>
+          </div>
+
+          {rules.map((rule) => (
+            <div
+              key={rule.id}
+              className={`bg-card border rounded-lg p-4 transition-colors ${
+                rule.enabled ? "border-border" : "border-border/50 opacity-60"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <p className="text-sm font-medium">{rule.label}</p>
+                    <span className="font-mono text-[11px] text-muted-foreground bg-muted px-2 py-0.5 rounded">
+                      {rule.config}
+                    </span>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground leading-relaxed">
+                    {rule.description}
+                  </p>
+                </div>
+                <button
+                  onClick={() => toggleRule(rule.id)}
+                  className={`flex-shrink-0 w-10 h-5 rounded-full transition-colors ${
+                    rule.enabled ? "bg-primary" : "bg-muted"
+                  }`}
+                  aria-label={rule.enabled ? "Disable rule" : "Enable rule"}
+                >
+                  <span
+                    className={`block w-4 h-4 bg-white rounded-full shadow transition-transform mx-0.5 ${
+                      rule.enabled ? "translate-x-5" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+            </div>
+          ))}
+
+          <div className="bg-card border border-dashed border-border rounded-lg p-4 flex items-center gap-3">
+            <p className="text-[11px] text-muted-foreground flex-1">
+              Connect Supabase to persist rule configurations and log
+              violations.
+            </p>
+          </div>
+        </div>
+
+        {/* Weekly checklist */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <div className="flex items-center gap-2">
+              <CheckSquare className="w-4 h-4 text-muted-foreground" />
+              <h2 className="text-sm font-medium">Weekly checklist</h2>
+            </div>
+            <span className="text-[11px] font-mono text-muted-foreground">
+              {doneCount} / {checklistTemplate.length}
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {checklistTemplate.map((item, i) => (
+              <button
+                key={i}
+                onClick={() => toggleCheck(i)}
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+              >
+                <div
+                  className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-colors ${
+                    checked[i] ? "bg-primary border-primary" : "border-border"
+                  }`}
+                >
+                  {checked[i] && (
+                    <svg
+                      className="w-2.5 h-2.5 text-primary-foreground"
+                      fill="none"
+                      viewBox="0 0 10 10"
+                    >
+                      <path
+                        d="M1.5 5l2.5 2.5 4.5-4.5"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </div>
+                <span
+                  className={`text-xs ${checked[i] ? "line-through text-muted-foreground" : ""}`}
+                >
+                  {item}
+                </span>
+              </button>
+            ))}
+          </div>
+          <div className="px-4 py-3 border-t border-border bg-muted/20">
+            <p className="text-[11px] text-muted-foreground">
+              Checklist resets each week. Connect Supabase to persist
+              completions.
+            </p>
+          </div>
+        </div>
+
+        {/* Violation log */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+            <AlertTriangle className="w-4 h-4 text-muted-foreground" />
+            <h2 className="text-sm font-medium">Override log</h2>
+          </div>
+          <div className="px-4 py-8 text-center">
+            <p className="text-xs text-muted-foreground">
+              No overrides recorded
+            </p>
+            <p className="text-[11px] text-muted-foreground/60 mt-1">
+              When you trade against a firing rule, Signal logs the override
+              with your reason here.
+            </p>
+          </div>
+        </div>
+      </div>
+    </SignalLayout>
+  );
+}

--- a/src/pages/signal/Firings.tsx
+++ b/src/pages/signal/Firings.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { Zap } from "lucide-react";
+import SignalLayout from "@/components/SignalLayout";
+import { useSEO } from "@/lib/seo";
+
+type Severity = "all" | "monitor" | "alert" | "urgent";
+type FiringStatus = "active" | "dismissed" | "expired";
+
+const patternDescriptions: Record<string, string> = {
+  G1: "Government stake imminent",
+  NV1: "Nvidia portfolio addition setup",
+  C1: "Congressional cluster",
+  HC: "Hyperscaler capex cascade",
+  CM: "Critical mineral squeeze",
+};
+
+const severities: Severity[] = ["all", "monitor", "alert", "urgent"];
+
+export default function Firings() {
+  useSEO({ title: "Signal — Firings", noIndex: true });
+  const [activeSeverity, setActiveSeverity] = useState<Severity>("all");
+  const [activeStatus, setActiveStatus] = useState<FiringStatus>("active");
+
+  return (
+    <SignalLayout>
+      <div className="p-6 max-w-5xl space-y-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-medium">Pattern firings</h1>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Convergence events detected by the pattern engine
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {(["active", "dismissed", "expired"] as FiringStatus[]).map((s) => (
+              <button
+                key={s}
+                onClick={() => setActiveStatus(s)}
+                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                  activeStatus === s
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Severity filter */}
+        <div className="flex items-center gap-1">
+          {severities.map((s) => (
+            <button
+              key={s}
+              onClick={() => setActiveSeverity(s)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                activeSeverity === s
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
+              }`}
+            >
+              {s !== "all" && (
+                <span
+                  className={`w-1.5 h-1.5 rounded-full ${
+                    s === "monitor"
+                      ? "bg-amber-500"
+                      : s === "alert"
+                        ? "bg-orange-500"
+                        : "bg-red-500"
+                  }`}
+                />
+              )}
+              {s}
+            </button>
+          ))}
+        </div>
+
+        {/* Pattern legend */}
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
+          {Object.entries(patternDescriptions).map(([id, desc]) => (
+            <div
+              key={id}
+              className="bg-card border border-border rounded-lg px-3 py-2"
+            >
+              <p className="text-xs font-mono font-medium">{id}</p>
+              <p className="text-[11px] text-muted-foreground mt-0.5 leading-tight">
+                {desc}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Firings table */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[650px]">
+              <thead>
+                <tr className="border-b border-border bg-muted/30">
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Ticker
+                  </th>
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Pattern
+                  </th>
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Severity
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider tabular-nums">
+                    Confidence
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider tabular-nums">
+                    Evidence
+                  </th>
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Fired
+                  </th>
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Label
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td colSpan={7} className="px-4 py-16 text-center">
+                    <Zap className="w-8 h-8 text-muted-foreground/20 mx-auto mb-3" />
+                    <p className="text-sm text-muted-foreground">
+                      No firings yet
+                    </p>
+                    <p className="text-[11px] text-muted-foreground/60 mt-1 max-w-sm mx-auto">
+                      Pattern engine will surface convergence events here once
+                      signal ingestion is configured and positions/watchlist are
+                      added.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Disclaimer */}
+        <p className="text-[11px] text-muted-foreground/60 leading-relaxed">
+          Signal is informational only and not investment advice. Patterns are
+          based on historical correlations and do not guarantee future results.
+          Consult a licensed advisor before making investment decisions.
+        </p>
+      </div>
+    </SignalLayout>
+  );
+}

--- a/src/pages/signal/Journal.tsx
+++ b/src/pages/signal/Journal.tsx
@@ -1,0 +1,226 @@
+import { useState } from "react";
+import { BookOpen, Plus, Search, Tag, ChevronDown } from "lucide-react";
+import SignalLayout from "@/components/SignalLayout";
+import { useSEO } from "@/lib/seo";
+
+type EntryType =
+  | "thesis"
+  | "observation"
+  | "lesson"
+  | "trade_log"
+  | "weekly_review";
+
+const entryTypeLabels: Record<EntryType, string> = {
+  thesis: "Thesis",
+  observation: "Observation",
+  lesson: "Lesson",
+  trade_log: "Trade log",
+  weekly_review: "Weekly review",
+};
+
+const entryTypes: EntryType[] = [
+  "thesis",
+  "observation",
+  "lesson",
+  "trade_log",
+  "weekly_review",
+];
+
+export default function Journal() {
+  useSEO({ title: "Signal — Journal", noIndex: true });
+  const [activeType, setActiveType] = useState<EntryType | "all">("all");
+  const [search, setSearch] = useState("");
+  const [composing, setComposing] = useState(false);
+  const [draft, setDraft] = useState({
+    type: "observation" as EntryType,
+    title: "",
+    content: "",
+    tickers: "",
+  });
+
+  return (
+    <SignalLayout>
+      <div className="p-6 max-w-5xl space-y-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-medium">Journal</h1>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Thesis, observations, lessons, and trade logs
+            </p>
+          </div>
+          <button
+            onClick={() => setComposing((v) => !v)}
+            className="flex items-center gap-2 px-3 py-1.5 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:opacity-90 transition-opacity"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            New entry
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {/* Left: entry list */}
+          <div className="md:col-span-1 space-y-3">
+            {/* Search */}
+            <div className="relative">
+              <Search className="absolute left-3 top-2.5 w-3.5 h-3.5 text-muted-foreground" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search entries..."
+                className="w-full pl-9 pr-3 py-2 bg-background border border-border rounded-md text-xs focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
+
+            {/* Type filter */}
+            <div className="space-y-0.5">
+              <button
+                onClick={() => setActiveType("all")}
+                className={`w-full text-left px-3 py-1.5 rounded-md text-xs transition-colors ${
+                  activeType === "all"
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                }`}
+              >
+                All entries
+              </button>
+              {entryTypes.map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setActiveType(t)}
+                  className={`w-full text-left flex items-center gap-2 px-3 py-1.5 rounded-md text-xs transition-colors ${
+                    activeType === t
+                      ? "bg-primary/10 text-primary"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                  }`}
+                >
+                  <span
+                    className={`w-1.5 h-1.5 rounded-full ${
+                      t === "thesis"
+                        ? "bg-blue-500"
+                        : t === "lesson"
+                          ? "bg-amber-500"
+                          : t === "trade_log"
+                            ? "bg-violet-500"
+                            : t === "weekly_review"
+                              ? "bg-emerald-500"
+                              : "bg-slate-400"
+                    }`}
+                  />
+                  {entryTypeLabels[t]}
+                </button>
+              ))}
+            </div>
+
+            {/* Entry list */}
+            <div className="bg-card border border-border rounded-lg overflow-hidden">
+              <div className="px-3 py-8 text-center">
+                <BookOpen className="w-6 h-6 text-muted-foreground/20 mx-auto mb-2" />
+                <p className="text-xs text-muted-foreground">No entries yet</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Right: composer / placeholder */}
+          <div className="md:col-span-2">
+            {composing ? (
+              <div className="bg-card border border-border rounded-lg overflow-hidden">
+                <div className="border-b border-border px-4 py-3 flex items-center gap-3">
+                  <div className="relative">
+                    <select
+                      value={draft.type}
+                      onChange={(e) =>
+                        setDraft((p) => ({
+                          ...p,
+                          type: e.target.value as EntryType,
+                        }))
+                      }
+                      className="appearance-none text-xs font-medium bg-transparent focus:outline-none pr-5"
+                    >
+                      {entryTypes.map((t) => (
+                        <option key={t} value={t}>
+                          {entryTypeLabels[t]}
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown className="absolute right-0 top-0.5 w-3 h-3 text-muted-foreground pointer-events-none" />
+                  </div>
+                </div>
+                <div className="p-4 space-y-3">
+                  <input
+                    type="text"
+                    value={draft.title}
+                    onChange={(e) =>
+                      setDraft((p) => ({ ...p, title: e.target.value }))
+                    }
+                    placeholder="Title"
+                    className="w-full text-base font-medium bg-transparent focus:outline-none placeholder:text-muted-foreground/40"
+                  />
+                  <div className="flex items-center gap-2">
+                    <Tag className="w-3.5 h-3.5 text-muted-foreground" />
+                    <input
+                      type="text"
+                      value={draft.tickers}
+                      onChange={(e) =>
+                        setDraft((p) => ({
+                          ...p,
+                          tickers: e.target.value.toUpperCase(),
+                        }))
+                      }
+                      placeholder="NVDA, MSFT, AVGO"
+                      className="text-xs font-mono bg-transparent focus:outline-none placeholder:text-muted-foreground/40 w-full"
+                    />
+                  </div>
+                  <textarea
+                    value={draft.content}
+                    onChange={(e) =>
+                      setDraft((p) => ({ ...p, content: e.target.value }))
+                    }
+                    placeholder="Write your entry in markdown. Use @TICKER to cross-reference positions..."
+                    rows={16}
+                    className="w-full text-sm bg-transparent focus:outline-none resize-none placeholder:text-muted-foreground/40 leading-relaxed"
+                  />
+                </div>
+                <div className="border-t border-border px-4 py-3 flex items-center gap-3">
+                  <button
+                    disabled
+                    className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-xs font-medium opacity-50 cursor-not-allowed"
+                  >
+                    Save entry
+                  </button>
+                  <button
+                    onClick={() => setComposing(false)}
+                    className="px-4 py-2 border border-border rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                  >
+                    Discard
+                  </button>
+                  <p className="text-[11px] text-muted-foreground ml-auto">
+                    Connect Supabase to persist entries
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="bg-card border border-border rounded-lg flex flex-col items-center justify-center py-24 text-center">
+                <BookOpen className="w-10 h-10 text-muted-foreground/20 mb-4" />
+                <p className="text-sm text-muted-foreground">
+                  Select an entry or write a new one
+                </p>
+                <p className="text-[11px] text-muted-foreground/60 mt-1 max-w-xs">
+                  Use @TICKER in entries to link to positions and pattern
+                  firings automatically.
+                </p>
+                <button
+                  onClick={() => setComposing(true)}
+                  className="mt-5 flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:opacity-90 transition-opacity"
+                >
+                  <Plus className="w-3.5 h-3.5" />
+                  New entry
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </SignalLayout>
+  );
+}

--- a/src/pages/signal/Portfolio.tsx
+++ b/src/pages/signal/Portfolio.tsx
@@ -1,0 +1,262 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Plus, X, ChevronDown } from "lucide-react";
+import SignalLayout from "@/components/SignalLayout";
+import { useSEO } from "@/lib/seo";
+
+type Tier = "anchor" | "capex_flow" | "moonshot" | "cash";
+
+const tierColors: Record<Tier, string> = {
+  anchor: "text-blue-500 bg-blue-500/10",
+  capex_flow: "text-violet-500 bg-violet-500/10",
+  moonshot: "text-orange-500 bg-orange-500/10",
+  cash: "text-slate-400 bg-slate-500/10",
+};
+
+const tiers: Tier[] = ["anchor", "capex_flow", "moonshot", "cash"];
+
+interface NewPositionForm {
+  ticker: string;
+  shares: string;
+  cost: string;
+  tier: Tier;
+  entryDate: string;
+  notes: string;
+}
+
+const empty: NewPositionForm = {
+  ticker: "",
+  shares: "",
+  cost: "",
+  tier: "anchor",
+  entryDate: new Date().toISOString().split("T")[0],
+  notes: "",
+};
+
+export default function Portfolio() {
+  useSEO({ title: "Signal — Portfolio", noIndex: true });
+  const [showAdd, setShowAdd] = useState(false);
+  const [form, setForm] = useState<NewPositionForm>(empty);
+
+  const update = (k: keyof NewPositionForm, v: string) =>
+    setForm((p) => ({ ...p, [k]: v }));
+
+  return (
+    <SignalLayout>
+      <div className="p-6 max-w-5xl space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-medium">Portfolio</h1>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              0 positions · $0 total value
+            </p>
+          </div>
+          <button
+            onClick={() => setShowAdd((v) => !v)}
+            className="flex items-center gap-2 px-3 py-1.5 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:opacity-90 transition-opacity"
+          >
+            {showAdd ? (
+              <X className="w-3.5 h-3.5" />
+            ) : (
+              <Plus className="w-3.5 h-3.5" />
+            )}
+            {showAdd ? "Cancel" : "Add position"}
+          </button>
+        </div>
+
+        {/* Add position form */}
+        <AnimatePresence>
+          {showAdd && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              className="overflow-hidden"
+            >
+              <div className="bg-card border border-border rounded-lg p-5">
+                <h2 className="text-sm font-medium mb-4">New position</h2>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Ticker
+                    </label>
+                    <input
+                      type="text"
+                      value={form.ticker}
+                      onChange={(e) =>
+                        update("ticker", e.target.value.toUpperCase())
+                      }
+                      placeholder="NVDA"
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Shares
+                    </label>
+                    <input
+                      type="number"
+                      value={form.shares}
+                      onChange={(e) => update("shares", e.target.value)}
+                      placeholder="100"
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm font-mono tabular-nums focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Cost basis / share
+                    </label>
+                    <input
+                      type="number"
+                      value={form.cost}
+                      onChange={(e) => update("cost", e.target.value)}
+                      placeholder="450.00"
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm font-mono tabular-nums focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Tier
+                    </label>
+                    <div className="relative">
+                      <select
+                        value={form.tier}
+                        onChange={(e) => update("tier", e.target.value)}
+                        className="w-full appearance-none px-3 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary pr-8"
+                      >
+                        {tiers.map((t) => (
+                          <option key={t} value={t}>
+                            {t.replace("_", " ")}
+                          </option>
+                        ))}
+                      </select>
+                      <ChevronDown className="absolute right-2.5 top-2.5 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+                    </div>
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Entry date
+                    </label>
+                    <input
+                      type="date"
+                      value={form.entryDate}
+                      onChange={(e) => update("entryDate", e.target.value)}
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Notes
+                    </label>
+                    <input
+                      type="text"
+                      value={form.notes}
+                      onChange={(e) => update("notes", e.target.value)}
+                      placeholder="Optional thesis note"
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                </div>
+                <div className="flex items-center gap-3 mt-5">
+                  <button
+                    disabled
+                    className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-xs font-medium opacity-50 cursor-not-allowed"
+                    title="Supabase integration required"
+                  >
+                    Save position
+                  </button>
+                  <p className="text-[11px] text-muted-foreground">
+                    Connect Supabase to persist positions
+                  </p>
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Tier summary */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {tiers.map((tier) => (
+            <div
+              key={tier}
+              className="bg-card border border-border rounded-lg p-4"
+            >
+              <span
+                className={`text-[10px] font-mono px-2 py-0.5 rounded-full ${tierColors[tier]}`}
+              >
+                {tier.replace("_", " ")}
+              </span>
+              <p className="text-xl font-mono tabular-nums mt-2">$0</p>
+              <p className="text-[11px] text-muted-foreground">
+                0% of portfolio
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Holdings table */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[700px]">
+              <thead>
+                <tr className="border-b border-border bg-muted/30">
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Ticker
+                  </th>
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Tier
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider tabular-nums">
+                    Shares
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider tabular-nums">
+                    Cost
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider tabular-nums">
+                    Value
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider tabular-nums">
+                    P/L
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Conc.
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td colSpan={7} className="px-4 py-14 text-center">
+                    <p className="text-sm text-muted-foreground">
+                      No positions yet
+                    </p>
+                    <p className="text-xs text-muted-foreground/60 mt-1">
+                      Add your first position to start tracking
+                    </p>
+                    <button
+                      onClick={() => setShowAdd(true)}
+                      className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:opacity-90 transition-opacity"
+                    >
+                      <Plus className="w-3.5 h-3.5" />
+                      Add position
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Closed positions */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="px-4 py-3 border-b border-border">
+            <h2 className="text-sm font-medium">Closed positions</h2>
+          </div>
+          <div className="px-4 py-8 text-center">
+            <p className="text-xs text-muted-foreground">No closed positions</p>
+          </div>
+        </div>
+      </div>
+    </SignalLayout>
+  );
+}

--- a/src/pages/signal/Settings.tsx
+++ b/src/pages/signal/Settings.tsx
@@ -1,0 +1,341 @@
+import { useState } from "react";
+import { Bell, Clock, Key } from "lucide-react";
+import SignalLayout from "@/components/SignalLayout";
+import { useSEO } from "@/lib/seo";
+
+type Tab = "notifications" | "sources" | "integrations";
+
+interface NotifChannel {
+  id: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+  minSeverity: "monitor" | "alert" | "urgent";
+}
+
+const defaultChannels: NotifChannel[] = [
+  {
+    id: "in_app",
+    label: "In-app",
+    description: "Real-time alerts in the Signal workspace",
+    enabled: true,
+    minSeverity: "monitor",
+  },
+  {
+    id: "email",
+    label: "Email",
+    description: "Alerts sent to your account email via Resend",
+    enabled: false,
+    minSeverity: "alert",
+  },
+  {
+    id: "sms",
+    label: "SMS",
+    description: "Urgent-tier alerts via Twilio",
+    enabled: false,
+    minSeverity: "urgent",
+  },
+];
+
+const integrations = [
+  {
+    id: "polygon",
+    label: "Polygon.io",
+    description: "Real-time and delayed market data",
+    envKey: "POLYGON_API_KEY",
+    required: true,
+  },
+  {
+    id: "capitol_trades",
+    label: "Capitol Trades",
+    description: "Congressional PTR filings API",
+    envKey: "CAPITOL_TRADES_API_KEY",
+    required: true,
+  },
+  {
+    id: "resend",
+    label: "Resend",
+    description: "Transactional email for alerts",
+    envKey: "RESEND_API_KEY",
+    required: false,
+  },
+  {
+    id: "twilio",
+    label: "Twilio",
+    description: "SMS alerts for urgent firings",
+    envKey: "TWILIO_ACCOUNT_SID",
+    required: false,
+  },
+];
+
+export default function SignalSettings() {
+  useSEO({ title: "Signal — Settings", noIndex: true });
+  const [activeTab, setActiveTab] = useState<Tab>("notifications");
+  const [channels, setChannels] = useState(defaultChannels);
+  const [quietStart, setQuietStart] = useState("22:00");
+  const [quietEnd, setQuietEnd] = useState("08:00");
+
+  const toggleChannel = (id: string) =>
+    setChannels((prev) =>
+      prev.map((c) => (c.id === id ? { ...c, enabled: !c.enabled } : c)),
+    );
+
+  const setSeverity = (id: string, sev: NotifChannel["minSeverity"]) =>
+    setChannels((prev) =>
+      prev.map((c) => (c.id === id ? { ...c, minSeverity: sev } : c)),
+    );
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: "notifications", label: "Notifications" },
+    { id: "sources", label: "Signal sources" },
+    { id: "integrations", label: "Integrations" },
+  ];
+
+  return (
+    <SignalLayout>
+      <div className="p-6 max-w-3xl space-y-5">
+        <div>
+          <h1 className="text-lg font-medium">Settings</h1>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Alert thresholds, notification channels, and API keys
+          </p>
+        </div>
+
+        {/* Tab nav */}
+        <div className="flex items-center gap-1 border-b border-border">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setActiveTab(t.id)}
+              className={`px-4 py-2.5 text-xs font-medium border-b-2 transition-colors -mb-px ${
+                activeTab === t.id
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Notifications tab */}
+        {activeTab === "notifications" && (
+          <div className="space-y-4">
+            {channels.map((ch) => (
+              <div
+                key={ch.id}
+                className="bg-card border border-border rounded-lg p-4"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-2">
+                    <Bell className="w-4 h-4 text-muted-foreground" />
+                    <p className="text-sm font-medium">{ch.label}</p>
+                  </div>
+                  <button
+                    onClick={() => toggleChannel(ch.id)}
+                    className={`w-10 h-5 rounded-full transition-colors ${
+                      ch.enabled ? "bg-primary" : "bg-muted"
+                    }`}
+                    aria-label={ch.enabled ? "Disable" : "Enable"}
+                  >
+                    <span
+                      className={`block w-4 h-4 bg-white rounded-full shadow transition-transform mx-0.5 ${
+                        ch.enabled ? "translate-x-5" : "translate-x-0"
+                      }`}
+                    />
+                  </button>
+                </div>
+                <p className="text-[11px] text-muted-foreground mb-3">
+                  {ch.description}
+                </p>
+                <div className="flex items-center gap-2">
+                  <p className="text-[11px] text-muted-foreground">
+                    Minimum severity:
+                  </p>
+                  <div className="flex items-center gap-1">
+                    {(["monitor", "alert", "urgent"] as const).map((s) => (
+                      <button
+                        key={s}
+                        onClick={() => setSeverity(ch.id, s)}
+                        className={`px-2 py-0.5 rounded text-[10px] font-mono transition-colors ${
+                          ch.minSeverity === s
+                            ? s === "monitor"
+                              ? "bg-amber-500/20 text-amber-500"
+                              : s === "alert"
+                                ? "bg-orange-500/20 text-orange-500"
+                                : "bg-red-500/20 text-red-500"
+                            : "bg-muted text-muted-foreground hover:bg-muted/80"
+                        }`}
+                      >
+                        {s}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
+
+            {/* Quiet hours */}
+            <div className="bg-card border border-border rounded-lg p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <Clock className="w-4 h-4 text-muted-foreground" />
+                <p className="text-sm font-medium">Quiet hours</p>
+              </div>
+              <p className="text-[11px] text-muted-foreground mb-4">
+                No alerts delivered during this window (all channels).
+              </p>
+              <div className="flex items-center gap-4">
+                <div>
+                  <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                    Start
+                  </label>
+                  <input
+                    type="time"
+                    value={quietStart}
+                    onChange={(e) => setQuietStart(e.target.value)}
+                    className="px-3 py-2 bg-background border border-border rounded-md text-sm font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+                  />
+                </div>
+                <div>
+                  <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                    End
+                  </label>
+                  <input
+                    type="time"
+                    value={quietEnd}
+                    onChange={(e) => setQuietEnd(e.target.value)}
+                    className="px-3 py-2 bg-background border border-border rounded-md text-sm font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Signal sources tab */}
+        {activeTab === "sources" && (
+          <div className="space-y-3">
+            <p className="text-xs text-muted-foreground">
+              Each source is a Supabase Edge Function on a cron schedule.
+              Configure them in{" "}
+              <code className="font-mono bg-muted px-1 py-0.5 rounded text-[11px]">
+                supabase/functions/
+              </code>
+              .
+            </p>
+            {[
+              {
+                id: "edgar_8k",
+                label: "SEC EDGAR — 8-K",
+                schedule: "every 5 min",
+                status: "pending",
+              },
+              {
+                id: "edgar_form4",
+                label: "SEC EDGAR — Form 4",
+                schedule: "every 15 min",
+                status: "pending",
+              },
+              {
+                id: "edgar_13dg",
+                label: "SEC EDGAR — 13D/G",
+                schedule: "every 30 min",
+                status: "pending",
+              },
+              {
+                id: "whitehouse",
+                label: "White House press releases",
+                schedule: "every 15 min",
+                status: "pending",
+              },
+              {
+                id: "fed_register",
+                label: "Federal Register",
+                schedule: "hourly",
+                status: "pending",
+              },
+              {
+                id: "dod",
+                label: "DOD contract announcements",
+                schedule: "daily 5pm ET",
+                status: "pending",
+              },
+              {
+                id: "capitol_trades",
+                label: "Capitol Trades",
+                schedule: "every 30 min",
+                status: "pending",
+              },
+              {
+                id: "substack",
+                label: "Substack RSS (configurable)",
+                schedule: "hourly",
+                status: "pending",
+              },
+              {
+                id: "earnings",
+                label: "NASDAQ earnings calendar",
+                schedule: "daily",
+                status: "pending",
+              },
+              {
+                id: "fomc",
+                label: "FOMC / macro calendar",
+                schedule: "weekly",
+                status: "pending",
+              },
+            ].map((src) => (
+              <div
+                key={src.id}
+                className="bg-card border border-border rounded-lg px-4 py-3 flex items-center justify-between"
+              >
+                <div>
+                  <p className="text-xs font-medium">{src.label}</p>
+                  <p className="text-[11px] text-muted-foreground font-mono mt-0.5">
+                    {src.schedule}
+                  </p>
+                </div>
+                <span className="text-[10px] font-mono text-muted-foreground/60 border border-border px-2 py-0.5 rounded-full">
+                  {src.status}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Integrations tab */}
+        {activeTab === "integrations" && (
+          <div className="space-y-3">
+            <p className="text-xs text-muted-foreground">
+              Set these as environment variables in Netlify and Supabase Vault.
+            </p>
+            {integrations.map((int) => (
+              <div
+                key={int.id}
+                className="bg-card border border-border rounded-lg p-4"
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <p className="text-sm font-medium">{int.label}</p>
+                  {int.required && (
+                    <span className="text-[10px] text-red-500 font-mono">
+                      required
+                    </span>
+                  )}
+                </div>
+                <p className="text-[11px] text-muted-foreground mb-3">
+                  {int.description}
+                </p>
+                <div className="flex items-center gap-2">
+                  <Key className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
+                  <code className="text-[11px] font-mono text-muted-foreground bg-muted px-2 py-0.5 rounded">
+                    {int.envKey}
+                  </code>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </SignalLayout>
+  );
+}

--- a/src/pages/signal/SignalFeed.tsx
+++ b/src/pages/signal/SignalFeed.tsx
@@ -1,0 +1,211 @@
+import { useState } from "react";
+import { Radio, RefreshCw } from "lucide-react";
+import SignalLayout from "@/components/SignalLayout";
+import { useSEO } from "@/lib/seo";
+
+type SourceCategory =
+  | "all"
+  | "sec"
+  | "government"
+  | "congress"
+  | "market"
+  | "analyst";
+
+const categories: { id: SourceCategory; label: string }[] = [
+  { id: "all", label: "All sources" },
+  { id: "sec", label: "SEC EDGAR" },
+  { id: "government", label: "Government" },
+  { id: "congress", label: "Congress" },
+  { id: "market", label: "Market" },
+  { id: "analyst", label: "Analyst" },
+];
+
+const sourceBadgeColors: Record<string, string> = {
+  sec: "bg-blue-500/15 text-blue-500",
+  government: "bg-amber-500/15 text-amber-500",
+  congress: "bg-violet-500/15 text-violet-500",
+  market: "bg-emerald-500/15 text-emerald-500",
+  analyst: "bg-pink-500/15 text-pink-500",
+  macro: "bg-orange-500/15 text-orange-500",
+};
+
+export default function SignalFeed() {
+  useSEO({ title: "Signal — Feed", noIndex: true });
+  const [activeCategory, setActiveCategory] = useState<SourceCategory>("all");
+
+  return (
+    <SignalLayout>
+      <div className="p-6 max-w-4xl space-y-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-medium">Signal feed</h1>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Raw events from all configured sources
+            </p>
+          </div>
+          <button className="flex items-center gap-2 px-3 py-1.5 border border-border rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
+            <RefreshCw className="w-3.5 h-3.5" />
+            Refresh
+          </button>
+        </div>
+
+        {/* Source filter tabs */}
+        <div className="flex items-center gap-1 flex-wrap">
+          {categories.map((c) => (
+            <button
+              key={c.id}
+              onClick={() => setActiveCategory(c.id)}
+              className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                activeCategory === c.id
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
+              }`}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Source status cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {[
+            {
+              id: "edgar_8k",
+              label: "SEC EDGAR — 8-K",
+              category: "sec",
+              status: "not configured",
+              schedule: "every 5 min",
+            },
+            {
+              id: "edgar_form4",
+              label: "SEC EDGAR — Form 4",
+              category: "sec",
+              status: "not configured",
+              schedule: "every 15 min",
+            },
+            {
+              id: "whitehouse",
+              label: "White House press releases",
+              category: "government",
+              status: "not configured",
+              schedule: "every 15 min",
+            },
+            {
+              id: "fed_register",
+              label: "Federal Register",
+              category: "government",
+              status: "not configured",
+              schedule: "hourly",
+            },
+            {
+              id: "capitol_trades",
+              label: "Capitol Trades",
+              category: "congress",
+              status: "not configured",
+              schedule: "every 30 min",
+            },
+            {
+              id: "substack",
+              label: "Substack RSS",
+              category: "analyst",
+              status: "not configured",
+              schedule: "hourly",
+            },
+          ].map((source) => (
+            <div
+              key={source.id}
+              className="bg-card border border-border rounded-lg p-4"
+            >
+              <div className="flex items-center justify-between mb-2">
+                <span
+                  className={`text-[10px] font-mono px-2 py-0.5 rounded-full ${sourceBadgeColors[source.category]}`}
+                >
+                  {source.category}
+                </span>
+                <span className="text-[10px] font-mono text-muted-foreground/60 px-2 py-0.5 border border-border rounded-full">
+                  {source.status}
+                </span>
+              </div>
+              <p className="text-xs font-medium">{source.label}</p>
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                {source.schedule}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Event feed (empty state) */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <div className="flex items-center gap-2">
+              <Radio className="w-4 h-4 text-muted-foreground" />
+              <h2 className="text-sm font-medium">Event stream</h2>
+            </div>
+            <span className="text-[11px] font-mono text-muted-foreground">
+              0 events
+            </span>
+          </div>
+          <div className="px-4 py-16 text-center">
+            <Radio className="w-8 h-8 text-muted-foreground/20 mx-auto mb-3" />
+            <p className="text-sm text-muted-foreground">
+              No events ingested yet
+            </p>
+            <p className="text-[11px] text-muted-foreground/60 mt-1 max-w-xs mx-auto">
+              Configure Supabase Edge Functions and API keys to start pulling
+              from live sources.
+            </p>
+          </div>
+        </div>
+
+        {/* Setup guide */}
+        <div className="bg-card border border-border rounded-lg p-5 space-y-3">
+          <h2 className="text-sm font-medium">Setup checklist</h2>
+          {[
+            {
+              step: "1",
+              label: "Add Supabase Edge Function: ingest-sec-edgar",
+              done: false,
+            },
+            {
+              step: "2",
+              label: "Set SEC_EDGAR_USER_AGENT env var",
+              done: false,
+            },
+            {
+              step: "3",
+              label: "Add Capitol Trades API key (CAPITOL_TRADES_API_KEY)",
+              done: false,
+            },
+            {
+              step: "4",
+              label: "Configure pg_cron job to invoke ingest functions",
+              done: false,
+            },
+            {
+              step: "5",
+              label: "Enable Supabase Realtime on events table",
+              done: false,
+            },
+          ].map((item) => (
+            <div key={item.step} className="flex items-center gap-3">
+              <div
+                className={`w-5 h-5 rounded-full border flex items-center justify-center flex-shrink-0 text-[10px] font-mono ${
+                  item.done
+                    ? "bg-primary border-primary text-primary-foreground"
+                    : "border-border text-muted-foreground"
+                }`}
+              >
+                {item.step}
+              </div>
+              <span
+                className={`text-xs ${item.done ? "line-through text-muted-foreground" : ""}`}
+              >
+                {item.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </SignalLayout>
+  );
+}

--- a/src/pages/signal/Watchlist.tsx
+++ b/src/pages/signal/Watchlist.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Plus, X, Star } from "lucide-react";
+import SignalLayout from "@/components/SignalLayout";
+import { useSEO } from "@/lib/seo";
+
+export default function Watchlist() {
+  useSEO({ title: "Signal — Watchlist", noIndex: true });
+  const [showAdd, setShowAdd] = useState(false);
+  const [ticker, setTicker] = useState("");
+  const [thesis, setThesis] = useState("");
+
+  return (
+    <SignalLayout>
+      <div className="p-6 max-w-4xl space-y-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-medium">Watchlist</h1>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              0 tickers being monitored
+            </p>
+          </div>
+          <button
+            onClick={() => setShowAdd((v) => !v)}
+            className="flex items-center gap-2 px-3 py-1.5 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:opacity-90 transition-opacity"
+          >
+            {showAdd ? (
+              <X className="w-3.5 h-3.5" />
+            ) : (
+              <Plus className="w-3.5 h-3.5" />
+            )}
+            {showAdd ? "Cancel" : "Add ticker"}
+          </button>
+        </div>
+
+        <AnimatePresence>
+          {showAdd && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              className="overflow-hidden"
+            >
+              <div className="bg-card border border-border rounded-lg p-5">
+                <h2 className="text-sm font-medium mb-4">Add to watchlist</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Ticker
+                    </label>
+                    <input
+                      type="text"
+                      value={ticker}
+                      onChange={(e) => setTicker(e.target.value.toUpperCase())}
+                      placeholder="AAPL"
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm font-mono focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[11px] text-muted-foreground uppercase tracking-wider block mb-1.5">
+                      Thesis (optional)
+                    </label>
+                    <input
+                      type="text"
+                      value={thesis}
+                      onChange={(e) => setThesis(e.target.value)}
+                      placeholder="Why are you watching this?"
+                      className="w-full px-3 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                    />
+                  </div>
+                </div>
+                <div className="flex items-center gap-3 mt-4">
+                  <button
+                    disabled
+                    className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-xs font-medium opacity-50 cursor-not-allowed"
+                    title="Supabase integration required"
+                  >
+                    Add to watchlist
+                  </button>
+                  <p className="text-[11px] text-muted-foreground">
+                    Connect Supabase to persist watchlist
+                  </p>
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Watchlist table */}
+        <div className="bg-card border border-border rounded-lg overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-border bg-muted/30">
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Ticker
+                  </th>
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Thesis
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider tabular-nums">
+                    Price
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider tabular-nums">
+                    1d %
+                  </th>
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Active signals
+                  </th>
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                    Added
+                  </th>
+                  <th className="px-4 py-2.5" />
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td colSpan={7} className="px-4 py-14 text-center">
+                    <Star className="w-6 h-6 text-muted-foreground/30 mx-auto mb-3" />
+                    <p className="text-sm text-muted-foreground">
+                      No tickers on watchlist
+                    </p>
+                    <p className="text-xs text-muted-foreground/60 mt-1">
+                      Add tickers to monitor signals and catalog your thesis
+                    </p>
+                    <button
+                      onClick={() => setShowAdd(true)}
+                      className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:opacity-90 transition-opacity"
+                    >
+                      <Plus className="w-3.5 h-3.5" />
+                      Add ticker
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="bg-card border border-border rounded-lg p-4">
+          <p className="text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">
+              Signal coverage:
+            </span>{" "}
+            Watchlist tickers are included in pattern matching. Signals that
+            fire against any watchlist ticker generate an alert even if you
+            don't hold the position yet.
+          </p>
+        </div>
+      </div>
+    </SignalLayout>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a personal investment cockpit at `/signal/*` — auth-gated via existing Clerk setup, completely isolated from the public site and admin panel
- Implements `SignalLayout` (220px collapsible sidebar, cockpit header) as a parallel to `AdminLayout`
- Scaffolds all 9 Phase 0 routes with real UI structure, empty states, and integration hooks ready to wire to Supabase

## Routes

| Path | Page |
|---|---|
| `/signal` | Dashboard — portfolio value, metric grid, holdings by tier, checklist, alerts, catalysts, firings feed, deployment plan |
| `/signal/portfolio` | Holdings table + add-position form |
| `/signal/watchlist` | Ticker watchlist with thesis field |
| `/signal/signals` | Raw event feed + source status cards |
| `/signal/firings` | Pattern firings inbox (monitor / alert / urgent severity) |
| `/signal/catalysts` | Catalyst calendar (macro events pre-loaded) |
| `/signal/discipline` | Toggleable rules (concentration, parabolic, drawdown) + weekly checklist |
| `/signal/journal` | Split-pane markdown journal with @TICKER mentions |
| `/signal/settings` | Notification channels, quiet hours, integration API keys |

## Design
- Follows PRD §12.3: `font-mono tabular-nums` on numbers, semantic color only, sentence case, calm aesthetic
- Tier color system: anchor=blue, capex_flow=violet, moonshot=orange, cash=slate
- Severity: monitor=amber, alert=orange, urgent=red (no animation)

## What's not in this PR
- Supabase database migrations (PRD §10 tables)
- Real data queries — all save buttons are disabled with "Connect Supabase" note
- Signal ingestion Edge Functions
- Pattern engine

## Test plan
- [ ] Navigate to `/signal` while logged out — should redirect to `/admin/login`
- [ ] Navigate to `/signal` while logged in — dashboard renders with empty states
- [ ] All 9 sidebar links resolve without 404
- [ ] Existing `/admin/*` and public routes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)