### PR TITLE
AI Products Success Roadmap, talks, and GEO/SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,15 @@
     <link rel="apple-touch-icon" href="/icon-192.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Jonathan Christensen - AI Automation Engineer</title>
-    <meta name="description" content="Jonathan Christensen is an AI Automation Engineer II specializing in Microsoft 365, Azure, and automation workflows. Based in San Diego, CA." />
+    <meta name="description" content="Jonathan Christensen is an AI Automation Engineer in San Diego building governed agents, MSP automation, and evidence-preserving IT workflows for lab and production environments." />
+    <meta name="author" content="Jonathan Christensen" />
+    <meta name="keywords" content="AI automation engineer, governed agents, MSP, lab IT, Microsoft 365, Azure, endpoint provisioning, centrexIT" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://mejohnc.org/" />
     <meta property="og:title" content="Jonathan Christensen - AI Automation Engineer" />
-    <meta property="og:description" content="AI Automation Engineer specializing in agentic systems, Microsoft 365, Azure, and automation workflows." />
+    <meta property="og:description" content="AI Automation Engineer building governed agents, MSP automation, and evidence-preserving IT workflows. San Diego, CA." />
     <meta property="og:image" content="https://mejohnc.org/og-image.png" />
     <meta property="og:site_name" content="Jonathan Christensen" />
     <meta property="og:locale" content="en_US" />
@@ -23,7 +25,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://mejohnc.org/" />
     <meta name="twitter:title" content="Jonathan Christensen - AI Automation Engineer" />
-    <meta name="twitter:description" content="AI Automation Engineer specializing in agentic systems, Microsoft 365, Azure, and automation workflows." />
+    <meta name="twitter:description" content="AI Automation Engineer building governed agents, MSP automation, and evidence-preserving IT workflows. San Diego, CA." />
     <meta name="twitter:image" content="https://mejohnc.org/og-image.png" />
 
     <!-- Canonical -->

--- a/public/_headers
+++ b/public/_headers
@@ -54,6 +54,10 @@
 /robots.txt
   Cache-Control: public, max-age=3600
 
+/llms.txt
+  Content-Type: text/plain; charset=utf-8
+  Cache-Control: public, max-age=3600
+
 # Mac bootstrap shim — served as plain text so `curl | bash` works cleanly
 /mac
   Content-Type: text/plain; charset=utf-8

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,43 @@
+# Jonathan Christensen / MeJohnC.org
+
+> Personal site of John Christensen (Jonathan Christensen), AI Automation Engineer at centrexIT, based in San Diego.
+
+Site: https://mejohnc.org
+Portfolio: https://mejohnc.org/portfolio
+AI Products: https://mejohnc.org/portfolio?track=ai-products
+Endpoint Logistics: https://mejohnc.org/portfolio?track=endpoint-logistics
+About / Collab: https://mejohnc.org/about
+Content: https://mejohnc.org/portfolio?tab=content
+
+## Who
+
+John builds governed AI products and MSP operations systems. Background in enterprise IT (Azure, Intune, Microsoft 365) applied to agentic workflows that preserve evidence and keep humans in production authority.
+
+## AI Products (most recent portfolio item)
+
+centrexIT’s portfolio is a developing operating system for how an MSP senses demand, chooses investments, governs AI, builds safely, completes work, and learns.
+
+Products with full briefs:
+- Client Toolbox (owner: John) — evidence-backed vITM workspace
+- Service Desk Toolbox + Incident Buddy (owner: Toby) — technician automations and 10-domain investigations
+- Iris (owner: John) — governed employee AI / agent OS
+- Proxima (shared platform) — governed agentic engineering, draft-mode
+- accessAI (R&D) — AI control plane, pre-GA as a universal control plane
+
+Named seams without full briefs: Cadre, Spark, Spot, Navigate, Vantage, Knowledge, AI Triage.
+
+Honest claim: coherent portfolio with strong product depth and a credible control-plane architecture. Not yet one uniformly integrated or enforced platform. accessAI is substantial but pre-GA. Agents may advise, draft, test, and reconcile. Humans retain merge, deploy, external-send, destructive action, billing, and autonomy promotion.
+
+## Endpoint Logistics
+
+Provisioning transformation at centrexIT: COVID backlog → Immy.Bot → one-touch provisioning → Autopilot / 3PL.
+
+## Talks
+
+Talks appear under Content with timestamps when posted. None are listed yet; do not invent titles or dates.
+
+## Contact
+
+Email: mejohnwc@gmail.com
+LinkedIn: https://www.linkedin.com/in/mejohnc/
+GitHub: https://github.com/mejohnc-ft

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,3 +8,6 @@ Disallow: /admin/*
 
 # Sitemap location
 Sitemap: https://mejohnc.org/sitemap.xml
+
+# Concise machine-readable summary for AI crawlers
+# https://mejohnc.org/llms.txt

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -31,6 +31,16 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://mejohnc.org/portfolio?track=ai-products</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.85</priority>
+  </url>
+  <url>
+    <loc>https://mejohnc.org/portfolio?track=endpoint-logistics</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://mejohnc.org/portfolio?tab=projects</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -22,6 +22,8 @@ const staticRoutes = [
   { path: "/about", priority: 0.8, changefreq: "monthly" },
   { path: "/projects/territories", priority: 0.7, changefreq: "monthly" },
   { path: "/portfolio?tab=work", priority: 0.8, changefreq: "weekly" },
+  { path: "/portfolio?track=ai-products", priority: 0.85, changefreq: "weekly" },
+  { path: "/portfolio?track=endpoint-logistics", priority: 0.8, changefreq: "weekly" },
   { path: "/portfolio?tab=projects", priority: 0.8, changefreq: "weekly" },
   { path: "/portfolio?tab=software", priority: 0.8, changefreq: "weekly" },
   { path: "/portfolio?tab=content", priority: 0.8, changefreq: "daily" },

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -22,8 +22,16 @@ const staticRoutes = [
   { path: "/about", priority: 0.8, changefreq: "monthly" },
   { path: "/projects/territories", priority: 0.7, changefreq: "monthly" },
   { path: "/portfolio?tab=work", priority: 0.8, changefreq: "weekly" },
-  { path: "/portfolio?track=ai-products", priority: 0.85, changefreq: "weekly" },
-  { path: "/portfolio?track=endpoint-logistics", priority: 0.8, changefreq: "weekly" },
+  {
+    path: "/portfolio?track=ai-products",
+    priority: 0.85,
+    changefreq: "weekly",
+  },
+  {
+    path: "/portfolio?track=endpoint-logistics",
+    priority: 0.8,
+    changefreq: "weekly",
+  },
   { path: "/portfolio?tab=projects", priority: 0.8, changefreq: "weekly" },
   { path: "/portfolio?tab=software", priority: 0.8, changefreq: "weekly" },
   { path: "/portfolio?tab=content", priority: 0.8, changefreq: "daily" },
@@ -82,7 +90,8 @@ function generateSitemapXml(routes) {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${urlEntries}
-</urlset>`;
+</urlset>
+`;
 }
 
 async function main() {

--- a/src/components/ProjectTimeline.test.tsx
+++ b/src/components/ProjectTimeline.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@/lib/theme";
+import { KeyboardFocusProvider } from "@/lib/keyboard-focus";
+import ProjectTimeline from "@/components/ProjectTimeline";
+import AiProductsPanel from "@/components/portfolio/AiProductsPanel";
+import {
+  DEFAULT_TIMELINE_TRACK,
+  TIMELINE_TRACKS,
+  defaultTimelineData,
+  entriesForTrack,
+  normalizeTimelineTrack,
+  resolveTimelineTrack,
+} from "@/data/timeline-tracks";
+import { orderProductBriefs, portfolioThesis, productBriefs } from "@/data/ai-products";
+import { formatTalkTimestamp, sortTalksByDateDesc, talks, type Talk } from "@/data/talks";
+import TalksSection from "@/components/portfolio/TalksSection";
+import {
+  buildCreativeWorkJsonLd,
+  buildOccupationJsonLd,
+  buildPersonJsonLd,
+  buildWebsiteJsonLd,
+  personSchema,
+  softwareSchema,
+  occupationSchema,
+} from "@/lib/seo";
+
+vi.mock("@/lib/supabase", () => ({
+  useSupabaseClient: () => null,
+}));
+
+vi.mock("@/lib/supabase-queries", () => ({
+  getTimelineWithEntries: vi.fn(),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock("framer-motion", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  const passThrough = actual.forwardRef(function Motion(
+    {
+      children,
+      ...props
+    }: {
+      children?: actual.ReactNode;
+      [key: string]: unknown;
+    },
+    ref,
+  ) {
+    const rest = { ...props } as Record<string, unknown>;
+    delete rest.initial;
+    delete rest.animate;
+    delete rest.exit;
+    delete rest.transition;
+    delete rest.whileHover;
+    delete rest.whileTap;
+    delete rest.variants;
+    delete rest.layout;
+    return actual.createElement("div", { ...rest, ref }, children);
+  });
+
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: () => passThrough,
+      },
+    ),
+    AnimatePresence: ({ children }: { children: actual.ReactNode }) => children,
+  };
+});
+
+function renderTimeline() {
+  return render(
+    <ThemeProvider>
+      <KeyboardFocusProvider>
+        <ProjectTimeline />
+      </KeyboardFocusProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe("Success Roadmap tracks", () => {
+  it("lists AI Products first and Endpoint Logistics second", () => {
+    expect(TIMELINE_TRACKS.map((track) => track.id)).toEqual([
+      "ai-products",
+      "endpoint-logistics",
+    ]);
+    expect(DEFAULT_TIMELINE_TRACK).toBe("ai-products");
+  });
+
+  it("defaults unknown track query values to AI Products", () => {
+    expect(resolveTimelineTrack(null)).toBe("ai-products");
+    expect(resolveTimelineTrack("nope")).toBe("ai-products");
+    expect(resolveTimelineTrack("endpoint-logistics")).toBe("endpoint-logistics");
+  });
+
+  it("treats missing DB track as endpoint logistics so live year pills stay on that track", () => {
+    expect(normalizeTimelineTrack(undefined)).toBe("endpoint-logistics");
+    expect(normalizeTimelineTrack("ai-products")).toBe("ai-products");
+  });
+
+  it("keeps the provisioning year history on Endpoint Logistics", () => {
+    const years = entriesForTrack(defaultTimelineData, "endpoint-logistics").map(
+      (entry) => entry.label,
+    );
+    expect(years).toEqual(["2022-2023", "2024", "2025", "2026+"]);
+  });
+
+  it("renders AI Products selected by default", async () => {
+    renderTimeline();
+    const ai = screen.getByRole("tab", { name: "AI Products" });
+    const logistics = screen.getByRole("tab", { name: "Endpoint Logistics" });
+    expect(ai).toHaveAttribute("aria-selected", "true");
+    expect(logistics).toHaveAttribute("aria-selected", "false");
+    expect(
+      await screen.findByRole("heading", {
+        name: /developing operating system/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("switches to Endpoint Logistics and shows year pills", async () => {
+    const user = userEvent.setup();
+    renderTimeline();
+    await user.click(screen.getByRole("tab", { name: "Endpoint Logistics" }));
+    expect(screen.getByRole("tab", { name: "2022-2023" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "2024" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "2025" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "2026+" })).toBeInTheDocument();
+    expect(
+      screen.getByText(/inherited a provisioning backlog/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("AI Products briefs", () => {
+  it("includes the portfolio thesis and Client Toolbox", () => {
+    expect(portfolioThesis.lead).toMatch(/developing operating system/i);
+    expect(portfolioThesis.honestClaim).toMatch(/not yet one uniformly integrated/i);
+    const toolbox = productBriefs.find((brief) => brief.id === "client-toolbox");
+    expect(toolbox?.owner).toBe("John");
+    expect(toolbox?.capabilities).toHaveLength(6);
+    expect(toolbox?.flow).toHaveLength(5);
+  });
+
+  it("does not invent full briefs for named seams", () => {
+    const ids = productBriefs.map((brief) => brief.id);
+    expect(ids).toEqual([
+      "client-toolbox",
+      "service-desk-toolbox",
+      "iris",
+      "proxima",
+      "accessai",
+    ]);
+    expect(portfolioThesis.namedSeams).toContain("Vantage");
+    expect(portfolioThesis.namedSeams).toContain("Cadre");
+  });
+
+  it("orders briefs from timeline entry keys when present", () => {
+    const ordered = orderProductBriefs([
+      {
+        id: "x",
+        label: "Iris",
+        phase: "AI",
+        summary: null,
+        content: null,
+        dot_position: 1,
+        track: "ai-products",
+        entry_key: "iris",
+      },
+    ]);
+    expect(ordered[0].id).toBe("iris");
+    expect(ordered.map((brief) => brief.id)).toContain("client-toolbox");
+  });
+
+  it("renders thesis copy and at least one product brief", async () => {
+    render(
+      <ThemeProvider>
+        <AiProductsPanel />
+      </ThemeProvider>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /developing operating system/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/14 normalized briefs/i)).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Client Toolbox" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(
+      screen.getByText(/Evidence-backed vITM workspace/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("Talks timestamps", () => {
+  it("has no invented talks in the typed source", () => {
+    expect(talks).toEqual([]);
+  });
+
+  it("sorts talks newest first by occurredAt", () => {
+    const sample: Talk[] = [
+      { id: "old", title: "Older talk", occurredAt: "2024-01-15" },
+      { id: "new", title: "Newer talk", occurredAt: "2026-03-02" },
+      { id: "mid", title: "Middle talk", occurredAt: "2025-11-01" },
+    ];
+    expect(sortTalksByDateDesc(sample).map((talk) => talk.id)).toEqual([
+      "new",
+      "mid",
+      "old",
+    ]);
+  });
+
+  it("formats UTC timestamps for display", () => {
+    expect(formatTalkTimestamp("2026-03-02")).toBe("Mar 2, 2026");
+  });
+
+  it("renders a Talks section that does not invent titles", () => {
+    render(<TalksSection />);
+    expect(screen.getByRole("heading", { name: "Talks" })).toBeInTheDocument();
+    expect(screen.getByText(/No talks posted yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/nothing here is invented/i)).toBeInTheDocument();
+  });
+});
+
+describe("SEO helpers", () => {
+  it("builds Person JSON-LD with recruiting-relevant knowsAbout", () => {
+    const json = buildPersonJsonLd(personSchema, "https://mejohnc.org");
+    expect(json["@type"]).toBe("Person");
+    expect(json.jobTitle).toBe("AI Automation Engineer");
+    expect(json.knowsAbout).toEqual(
+      expect.arrayContaining(["Governed agents", "MSP operations"]),
+    );
+    expect(json.worksFor).toEqual({
+      "@type": "Organization",
+      name: "centrexIT",
+    });
+  });
+
+  it("builds Website, Occupation, and CreativeWork JSON-LD", () => {
+    expect(buildWebsiteJsonLd({ type: "Website", name: "MeJohnC", url: "https://mejohnc.org" })["@type"]).toBe(
+      "WebSite",
+    );
+    expect(buildOccupationJsonLd(occupationSchema).name).toBe(
+      "AI Automation Engineer",
+    );
+    const work = buildCreativeWorkJsonLd(softwareSchema, "https://mejohnc.org");
+    expect(work.url).toBe("https://mejohnc.org/portfolio?track=ai-products");
+    expect(String(work.description)).toMatch(/pre-GA/i);
+  });
+});

--- a/src/components/ProjectTimeline.tsx
+++ b/src/components/ProjectTimeline.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Pause, Play, Loader2 } from 'lucide-react';
 import { useTheme } from '@/lib/theme';
@@ -6,6 +6,19 @@ import { useKeyboardFocus } from '@/lib/keyboard-focus';
 import { useSupabaseClient } from '@/lib/supabase';
 import { getTimelineWithEntries, type TimelineEntry } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { useReducedMotion } from '@/lib/reduced-motion';
+import {
+  DEFAULT_TIMELINE_SLUG,
+  DEFAULT_TIMELINE_TRACK,
+  TIMELINE_TRACKS,
+  defaultTimelineData,
+  entriesForTrack,
+  normalizeTimelineTrack,
+  type TimelineItem,
+  type TimelineTrackId,
+} from '@/data/timeline-tracks';
+
+const AiProductsPanel = lazy(() => import('@/components/portfolio/AiProductsPanel'));
 
 // Theme color definitions
 const themes = {
@@ -83,49 +96,35 @@ const themes = {
   },
 };
 
-// Fallback timeline data
-const defaultTimelineData = [
-  {
-    id: '2022-2023',
-    label: '2022-2023',
-    phase: 'Recovery & Foundation',
-    summary: 'Cleared COVID backlog, created inventory sheets, standardized SOPs & SLAs',
-    content: `Starting in 2022, I inherited a provisioning backlog of over 72,000 tickets accumulated during the COVID-19 pandemic. Within 6 months, I systematically cleared this backlog by implementing standardized workflows and creating comprehensive inventory tracking sheets. I reintroduced media sanitization protocols that had lapsed and established the SOPs and SLAs that would become the foundation for all future automation work. This phase was about building trust, understanding the systems, and laying groundwork for what was to come.`,
-    dot_position: 13,
-  },
-  {
-    id: '2024',
-    label: '2024',
-    phase: 'Automation & Knowledge',
-    summary: 'Completed Immy.Bot buildout, standardized Provisioning KB',
-    content: `2024 marked the shift from manual processes to intelligent automation. I completed the full Immy.Bot buildout, enabling automated software deployments and configurations across our entire client base. The Provisioning Knowledge Base was standardized and made accessible, transforming tribal knowledge into documented, searchable resources. This year laid the technical foundation that would enable the dramatic improvements seen in 2025.`,
-    dot_position: 24,
-  },
-  {
-    id: '2025',
-    label: '2025',
-    phase: 'Optimization & Growth',
-    summary: 'One-touch provisions for 75%+ clients, <5 day turnaround, record-breaking October',
-    content: `2025 was the year everything came together. We achieved in-house one-touch provisioning for over 75% of our clients. Provisioning turnaround dropped to under 5 business days—a dramatic improvement from the weeks-long timelines of previous years. October 2025 became our largest provisioning month ever, and we launched a brand-new Inventory system with enhanced UX. I successfully handed off operations to a new hire, established the Provisioning ToolBox with 15 knowledge pieces, and ended the year with fully automated provisioning and inventory intake systems.`,
-    dot_position: 41,
-  },
-  {
-    id: '2026+',
-    label: '2026+',
-    phase: 'Future State',
-    summary: 'Autopilot/White glove for all clients, 3PL integration, office-free logistics',
-    content: `Looking ahead, the vision is complete automation independence. Every client will have Autopilot or White Glove configuration ready from day one. Third-party logistics (3PL) integration will reduce costs while maintaining our rigorous SLAs. The ultimate goal: eliminate any reliance on physical office space for inventory and logistics, enabling a fully distributed, resilient provisioning operation.`,
-    dot_position: 75,
-  },
-];
+function mapEntry(entry: TimelineEntry, index: number): TimelineItem {
+  return {
+    id: entry.id,
+    label: entry.label,
+    phase: entry.phase,
+    summary: entry.summary,
+    content: entry.content,
+    dot_position: entry.dot_position,
+    track: normalizeTimelineTrack(entry.track),
+    entry_key: entry.entry_key ?? entry.label ?? `entry-${index}`,
+  };
+}
+
+function mergeTimelineEntries(fetched: TimelineItem[]): TimelineItem[] {
+  const logistics = entriesForTrack(fetched, 'endpoint-logistics');
+  const aiProducts = entriesForTrack(fetched, 'ai-products');
+  const fallbackLogistics = entriesForTrack(defaultTimelineData, 'endpoint-logistics');
+  const fallbackAi = entriesForTrack(defaultTimelineData, 'ai-products');
+
+  return [
+    ...(aiProducts.length > 0 ? aiProducts : fallbackAi),
+    ...(logistics.length > 0 ? logistics : fallbackLogistics),
+  ];
+}
 
 // Convert dot_position (0-100) to chart coordinates
 function getDotPosition(dotPosition: number, entryCount: number, index: number) {
-  // X position: distribute evenly across the chart
   const segmentWidth = 100 / entryCount;
   const left = `${segmentWidth * index + segmentWidth / 2}%`;
-
-  // Y position: map dot_position (0=bottom, 100=top) to chart (92=bottom, 15=top)
   const top = `${92 - (dotPosition / 100) * 77}%`;
 
   return { left, top };
@@ -138,14 +137,12 @@ function generateCurvePath(entries: { dot_position: number }[]) {
   const count = entries.length;
   const segmentWidth = 100 / count;
 
-  // Calculate points
   const points = entries.map((entry, i) => {
     const x = segmentWidth * i + segmentWidth / 2;
     const y = 92 - (entry.dot_position / 100) * 77;
     return { x, y };
   });
 
-  // Build path with bezier curves
   let path = `M 0,${92 - (entries[0].dot_position / 100) * 77 + 5}`;
 
   points.forEach((point, i) => {
@@ -159,32 +156,26 @@ function generateCurvePath(entries: { dot_position: number }[]) {
     }
   });
 
-  // Extend to edge
   const lastPoint = points[points.length - 1];
   path += ` C ${lastPoint.x + 5},${lastPoint.y - 3} ${98},${lastPoint.y - 8} 100,${lastPoint.y - 10}`;
 
   return path;
 }
 
-interface TimelineItem {
-  id: string;
-  label: string;
-  phase: string;
-  summary: string | null;
-  content: string | null;
-  dot_position: number;
-}
-
 interface ProjectTimelineProps {
   slug?: string;
   focused?: boolean;
+  activeTrack?: TimelineTrackId;
+  onTrackChange?: (track: TimelineTrackId) => void;
   onRequestFocusUp?: () => void;
   onRequestFocusDown?: () => void;
 }
 
 const ProjectTimeline = ({
-  slug = 'provisioning-roadmap',
+  slug = DEFAULT_TIMELINE_SLUG,
   focused = false,
+  activeTrack: controlledTrack,
+  onTrackChange,
   onRequestFocusUp,
   onRequestFocusDown
 }: ProjectTimelineProps) => {
@@ -192,58 +183,91 @@ const ProjectTimeline = ({
   const theme = themes[currentTheme];
   const supabase = useSupabaseClient();
   const { setFocusLevel } = useKeyboardFocus();
+  const prefersReducedMotion = useReducedMotion();
 
   const [timelineData, setTimelineData] = useState<TimelineItem[]>(defaultTimelineData);
-  const [isLoading, setIsLoading] = useState(true);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [isAutoPlaying, setIsAutoPlaying] = useState(true);
+  const [internalTrack, setInternalTrack] = useState<TimelineTrackId>(
+    controlledTrack ?? DEFAULT_TIMELINE_TRACK
+  );
+  const [expandedId, setExpandedId] = useState<string | null>(
+    entriesForTrack(defaultTimelineData, 'endpoint-logistics')[0]?.id ?? null
+  );
+  const [isAutoPlaying, setIsAutoPlaying] = useState(!prefersReducedMotion);
 
-  // Fetch timeline data
+  const activeTrack = controlledTrack ?? internalTrack;
+
+  const setActiveTrack = useCallback((track: TimelineTrackId) => {
+    if (onTrackChange) {
+      onTrackChange(track);
+    } else {
+      setInternalTrack(track);
+    }
+    setIsAutoPlaying(false);
+    setFocusLevel('timeline');
+  }, [onTrackChange, setFocusLevel]);
+
   useEffect(() => {
+    if (controlledTrack) {
+      setInternalTrack(controlledTrack);
+    }
+  }, [controlledTrack]);
+
+  useEffect(() => {
+    if (prefersReducedMotion) {
+      setIsAutoPlaying(false);
+    }
+  }, [prefersReducedMotion]);
+
+  // Fetch timeline data without blocking on a spinner (fallback already rendered)
+  useEffect(() => {
+    let cancelled = false;
+
     async function fetchTimeline() {
+      if (!supabase) return;
       try {
         const data = await getTimelineWithEntries(slug, supabase);
+        if (cancelled) return;
         if (data && data.entries.length > 0) {
-          const items: TimelineItem[] = data.entries.map((entry: TimelineEntry) => ({
-            id: entry.id,
-            label: entry.label,
-            phase: entry.phase,
-            summary: entry.summary,
-            content: entry.content,
-            dot_position: entry.dot_position,
-          }));
+          const items = mergeTimelineEntries(data.entries.map(mapEntry));
           setTimelineData(items);
-          setExpandedId(items[0].id);
-        } else {
-          setExpandedId(defaultTimelineData[0].id);
+          const logistics = entriesForTrack(items, 'endpoint-logistics');
+          if (logistics[0]) {
+            setExpandedId((current) => {
+              const stillThere = logistics.some((item) => item.id === current);
+              return stillThere ? current : logistics[0].id;
+            });
+          }
         }
       } catch (err) {
         captureException(err instanceof Error ? err : new Error(String(err)), {
           context: 'ProjectTimeline.fetchTimeline',
           slug,
         });
-        setExpandedId(defaultTimelineData[0].id);
-      } finally {
-        setIsLoading(false);
       }
     }
     fetchTimeline();
-     
+    return () => {
+      cancelled = true;
+    };
   }, [slug, supabase]);
 
+  const logisticsEntries = entriesForTrack(timelineData, 'endpoint-logistics');
+  const aiProductEntries = entriesForTrack(timelineData, 'ai-products');
+  const trackMeta = TIMELINE_TRACKS.find((track) => track.id === activeTrack) ?? TIMELINE_TRACKS[0];
+
   const goToNext = useCallback(() => {
-    const currentIndex = timelineData.findIndex(item => item.id === expandedId);
-    const nextIndex = (currentIndex + 1) % timelineData.length;
-    setExpandedId(timelineData[nextIndex].id);
+    const currentIndex = logisticsEntries.findIndex(item => item.id === expandedId);
+    const nextIndex = (currentIndex + 1) % logisticsEntries.length;
+    setExpandedId(logisticsEntries[nextIndex]?.id ?? null);
     setIsAutoPlaying(false);
-  }, [expandedId, timelineData]);
+  }, [expandedId, logisticsEntries]);
 
   const goToPrev = useCallback(() => {
-    const currentIndex = timelineData.findIndex(item => item.id === expandedId);
-    const prevIndex = (currentIndex - 1 + timelineData.length) % timelineData.length;
-    setExpandedId(timelineData[prevIndex].id);
+    const currentIndex = logisticsEntries.findIndex(item => item.id === expandedId);
+    const prevIndex = (currentIndex - 1 + logisticsEntries.length) % logisticsEntries.length;
+    setExpandedId(logisticsEntries[prevIndex]?.id ?? null);
     setIsAutoPlaying(false);
-  }, [expandedId, timelineData]);
+  }, [expandedId, logisticsEntries]);
 
   // Keyboard navigation when focused
   useEffect(() => {
@@ -256,11 +280,23 @@ const ProjectTimeline = ({
       if (e.key === 'ArrowRight') {
         e.preventDefault();
         e.stopImmediatePropagation();
-        goToNext();
+        if (activeTrack === 'endpoint-logistics') {
+          goToNext();
+        } else {
+          const currentIndex = TIMELINE_TRACKS.findIndex((track) => track.id === activeTrack);
+          const next = TIMELINE_TRACKS[(currentIndex + 1) % TIMELINE_TRACKS.length];
+          setActiveTrack(next.id);
+        }
       } else if (e.key === 'ArrowLeft') {
         e.preventDefault();
         e.stopImmediatePropagation();
-        goToPrev();
+        if (activeTrack === 'endpoint-logistics') {
+          goToPrev();
+        } else {
+          const currentIndex = TIMELINE_TRACKS.findIndex((track) => track.id === activeTrack);
+          const prev = TIMELINE_TRACKS[(currentIndex - 1 + TIMELINE_TRACKS.length) % TIMELINE_TRACKS.length];
+          setActiveTrack(prev.id);
+        }
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         e.stopImmediatePropagation();
@@ -274,14 +310,14 @@ const ProjectTimeline = ({
 
     window.addEventListener('keydown', handleKeyDown, true);
     return () => window.removeEventListener('keydown', handleKeyDown, true);
-  }, [focused, goToNext, goToPrev, onRequestFocusUp, onRequestFocusDown]);
+  }, [focused, goToNext, goToPrev, onRequestFocusUp, onRequestFocusDown, activeTrack, setActiveTrack]);
 
-  // Auto-rotation timer (20 seconds per slide)
+  // Auto-rotation timer (20 seconds per slide) — logistics years only
   useEffect(() => {
-    if (!isAutoPlaying || isLoading) return;
+    if (!isAutoPlaying || activeTrack !== 'endpoint-logistics' || prefersReducedMotion) return;
     const timer = setInterval(goToNext, 20000);
     return () => clearInterval(timer);
-  }, [isAutoPlaying, isLoading, goToNext]);
+  }, [isAutoPlaying, goToNext, activeTrack, prefersReducedMotion]);
 
   const handleSegmentClick = (id: string, e?: React.MouseEvent) => {
     e?.stopPropagation();
@@ -290,31 +326,135 @@ const ProjectTimeline = ({
     setFocusLevel('timeline');
   };
 
-  if (isLoading) {
-    return (
-      <div className="mb-12 flex items-center justify-center py-20">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
-    );
-  }
-
-  const curvePath = generateCurvePath(timelineData);
+  const motionDuration = prefersReducedMotion ? 0 : 0.4;
 
   return (
     <div
-      className="mb-12 cursor-pointer"
+      className="mb-12"
       onClick={() => setFocusLevel('timeline')}
       role="region"
-      aria-label="Project timeline"
+      aria-label="Success roadmap"
     >
-      {/* Growth Curve Graph */}
+      <div
+        role="tablist"
+        aria-label="Success roadmap tracks"
+        className="flex flex-wrap gap-2 mb-6"
+      >
+        {TIMELINE_TRACKS.map((track) => {
+          const selected = activeTrack === track.id;
+          return (
+            <motion.button
+              key={track.id}
+              type="button"
+              role="tab"
+              id={`roadmap-track-${track.id}`}
+              aria-selected={selected}
+              aria-controls={`roadmap-panel-${track.id}`}
+              tabIndex={selected ? 0 : -1}
+              onClick={(e) => {
+                e.stopPropagation();
+                setActiveTrack(track.id);
+              }}
+              onKeyDown={(e) => {
+                if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+                e.preventDefault();
+                const index = TIMELINE_TRACKS.findIndex((item) => item.id === track.id);
+                const delta = e.key === 'ArrowRight' ? 1 : -1;
+                const next = TIMELINE_TRACKS[(index + delta + TIMELINE_TRACKS.length) % TIMELINE_TRACKS.length];
+                setActiveTrack(next.id);
+                document.getElementById(`roadmap-track-${next.id}`)?.focus();
+              }}
+              className={`font-mono text-sm uppercase tracking-wider px-4 py-2 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                selected
+                  ? 'border-primary text-primary bg-primary/10'
+                  : 'border-border text-muted-foreground hover:text-foreground hover:border-current'
+              }`}
+              whileHover={prefersReducedMotion ? undefined : { y: -1 }}
+              whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
+            >
+              {track.label}
+            </motion.button>
+          );
+        })}
+      </div>
+
+      <div className="mb-8">
+        <h3 className="text-2xl md:text-3xl font-black text-foreground">
+          {trackMeta.heading}
+        </h3>
+        <p className="text-muted-foreground mt-2 max-w-3xl">{trackMeta.summary}</p>
+      </div>
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={activeTrack}
+          id={`roadmap-panel-${activeTrack}`}
+          role="tabpanel"
+          aria-labelledby={`roadmap-track-${activeTrack}`}
+          initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+          transition={{ duration: motionDuration, ease: [0.25, 0.46, 0.45, 0.94] }}
+        >
+          {activeTrack === 'ai-products' ? (
+            <Suspense
+              fallback={
+                <div className="flex items-center justify-center py-20">
+                  <Loader2 className="w-8 h-8 animate-spin text-primary" />
+                </div>
+              }
+            >
+              <AiProductsPanel entries={aiProductEntries} />
+            </Suspense>
+          ) : (
+            <LogisticsTimeline
+              timelineData={logisticsEntries}
+              theme={theme}
+              focused={focused}
+              expandedId={expandedId}
+              isAutoPlaying={isAutoPlaying}
+              prefersReducedMotion={prefersReducedMotion}
+              onSegmentClick={handleSegmentClick}
+              onToggleAutoPlay={() => setIsAutoPlaying(!isAutoPlaying)}
+            />
+          )}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+};
+
+interface LogisticsTimelineProps {
+  timelineData: TimelineItem[];
+  theme: (typeof themes)['warm'];
+  focused: boolean;
+  expandedId: string | null;
+  isAutoPlaying: boolean;
+  prefersReducedMotion: boolean;
+  onSegmentClick: (id: string, e?: React.MouseEvent) => void;
+  onToggleAutoPlay: () => void;
+}
+
+function LogisticsTimeline({
+  timelineData,
+  theme,
+  focused,
+  expandedId,
+  isAutoPlaying,
+  prefersReducedMotion,
+  onSegmentClick,
+  onToggleAutoPlay,
+}: LogisticsTimelineProps) {
+  const curvePath = generateCurvePath(timelineData);
+  const motionDuration = prefersReducedMotion ? 0 : 0.4;
+
+  return (
+    <div>
       <div className="relative h-32 mb-6">
         <svg className="w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none">
-          {/* Grid lines */}
           <line x1="0" y1="74" x2="100" y2="74" stroke={theme.gridLine} strokeWidth="0.1" opacity="0.3" />
           <line x1="0" y1="53" x2="100" y2="53" stroke={theme.gridLine} strokeWidth="0.1" opacity="0.3" />
 
-          {/* Dynamic curve */}
           <motion.path
             d={curvePath}
             fill="none"
@@ -323,18 +463,18 @@ const ProjectTimeline = ({
             strokeLinecap="round"
             shapeRendering="geometricPrecision"
             style={{ filter: `drop-shadow(0 0 2px ${theme.primary})` }}
-            initial={{ pathLength: 0 }}
+            initial={{ pathLength: prefersReducedMotion ? 1 : 0 }}
             animate={{ pathLength: 1 }}
-            transition={{ duration: 1.5, ease: 'easeOut' }}
+            transition={{ duration: prefersReducedMotion ? 0 : 1.5, ease: 'easeOut' }}
           />
         </svg>
 
-        {/* Dots */}
         {timelineData.map((item, i) => {
           const pos = getDotPosition(item.dot_position, timelineData.length, i);
           return (
             <motion.button
               key={item.id}
+              type="button"
               className="absolute w-[18px] h-[18px] rounded-full"
               style={{
                 left: pos.left,
@@ -346,16 +486,18 @@ const ProjectTimeline = ({
                   ? `drop-shadow(0 0 12px ${theme.primary}) drop-shadow(0 0 20px ${theme.primary})`
                   : 'none',
               }}
-              initial={{ scale: 0, opacity: 0 }}
+              initial={{ scale: prefersReducedMotion ? 1 : 0, opacity: prefersReducedMotion ? 1 : 0 }}
               animate={{
                 scale: expandedId === item.id ? 1 : 0.667,
                 opacity: 1
               }}
               transition={{
-                scale: { type: 'spring', stiffness: 400, damping: 25 },
-                opacity: { delay: 0.3 + i * 0.2 }
+                scale: prefersReducedMotion
+                  ? { duration: 0 }
+                  : { type: 'spring', stiffness: 400, damping: 25 },
+                opacity: { delay: prefersReducedMotion ? 0 : 0.3 + i * 0.2, duration: motionDuration }
               }}
-              onClick={(e) => handleSegmentClick(item.id, e)}
+              onClick={(e) => onSegmentClick(item.id, e)}
               aria-label={`Timeline point: ${item.label} - ${item.phase}`}
               aria-pressed={expandedId === item.id}
             />
@@ -363,20 +505,20 @@ const ProjectTimeline = ({
         })}
       </div>
 
-      {/* Timeline Bar */}
       <div className="relative mb-4" role="tablist" aria-label="Timeline phases">
         <div className="flex h-12 rounded overflow-hidden">
           {timelineData.map((item, index) => (
             <motion.button
               key={item.id}
-              onClick={(e) => handleSegmentClick(item.id, e)}
+              type="button"
+              onClick={(e) => onSegmentClick(item.id, e)}
               className="flex-1 flex items-center justify-center font-mono text-sm font-semibold cursor-pointer transition-all"
               style={{
                 background: theme.segments[index % theme.segments.length],
                 color: theme.segmentText[index % theme.segmentText.length],
               }}
-              whileHover={{ scale: 1.02, zIndex: 10 }}
-              whileTap={{ scale: 0.98 }}
+              whileHover={prefersReducedMotion ? undefined : { scale: 1.02, zIndex: 10 }}
+              whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
               role="tab"
               aria-selected={expandedId === item.id}
               aria-controls={`timeline-content-${item.id}`}
@@ -386,9 +528,12 @@ const ProjectTimeline = ({
           ))}
         </div>
 
-        {/* Auto-play toggle */}
         <button
-          onClick={() => setIsAutoPlaying(!isAutoPlaying)}
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleAutoPlay();
+          }}
           className="absolute -right-12 top-1/2 -translate-y-1/2 p-2 rounded border border-border hover:border-current transition-colors"
           style={{ color: theme.primary }}
           aria-label={isAutoPlaying ? 'Pause auto-play' : 'Resume auto-play'}
@@ -398,12 +543,12 @@ const ProjectTimeline = ({
         </button>
       </div>
 
-      {/* Phase Labels */}
       <div className={`grid gap-4 mb-6 ${timelineData.length <= 4 ? 'grid-cols-2 md:grid-cols-4' : 'grid-cols-2 md:grid-cols-' + timelineData.length}`}>
         {timelineData.map((item) => (
           <button
             key={item.id}
-            onClick={(e) => handleSegmentClick(item.id, e)}
+            type="button"
+            onClick={(e) => onSegmentClick(item.id, e)}
             className={`text-center font-mono text-xs uppercase tracking-wider transition-colors cursor-pointer ${
               expandedId === item.id ? '' : 'text-muted-foreground hover:text-foreground'
             }`}
@@ -416,16 +561,15 @@ const ProjectTimeline = ({
         ))}
       </div>
 
-      {/* Expanded Content */}
       <div className="relative min-h-[200px]">
         <AnimatePresence mode="wait">
           {expandedId && (
             <motion.div
               key={expandedId}
-              initial={{ opacity: 0, x: 100 }}
+              initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, x: 24 }}
               animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -100 }}
-              transition={{ duration: 0.4, ease: [0.25, 0.46, 0.45, 0.94] }}
+              exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, x: -16 }}
+              transition={{ duration: motionDuration, ease: [0.25, 0.46, 0.45, 0.94] }}
             >
               <div
                 className="p-6 pb-8 rounded border bg-card/50 backdrop-blur-sm"
@@ -433,6 +577,8 @@ const ProjectTimeline = ({
                   borderColor: theme.primary,
                   boxShadow: `0 0 20px ${theme.glow}`,
                 }}
+                id={`timeline-content-${expandedId}`}
+                role="tabpanel"
               >
                 {timelineData
                   .filter((item) => item.id === expandedId)
@@ -457,24 +603,25 @@ const ProjectTimeline = ({
         </AnimatePresence>
       </div>
 
-      {/* Progress indicator */}
       {isAutoPlaying && (
         <div className="mt-4 flex justify-center gap-2">
           {timelineData.map((item) => (
             <button
               key={item.id}
-              onClick={(e) => handleSegmentClick(item.id, e)}
+              type="button"
+              onClick={(e) => onSegmentClick(item.id, e)}
               className="w-2 h-2 rounded-full transition-all"
               style={{
                 background: expandedId === item.id ? theme.primary : theme.progressInactive,
                 boxShadow: expandedId === item.id ? `0 0 8px ${theme.primary}` : 'none',
               }}
+              aria-label={`Show ${item.label}`}
             />
           ))}
         </div>
       )}
     </div>
   );
-};
+}
 
 export default ProjectTimeline;

--- a/src/components/portfolio/AiProductsPanel.tsx
+++ b/src/components/portfolio/AiProductsPanel.tsx
@@ -1,0 +1,445 @@
+import { useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  LOOP_STAGE_LABELS,
+  orderProductBriefs,
+  portfolioThesis,
+  type LoopStage,
+  type ProductBrief,
+  type ReadinessLedger,
+} from "@/data/ai-products";
+import type { TimelineItem } from "@/data/timeline-tracks";
+import { useReducedMotion } from "@/lib/reduced-motion";
+import { useTheme } from "@/lib/theme";
+
+const themes = {
+  warm: { primary: "hsl(25, 95%, 53%)", glow: "hsla(25, 95%, 53%, 0.15)" },
+  crisp: { primary: "hsl(177, 94%, 21%)", glow: "hsla(177, 94%, 21%, 0.15)" },
+  "solarized-dark": {
+    primary: "hsl(175, 59%, 40%)",
+    glow: "hsla(175, 59%, 40%, 0.15)",
+  },
+  "solarized-light": {
+    primary: "hsl(175, 59%, 40%)",
+    glow: "hsla(175, 59%, 40%, 0.15)",
+  },
+};
+
+const LOOP_ORDER: LoopStage[] = [
+  "sense",
+  "decide",
+  "govern",
+  "build",
+  "operate",
+];
+
+interface AiProductsPanelProps {
+  entries?: TimelineItem[];
+}
+
+export default function AiProductsPanel({ entries }: AiProductsPanelProps) {
+  const { theme: currentTheme } = useTheme();
+  const theme = themes[currentTheme];
+  const prefersReducedMotion = useReducedMotion();
+  const briefs = useMemo(() => orderProductBriefs(entries), [entries]);
+  const [selectedId, setSelectedId] = useState(briefs[0]?.id ?? "");
+  const selected = briefs.find((brief) => brief.id === selectedId) ?? briefs[0];
+
+  const duration = prefersReducedMotion ? 0 : 0.35;
+
+  return (
+    <div className="space-y-10">
+      <ThesisCard theme={theme} duration={duration} />
+
+      <div>
+        <div className="flex items-end justify-between gap-4 mb-4">
+          <div>
+            <span className="font-mono text-xs text-muted-foreground uppercase tracking-widest">
+              Product briefs
+            </span>
+            <p className="text-sm text-muted-foreground mt-1">
+              Five products with named owners. Cadre, Spark, Spot, Navigate,
+              Vantage, Knowledge, and AI Triage appear as seams in the loop
+              above — not as full briefs.
+            </p>
+          </div>
+        </div>
+
+        <div
+          role="tablist"
+          aria-label="AI product briefs"
+          className="flex flex-wrap gap-2 mb-6"
+        >
+          {briefs.map((brief) => {
+            const selectedBrief = brief.id === selected?.id;
+            return (
+              <motion.button
+                key={brief.id}
+                type="button"
+                role="tab"
+                id={`product-tab-${brief.id}`}
+                aria-selected={selectedBrief}
+                aria-controls={`product-panel-${brief.id}`}
+                tabIndex={selectedBrief ? 0 : -1}
+                onClick={() => setSelectedId(brief.id)}
+                onKeyDown={(event) => {
+                  if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+                    return;
+                  }
+                  event.preventDefault();
+                  const index = briefs.findIndex((item) => item.id === brief.id);
+                  const delta = event.key === "ArrowRight" ? 1 : -1;
+                  const next =
+                    briefs[(index + delta + briefs.length) % briefs.length];
+                  setSelectedId(next.id);
+                  document.getElementById(`product-tab-${next.id}`)?.focus();
+                }}
+                className={`font-mono text-xs uppercase tracking-wider px-3 py-2 rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                  selectedBrief
+                    ? "border-primary text-primary bg-primary/10"
+                    : "border-border text-muted-foreground hover:text-foreground hover:border-current"
+                }`}
+                whileHover={prefersReducedMotion ? undefined : { y: -1 }}
+                whileTap={prefersReducedMotion ? undefined : { scale: 0.98 }}
+              >
+                {brief.name}
+              </motion.button>
+            );
+          })}
+        </div>
+
+        <AnimatePresence mode="wait">
+          {selected && (
+            <motion.div
+              key={selected.id}
+              role="tabpanel"
+              id={`product-panel-${selected.id}`}
+              aria-labelledby={`product-tab-${selected.id}`}
+              initial={
+                prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 12 }
+              }
+              animate={{ opacity: 1, y: 0 }}
+              exit={
+                prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -8 }
+              }
+              transition={{ duration, ease: [0.25, 0.46, 0.45, 0.94] }}
+            >
+              <ProductBriefCard brief={selected} theme={theme} />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+function ThesisCard({
+  theme,
+  duration,
+}: {
+  theme: { primary: string; glow: string };
+  duration: number;
+}) {
+  const thesis = portfolioThesis;
+
+  return (
+    <motion.section
+      aria-labelledby="ai-products-thesis"
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration, ease: [0.25, 0.46, 0.45, 0.94] }}
+      className="p-6 md:p-8 rounded-xl border bg-card/50 backdrop-blur-sm"
+      style={{
+        borderColor: theme.primary,
+        boxShadow: `0 0 24px ${theme.glow}`,
+      }}
+    >
+      <span className="font-mono text-xs text-primary uppercase tracking-widest">
+        Portfolio thesis
+      </span>
+      <h3
+        id="ai-products-thesis"
+        className="text-2xl md:text-3xl font-black text-foreground mt-2 mb-4"
+      >
+        {thesis.title}
+      </h3>
+      <p className="text-muted-foreground leading-relaxed mb-6 max-w-3xl">
+        {thesis.lead}
+      </p>
+
+      <ul className="flex flex-wrap gap-2 mb-8">
+        {thesis.tags.map((tag) => (
+          <li
+            key={tag}
+            className="font-mono text-xs px-2.5 py-1 rounded-full border border-border text-foreground"
+          >
+            {tag}
+          </li>
+        ))}
+      </ul>
+
+      <div className="mb-8">
+        <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
+          Operating loop
+        </h4>
+        <ol className="grid gap-3 md:grid-cols-5">
+          {thesis.loop.map((step, index) => (
+            <li
+              key={step.stage}
+              className="rounded-lg border border-border p-3 bg-background/40"
+            >
+              <div
+                className="font-mono text-xs font-semibold mb-2"
+                style={{ color: theme.primary }}
+              >
+                {index + 1}. {LOOP_STAGE_LABELS[step.stage]}
+              </div>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                {step.detail}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <p className="text-foreground leading-relaxed mb-3">{thesis.cohesive}</p>
+      <p className="text-sm text-muted-foreground leading-relaxed mb-8">
+        {thesis.honestClaim}
+      </p>
+
+      <div className="grid md:grid-cols-2 gap-6 mb-8">
+        <div>
+          <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
+            Layers
+          </h4>
+          <ul className="space-y-2">
+            {thesis.layers.map((layer) => (
+              <li key={layer.name} className="text-sm">
+                <span className="font-semibold text-foreground">
+                  {layer.name}
+                </span>
+                <span className="text-muted-foreground"> — {layer.detail}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
+            Guardrails
+          </h4>
+          <ul className="flex flex-wrap gap-2 mb-4">
+            {thesis.guardrails.map((item) => (
+              <li
+                key={item}
+                className="text-xs px-2 py-1 rounded border border-border text-foreground"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {thesis.agentAuthority}
+          </p>
+        </div>
+      </div>
+
+      <p className="text-sm text-foreground mb-6">
+        <span className="font-semibold">Current truth. </span>
+        {thesis.currentTruth}
+      </p>
+
+      <ReadinessLedgerBlock ledger={thesis.operatingEvidence} />
+
+      <p className="text-xs text-muted-foreground mt-6">
+        Named seams: {thesis.namedSeams.join(" · ")}
+      </p>
+    </motion.section>
+  );
+}
+
+function ProductBriefCard({
+  brief,
+  theme,
+}: {
+  brief: ProductBrief;
+  theme: { primary: string; glow: string };
+}) {
+  return (
+    <article
+      className="p-6 md:p-8 rounded-xl border bg-card/50 backdrop-blur-sm"
+      style={{ borderColor: "hsl(var(--border))" }}
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-3 mb-3">
+        <h3 className="text-2xl font-black text-foreground">{brief.name}</h3>
+        <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          Owner {brief.owner}
+        </span>
+      </div>
+      <p className="text-muted-foreground leading-relaxed mb-4">
+        {brief.tagline}
+      </p>
+
+      <ul className="flex flex-wrap gap-2 mb-4">
+        {brief.chips.map((chip) => (
+          <li
+            key={chip}
+            className="font-mono text-xs px-2.5 py-1 rounded-full bg-primary/10 text-primary"
+          >
+            {chip}
+          </li>
+        ))}
+      </ul>
+
+      <LoopMarker stages={brief.loopStages} primary={theme.primary} />
+
+      <p className="text-sm text-foreground leading-relaxed my-6">
+        <span className="font-semibold">Primary. </span>
+        {brief.primaryCapability}
+      </p>
+
+      <div className="grid md:grid-cols-2 gap-8 mb-8">
+        <div>
+          <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
+            Capabilities
+          </h4>
+          <ol className="space-y-2">
+            {brief.capabilities.map((capability, index) => (
+              <li key={capability} className="text-sm text-foreground">
+                <span className="font-mono text-xs text-primary mr-2">
+                  {index + 1}.
+                </span>
+                {capability}
+              </li>
+            ))}
+          </ol>
+        </div>
+        <div className="space-y-6">
+          <div>
+            <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
+              Flow
+            </h4>
+            <p className="text-sm text-foreground">
+              {brief.flow.join(" → ")}
+            </p>
+          </div>
+          <div>
+            <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
+              Stack
+            </h4>
+            <p className="text-sm text-muted-foreground">{brief.stack.join(" · ")}</p>
+          </div>
+        </div>
+      </div>
+
+      {(brief.engineeringNotes || brief.securityNotes) && (
+        <div className="grid md:grid-cols-2 gap-6 mb-8">
+          {brief.engineeringNotes && (
+            <div>
+              <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-2">
+                Engineering
+              </h4>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {brief.engineeringNotes}
+              </p>
+            </div>
+          )}
+          {brief.securityNotes && (
+            <div>
+              <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-2">
+                Security
+              </h4>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {brief.securityNotes}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      <ReadinessLedgerBlock ledger={brief.readiness} />
+
+      <div className="grid md:grid-cols-3 gap-4 mt-6">
+        <MaturityColumn label="Proven today" items={brief.proven} />
+        <MaturityColumn label="Pre-GA" items={brief.preGa} />
+        <MaturityColumn label="Target seam" items={brief.target} />
+      </div>
+    </article>
+  );
+}
+
+function LoopMarker({
+  stages,
+  primary,
+}: {
+  stages: LoopStage[];
+  primary: string;
+}) {
+  return (
+    <p className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+      Loop{" "}
+      {LOOP_ORDER.map((stage, index) => {
+        const active = stages.includes(stage);
+        return (
+          <span key={stage}>
+            <span style={{ color: active ? primary : undefined }} className={active ? "font-semibold" : ""}>
+              {LOOP_STAGE_LABELS[stage]}
+            </span>
+            {index < LOOP_ORDER.length - 1 ? " → " : ""}
+          </span>
+        );
+      })}
+    </p>
+  );
+}
+
+function ReadinessLedgerBlock({ ledger }: { ledger: ReadinessLedger }) {
+  const rows: [string, string][] = [
+    ["Lifecycle", ledger.lifecycle],
+    ["Adoption", ledger.adoption],
+    ["Production", ledger.production],
+    ["Ownership", ledger.ownership],
+    ["Risk", ledger.risk],
+  ];
+  return (
+    <div>
+      <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
+        Readiness ledger
+      </h4>
+      <dl className="grid sm:grid-cols-2 gap-x-6 gap-y-2">
+        {rows.map(([label, value]) => (
+          <div key={label} className="text-sm">
+            <dt className="inline font-semibold text-foreground">{label}. </dt>
+            <dd className="inline text-muted-foreground">{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function MaturityColumn({
+  label,
+  items,
+}: {
+  label: string;
+  items: string[];
+}) {
+  return (
+    <div className="rounded-lg border border-border p-4 bg-background/40">
+      <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-2">
+        {label}
+      </h4>
+      {items.length === 0 ? (
+        <p className="text-xs text-muted-foreground">None claimed.</p>
+      ) : (
+        <ul className="space-y-1">
+          {items.map((item) => (
+            <li key={item} className="text-sm text-foreground">
+              {item}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/portfolio/ContentTab.tsx
+++ b/src/components/portfolio/ContentTab.tsx
@@ -11,6 +11,7 @@ import {
 import { BlogCardSkeleton } from "@/components/Skeleton";
 import { Badge } from "@/components/ui/badge";
 import BlogCard from "@/components/BlogCard";
+import TalksSection from "@/components/portfolio/TalksSection";
 import {
   getBlogPosts,
   getCuratedArticles,
@@ -19,6 +20,7 @@ import {
   type NewsSource,
 } from "@/lib/supabase-queries";
 import { captureException } from "@/lib/sentry";
+import { useReducedMotion } from "@/lib/reduced-motion";
 
 type ContentSource = "all" | "me" | "news";
 type ArticleWithSource = NewsArticle & { source: NewsSource | null };
@@ -71,6 +73,7 @@ function newsToUnified(article: ArticleWithSource): UnifiedPost {
 }
 
 export default function ContentTab() {
+  const prefersReducedMotion = useReducedMotion();
   const [localPosts, setLocalPosts] = useState<BlogPost[]>([]);
   const [curatedNews, setCuratedNews] = useState<ArticleWithSource[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -147,10 +150,10 @@ export default function ContentTab() {
   return (
     <motion.div
       key="content"
-      initial={{ opacity: 0, x: -50 }}
+      initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, x: -24 }}
       animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: 50 }}
-      transition={{ duration: 0.3, ease: "easeInOut" }}
+      exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, x: 24 }}
+      transition={{ duration: prefersReducedMotion ? 0 : 0.3, ease: "easeInOut" }}
     >
       <div className="mb-12">
         <span className="font-mono text-sm text-primary uppercase tracking-widest">
@@ -161,9 +164,11 @@ export default function ContentTab() {
         </h2>
         <p className="text-lg text-muted-foreground mt-4 max-w-2xl">
           Thoughts on AI, automation, engineering, and curated news from around
-          the web.
+          the web. Talks are listed with timestamps when they exist.
         </p>
       </div>
+
+      <TalksSection />
 
       {/* Source Tabs */}
       <div className="flex items-center gap-1 mb-6 border-b border-border">

--- a/src/components/portfolio/TalksSection.tsx
+++ b/src/components/portfolio/TalksSection.tsx
@@ -1,0 +1,75 @@
+import { Mic } from "lucide-react";
+import {
+  formatTalkTimestamp,
+  sortTalksByDateDesc,
+  talks,
+} from "@/data/talks";
+
+export default function TalksSection() {
+  const ordered = sortTalksByDateDesc(talks);
+
+  return (
+    <section className="mb-16" aria-labelledby="talks-heading">
+      <span className="font-mono text-sm text-primary uppercase tracking-widest">
+        Speaking
+      </span>
+      <h3
+        id="talks-heading"
+        className="text-2xl md:text-3xl font-black text-foreground mt-2 mb-3"
+      >
+        Talks
+      </h3>
+      <p className="text-muted-foreground mb-8 max-w-2xl">
+        Timestamped talks, newest first. Dates stay attached to each title so
+        recruiters and crawlers can see when something was actually given.
+      </p>
+
+      {ordered.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border p-8 text-center">
+          <div className="inline-flex p-3 bg-muted rounded-full mb-4">
+            <Mic className="w-6 h-6 text-muted-foreground" aria-hidden />
+          </div>
+          <p className="text-foreground font-semibold mb-2">No talks posted yet</p>
+          <p className="text-sm text-muted-foreground max-w-md mx-auto">
+            This section is wired to a typed talks list. Titles, venues, and
+            ISO dates still need to be added — nothing here is invented.
+          </p>
+        </div>
+      ) : (
+        <ol className="space-y-4">
+          {ordered.map((talk) => (
+            <li
+              key={talk.id}
+              className="rounded-xl border border-border bg-card/50 p-5"
+            >
+              <time
+                className="font-mono text-xs text-primary uppercase tracking-widest"
+                dateTime={talk.occurredAt}
+              >
+                {formatTalkTimestamp(talk.occurredAt)}
+              </time>
+              <h4 className="text-lg font-bold text-foreground mt-2">
+                {talk.url ? (
+                  <a
+                    href={talk.url}
+                    className="hover:text-primary transition-colors"
+                  >
+                    {talk.title}
+                  </a>
+                ) : (
+                  talk.title
+                )}
+              </h4>
+              {talk.venue && (
+                <p className="text-sm text-muted-foreground mt-1">{talk.venue}</p>
+              )}
+              {talk.summary && (
+                <p className="text-sm text-muted-foreground mt-2">{talk.summary}</p>
+              )}
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/src/components/portfolio/WorkTab.tsx
+++ b/src/components/portfolio/WorkTab.tsx
@@ -7,6 +7,8 @@ import { useSupabaseClient } from '@/lib/supabase';
 import { getCaseStudies, type CaseStudy } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
 import { Loader2 } from 'lucide-react';
+import { useReducedMotion } from '@/lib/reduced-motion';
+import type { TimelineTrackId } from '@/data/timeline-tracks';
 
 // Fallback case studies if database is empty
 const defaultCaseStudies = [
@@ -33,12 +35,19 @@ interface CaseStudyItem {
 
 interface WorkTabProps {
   onRequestFocusUp: () => void;
+  activeTrack?: TimelineTrackId;
+  onTrackChange?: (track: TimelineTrackId) => void;
 }
 
-export default function WorkTab({ onRequestFocusUp }: WorkTabProps) {
+export default function WorkTab({
+  onRequestFocusUp,
+  activeTrack,
+  onTrackChange,
+}: WorkTabProps) {
   const workHistoryRef = useRef<HTMLDivElement>(null);
   const { focusLevel, setFocusLevel } = useKeyboardFocus();
   const supabase = useSupabaseClient();
+  const prefersReducedMotion = useReducedMotion();
   const [caseStudies, setCaseStudies] = useState<CaseStudyItem[]>(defaultCaseStudies);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -107,25 +116,31 @@ export default function WorkTab({ onRequestFocusUp }: WorkTabProps) {
   return (
     <motion.div
       key="work"
-      initial={{ opacity: 0, x: -50 }}
+      initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, x: -24 }}
       animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: 50 }}
-      transition={{ duration: 0.3, ease: 'easeInOut' }}
+      exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, x: 24 }}
+      transition={{ duration: prefersReducedMotion ? 0 : 0.3, ease: 'easeInOut' }}
     >
-      {/* Provisioning Success Roadmaps Header */}
       <div className="mb-12">
         <span className="font-mono text-sm text-primary uppercase tracking-widest">
           Success Roadmaps
         </span>
         <h2 className="text-3xl md:text-4xl font-black text-foreground mt-2 mb-4">
-          Provisioning: Automation & Logistics Transformation
+          AI products and endpoint logistics
         </h2>
+        <p className="text-muted-foreground max-w-3xl">
+          Two tracks on one roadmap. AI Products is the latest portfolio item —
+          governed MSP apps John owns or leads. Endpoint Logistics keeps the
+          provisioning story from COVID backlog through Autopilot and 3PL.
+        </p>
       </div>
 
       {/* Hero Timeline */}
       <div className="scroll-mt-20">
         <ProjectTimeline
           focused={timelineFocused}
+          activeTrack={activeTrack}
+          onTrackChange={onTrackChange}
           onRequestFocusUp={timelineRequestFocusUp}
           onRequestFocusDown={focusWorkHistory}
         />

--- a/src/data/ai-products.ts
+++ b/src/data/ai-products.ts
@@ -1,0 +1,446 @@
+import type { TimelineItem } from "./timeline-tracks";
+
+export type LoopStage = "sense" | "decide" | "govern" | "build" | "operate";
+
+export const LOOP_STAGE_LABELS: Record<LoopStage, string> = {
+  sense: "Sense",
+  decide: "Decide",
+  govern: "Govern",
+  build: "Build+prove",
+  operate: "Operate+learn",
+};
+
+export interface ReadinessLedger {
+  lifecycle: string;
+  adoption: string;
+  production: string;
+  ownership: string;
+  risk: string;
+}
+
+export interface ProductBrief {
+  id: string;
+  name: string;
+  owner: string;
+  tagline: string;
+  chips: string[];
+  loopStages: LoopStage[];
+  capabilities: string[];
+  primaryCapability: string;
+  stack: string[];
+  flow: string[];
+  engineeringNotes?: string;
+  securityNotes?: string;
+  readiness: ReadinessLedger;
+  proven: string[];
+  preGa: string[];
+  target: string[];
+}
+
+export interface PortfolioThesis {
+  title: string;
+  lead: string;
+  tags: string[];
+  loop: { stage: LoopStage; detail: string }[];
+  cohesive: string;
+  honestClaim: string;
+  layers: { name: string; detail: string }[];
+  guardrails: string[];
+  agentAuthority: string;
+  currentTruth: string;
+  operatingEvidence: ReadinessLedger;
+  namedSeams: string[];
+}
+
+export const portfolioThesis: PortfolioThesis = {
+  title: "A developing operating system for MSP work",
+  lead: "centrexIT’s portfolio is a developing operating system for how an MSP senses demand, chooses investments, governs AI, builds safely, completes work, and learns. Products are substantial today; common contracts, package adoption, and several cross-product governance seams remain pre-GA or target state.",
+  tags: [
+    "14 normalized briefs",
+    "Evidence-preserving workflows",
+    "Human production authority",
+    "Shared governance model",
+  ],
+  loop: [
+    {
+      stage: "sense",
+      detail:
+        "Spark captures employee/meeting signals; Spot finds client opportunity; Service Desk and AI Triage capture ticket evidence; Client Toolbox assembles client posture; Iris captures employee intent and feedback.",
+    },
+    {
+      stage: "decide",
+      detail:
+        "Client Toolbox → client strategy; Navigate governs company strategy/KPIs; Vantage scores demand, governs PRDs and ROI, assigns ownership, measures realized value.",
+    },
+    {
+      stage: "govern",
+      detail:
+        "accessAI is the shared control-plane for identity, models, agents, tools, policy, runs, cost, audit, evaluation, promotion, rollback.",
+    },
+    {
+      stage: "build",
+      detail:
+        "Proxima governs delivery automation; Cadre supplies durable threads, paired execution hosts, workspace tools, evaluations, engineering evidence.",
+    },
+    {
+      stage: "operate",
+      detail:
+        "Service Desk Toolbox completes technician work; AI Triage improves routing; Knowledge governs documentation; Iris orchestrates context, durable work, specialists, approval-gated action.",
+    },
+  ],
+  cohesive:
+    "One governed operating loop from human signal to proven value. The defensible asset is not a chatbot. It is domain-specific apps + evidence-preserving decision flows + governed AI + agentic delivery inside deterministic controls + shared human-control design language.",
+  honestClaim:
+    "Coherent portfolio with strong product depth and a credible control-plane architecture — not yet one uniformly integrated or enforced platform.",
+  layers: [
+    { name: "Signal", detail: "Spark + operational evidence" },
+    { name: "Decision", detail: "Client Toolbox + Vantage" },
+    { name: "Control", detail: "accessAI" },
+    { name: "Delivery", detail: "Proxima + development standard" },
+    { name: "Work", detail: "Service Desk + Iris" },
+  ],
+  guardrails: [
+    "Tenant safety",
+    "Bounded agents",
+    "Deterministic evidence",
+    "Human control",
+  ],
+  agentAuthority:
+    "Agents may advise, draft, test, and reconcile. Humans retain merge, deploy, external-send, destructive-action, billing, and autonomy-promotion.",
+  currentTruth:
+    "Strong products; uneven shared enforcement. accessAI is substantial but pre-GA as a universal control plane.",
+  operatingEvidence: {
+    lifecycle: "Portfolio convergence",
+    adoption: "Product-level evidence, one baseline pending",
+    production: "Mixed live / pre-GA / target",
+    ownership: "Leadership + named product owners",
+    risk: "Uneven shared-contract enforcement",
+  },
+  namedSeams: [
+    "Cadre",
+    "Spark",
+    "Spot",
+    "Navigate",
+    "Vantage",
+    "Knowledge",
+    "AI Triage",
+  ],
+};
+
+export const productBriefs: ProductBrief[] = [
+  {
+    id: "client-toolbox",
+    name: "Client Toolbox",
+    owner: "John",
+    tagline:
+      "Evidence-backed vITM workspace converting identity, endpoint, security, network, licensing, and service data into a scoped client portfolio, explainable health, prioritized opportunities, and QBR-ready decisions.",
+    chips: [
+      "Assigned client book",
+      "Explainable controls",
+      "QBR lifecycle",
+      "Evidence provenance",
+    ],
+    loopStages: ["sense", "decide", "operate"],
+    capabilities: [
+      "Assigned client book",
+      "Client 360",
+      "Transparent standards (every score → control, observation, source, evidence age, coverage, confidence)",
+      "Risk / opportunity",
+      "QBR lifecycle",
+      "Governed AI teammate “Buddy” (source systems remain authoritative)",
+    ],
+    primaryCapability:
+      "One evidence spine from source system to QBR. Honest gaps reduce confidence instead of reading clean.",
+    stack: [
+      "React",
+      "TypeScript",
+      "Vite",
+      "Azure SWA",
+      "Entra ID",
+      "Supabase",
+      "PostgreSQL RLS",
+      "Rewst collectors",
+      "Azure AI Foundry",
+      "Teams",
+    ],
+    flow: [
+      "Collect",
+      "Reconcile identities",
+      "Score",
+      "Review",
+      "Communicate QBR",
+    ],
+    engineeringNotes:
+      "One issue per PR; locked builds, migration replay, typecheck, lint, tests, SWA smoke, security contracts, screenshots, perf budgets.",
+    securityNotes:
+      "Entra roles, signed principals, RLS, service-only mutations, scoped machine creds, audit.",
+    readiness: {
+      lifecycle: "Toolbox Next staging",
+      adoption: "Assigned-client workflow, baseline pending",
+      production: "Live collection and QBR workspace",
+      ownership: "John",
+      risk: "Portfolio-wide outcome linkage incomplete",
+    },
+    proven: [
+      "Collection",
+      "Provenance",
+      "Controls",
+      "Workspaces",
+      "QBR",
+    ],
+    preGa: [],
+    target: ["Universal outcome linkage to Vantage"],
+  },
+  {
+    id: "service-desk-toolbox",
+    name: "Service Desk Toolbox + Incident Buddy",
+    owner: "Toby",
+    tagline:
+      "Technician app that routes Halo tickets to governed automations and uses Incident Buddy for 10-domain investigations, then writes results back.",
+    chips: [
+      "20+ automation forms",
+      "Rewst-hosted shell",
+      "Halo-connected work",
+      "10-domain investigation",
+    ],
+    loopStages: ["sense", "operate"],
+    capabilities: [
+      "Application shell",
+      "20+ guided forms via Rewst (identity, Exchange, provisioning, security, service)",
+      "Halo ticket linking",
+      "Incident Buddy across identity, access, mail, endpoint, security, network, automation, ticket, client, infrastructure",
+      "Automation program metrics",
+      "Teams bot is intentionally narrow (chat + EOD numbers)",
+    ],
+    primaryCapability:
+      "Raise ticket quality with cross-system context. Human reviews findings before Halo writeback.",
+    stack: [
+      "Custom Toolbox shell",
+      "Rewst host / auth / forms",
+      "Halo SOR",
+      "Azure AI Foundry",
+      "Teams",
+    ],
+    flow: [
+      "Intake Halo",
+      "Route",
+      "Investigate 10 domains",
+      "Human review",
+      "Record + measure",
+    ],
+    readiness: {
+      lifecycle: "Operational product",
+      adoption: "20+ forms in use",
+      production: "Live technician app",
+      ownership: "Toby",
+      risk: "Portfolio outcome backbone still target",
+    },
+    proven: ["Shell", "Catalog", "Ticket linking", "Incident Buddy"],
+    preGa: [],
+    target: ["Portfolio outcome backbone"],
+  },
+  {
+    id: "iris",
+    name: "Iris",
+    owner: "John",
+    tagline:
+      "One assistant that understands company, client, ticket, meeting, and operational context, then researches, creates, remembers, schedules, investigates, and takes approved action from Teams or Iris OS.",
+    chips: [
+      "Teams + Iris OS",
+      "Company-grounded answers",
+      "Durable skills",
+      "Approved action",
+    ],
+    loopStages: ["sense", "operate"],
+    capabilities: [
+      "Teams + Iris OS (chat, role-composed home, apps, pins, files, skills, voice, search, PWA)",
+      "Grounds in handbook, people, approved Teams channels, MeetingOS, live Halo, ticket history, client records",
+      "Research / create with citations, OCR, signed expiring artifacts",
+      "Reminders, memory, skills, chains",
+      "Specialists (Incident Buddy, vITM tools)",
+      "Governed action via brokers (mail, calendar, MeetingOS, Halo, Rewst) with payload-bound approval and audit",
+    ],
+    primaryCapability:
+      "Personal AI with company context and permission to act.",
+    stack: [
+      "Bot Framework",
+      "Adaptive Cards",
+      "React",
+      "TypeScript",
+      "Vite",
+      "Cuelume",
+      "PWA SWA",
+      "iris-sdk",
+      "Azure Functions Node 22 v4",
+      "Durable Functions",
+      "Azure AI Foundry",
+      "Azure Tables",
+      "Blob",
+      "AI Search",
+      "Rewst",
+      "Halo",
+      "Graph",
+      "accessAI",
+    ],
+    flow: [
+      "Ask",
+      "Resolve identity / scope",
+      "Ground",
+      "Execute",
+      "Govern + learn",
+    ],
+    readiness: {
+      lifecycle: "Integrated product, federation pre-GA",
+      adoption: "Teams + Iris OS in use",
+      production: "Live assistant; accessAI federation pre-GA",
+      ownership: "John",
+      risk: "accessAI federation",
+    },
+    proven: ["Manager", "Teams", "Iris OS"],
+    preGa: ["accessAI federation"],
+    target: ["Full agent-OS citizenship"],
+  },
+  {
+    id: "proxima",
+    name: "Proxima",
+    owner: "Shared platform",
+    tagline:
+      "Turns approved Vantage work and GitHub evidence into reviewed branches, draft PRs, green CI, traceable delivery records, and concise human decisions.",
+    chips: [
+      "Vantage-governed intent",
+      "GitHub-native delivery",
+      "CI-bound completion",
+      "Draft-mode autonomy",
+    ],
+    loopStages: ["build"],
+    capabilities: [
+      "Steward approved Vantage work",
+      "Review PR estate (small unambiguous fixes only)",
+      "Build drafts in a fresh clone bound to true head SHA",
+      "Repair against real CI (up to two passes; model never self-declares success)",
+      "Reconcile to Vantage / Halo via signed Rewst bridge",
+      "Teams surfaces decisions, not noise",
+    ],
+    primaryCapability:
+      "Agentic delivery inside a deterministic shell. Humans retain merge, deploy, risky, and cost-incurring action.",
+    stack: [
+      "Forge monorepo",
+      "pnpm",
+      "Turbo",
+      "Node",
+      "Python",
+      "Docker",
+      "GitHub App / CLI",
+      "Azure CLI",
+      "Supabase CLI",
+    ],
+    flow: [
+      "Intake",
+      "Claim",
+      "Implement",
+      "Verify exact SHA",
+      "Repair + reconcile",
+    ],
+    engineeringNotes:
+      "CI is automatic; production is governed. Draft-mode autonomy — the model never self-declares success.",
+    readiness: {
+      lifecycle: "Draft-mode, autonomy pre-GA",
+      adoption: "Delivery loop in use for approved work",
+      production: "Draft delivery live; autonomy maturity pre-GA",
+      ownership: "Shared platform",
+      risk: "Autonomy promotion still human-gated",
+    },
+    proven: ["Draft delivery loop"],
+    preGa: ["Autonomy maturity"],
+    target: ["Portfolio conformance operator"],
+  },
+  {
+    id: "accessai",
+    name: "accessAI",
+    owner: "R&D",
+    tagline:
+      "Defines which identities, models, agents, tools, policies, compute destinations, and deployment bindings may operate; records execution, cost, audit, evaluation, promotion, rollback.",
+    chips: [
+      "Multi-model governance",
+      "Tenant-safe execution",
+      "Agent delivery control",
+      "Cost + audit + evaluation",
+    ],
+    loopStages: ["govern"],
+    capabilities: [
+      "Multi-provider (Azure OpenAI, Anthropic, OpenAI, Foundry)",
+      "Entra / MSAL JWT, API keys, tenant resolution, API RBAC, Postgres RLS",
+      "Recipes / harnesses / destinations",
+      "Builtin and Foundry execution with memory, tools, MCP, policy, approvals, kill switches",
+      "Append-only audit, evals, promotion, cost, telemetry, rollback",
+      "Central Exchange + Agent Factory",
+    ],
+    primaryCapability:
+      "Control plane defines what/why; providers execute how. Shared infrastructure IP — not an end-user assistant or foundation model. Not sellable-GA yet (no releases/tags, 0.0.0 packages, incomplete golden path, no live second-tenant acceptance).",
+    stack: [
+      "Node 22",
+      "TypeScript",
+      "Hono",
+      "React 19",
+      "Vite 8",
+      "Tailwind 4",
+      "PostgreSQL 16 + pgvector",
+      "Forced RLS",
+      "Azure Container Apps",
+      "SWA",
+      "Key Vault",
+      "Vitest",
+      "Playwright",
+      "CodeQL",
+      "ZAP",
+      "Trivy",
+    ],
+    flow: [
+      "Discover",
+      "Bind",
+      "Authorize fail-closed",
+      "Execute",
+      "Promote or roll back",
+    ],
+    engineeringNotes:
+      "Progressive deploy 5% → 25% → manually approved 100%.",
+    securityNotes:
+      "Forced RLS, fail-closed authorization, append-only audit, kill switches, tenant-safe execution.",
+    readiness: {
+      lifecycle: "Substantial control plane, pre-GA",
+      adoption: "Not sellable-GA; no live second-tenant acceptance",
+      production: "Broad implementation; universal use pre-GA",
+      ownership: "R&D",
+      risk: "Portfolio-wide enforcement is target state",
+    },
+    proven: ["Broad control-plane implementation"],
+    preGa: ["Sellability / universal use"],
+    target: ["Portfolio-wide enforcement"],
+  },
+];
+
+export function getProductBrief(id: string): ProductBrief | undefined {
+  return productBriefs.find((brief) => brief.id === id);
+}
+
+export function orderProductBriefs(entries?: TimelineItem[]): ProductBrief[] {
+  if (!entries?.length) return productBriefs;
+  const keys = entries
+    .map((entry) => entry.entry_key)
+    .filter((key): key is string => Boolean(key));
+  if (!keys.length) return productBriefs;
+
+  const byId = new Map(productBriefs.map((brief) => [brief.id, brief]));
+  const ordered: ProductBrief[] = [];
+  for (const key of keys) {
+    const match = byId.get(key);
+    if (match) {
+      ordered.push(match);
+      byId.delete(key);
+    }
+  }
+  for (const remaining of byId.values()) {
+    ordered.push(remaining);
+  }
+  return ordered;
+}

--- a/src/data/talks.ts
+++ b/src/data/talks.ts
@@ -1,0 +1,37 @@
+/**
+ * Public talks for the Content tab.
+ *
+ * Titles and dates are not invented. When John posts a talk, add it here
+ * (or later via CMS) with an ISO `occurredAt` timestamp.
+ */
+export interface Talk {
+  id: string;
+  title: string;
+  occurredAt: string;
+  venue?: string;
+  url?: string;
+  summary?: string;
+}
+
+export const talks: Talk[] = [];
+
+export function sortTalksByDateDesc(items: Talk[]): Talk[] {
+  return [...items].sort((a, b) => {
+    const aTime = Date.parse(a.occurredAt);
+    const bTime = Date.parse(b.occurredAt);
+    const aValid = Number.isFinite(aTime) ? aTime : 0;
+    const bValid = Number.isFinite(bTime) ? bTime : 0;
+    return bValid - aValid;
+  });
+}
+
+export function formatTalkTimestamp(isoDate: string): string {
+  const parsed = Date.parse(isoDate);
+  if (!Number.isFinite(parsed)) return isoDate;
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(parsed);
+}

--- a/src/data/timeline-tracks.ts
+++ b/src/data/timeline-tracks.ts
@@ -1,0 +1,180 @@
+/**
+ * Success Roadmap tracks for the Work tab timeline.
+ * AI Products is first and selected by default. Endpoint Logistics
+ * preserves the existing provisioning / Immy.Bot / Autopilot story.
+ */
+
+export const TIMELINE_TRACKS = [
+  {
+    id: "ai-products",
+    label: "AI Products",
+    heading: "Governed MSP operating loop",
+    summary:
+      "centrexIT products John owns or leads: evidence-preserving workflows, a shared control plane, and human production authority.",
+  },
+  {
+    id: "endpoint-logistics",
+    label: "Endpoint Logistics",
+    heading: "Provisioning: Automation & Logistics Transformation",
+    summary:
+      "COVID backlog through Immy.Bot, one-touch provisioning, and Autopilot / 3PL.",
+  },
+] as const;
+
+export type TimelineTrackId = (typeof TIMELINE_TRACKS)[number]["id"];
+
+export const DEFAULT_TIMELINE_TRACK: TimelineTrackId = "ai-products";
+export const DEFAULT_TIMELINE_SLUG = "provisioning-roadmap";
+
+export function isTimelineTrackId(value: string | null | undefined): value is TimelineTrackId {
+  return TIMELINE_TRACKS.some((track) => track.id === value);
+}
+
+export function resolveTimelineTrack(
+  value: string | null | undefined,
+): TimelineTrackId {
+  return isTimelineTrackId(value) ? value : DEFAULT_TIMELINE_TRACK;
+}
+
+export interface TimelineItem {
+  id: string;
+  label: string;
+  phase: string;
+  summary: string | null;
+  content: string | null;
+  dot_position: number;
+  track: TimelineTrackId;
+  entry_key: string | null;
+}
+
+/** Live Endpoint Logistics copy (Supabase fallback when the DB is empty). */
+export const defaultLogisticsEntries: TimelineItem[] = [
+  {
+    id: "2022-2023",
+    label: "2022-2023",
+    phase: "Recovery & Foundation",
+    summary:
+      "Cleared COVID backlog, created inventory sheets, standardized SOPs & SLAs",
+    content: `Starting at centrexIT in 2022, I inherited a provisioning backlog of over 72 tickets accumulated during the COVID-19 pandemic. It had blown our teams, office, and operational standards apart. Within 6 months, I systematically cleared this backlog by implementing standardized workflows and creating comprehensive inventory tracking sheets. I partnered with the Director of Operations to reintroduce media sanitization protocols that had lapsed and established the SOPs and SLAs that would become the foundation for all future automation work. This phase was about building trust, understanding the systems, and laying the groundwork for what was to come.`,
+    dot_position: 15,
+    track: "endpoint-logistics",
+    entry_key: "2022-2023",
+  },
+  {
+    id: "2024",
+    label: "2024",
+    phase: "Automation & Knowledge",
+    summary: "Completed Immy.Bot buildout, standardized Provisioning KB",
+    content: `2024 marked the shift from manual processes to intelligent automation. I completed the full Immy.Bot buildout, enabling automated software deployments and configurations across our entire client base. The Provisioning Knowledge Base was standardized and made accessible, transforming tribal knowledge into documented, searchable resources. This year laid the technical foundation that would enable the dramatic improvements seen in 2025.`,
+    dot_position: 24,
+    track: "endpoint-logistics",
+    entry_key: "2024",
+  },
+  {
+    id: "2025",
+    label: "2025",
+    phase: "Optimization & Growth",
+    summary:
+      "One-touch provisions for 75%+ clients, <2 day turnaround, record-breaking October, systems automation & observability",
+    content: `2025 was the year it all clicked. We delivered in-house, one-touch provisioning for 75%+ of our clients and cut turnaround to under two business days—down from weeks in prior years. October 2025 was our biggest provisioning month ever.
+
+We also launched a new Inventory system with a much better UX and started stacking automations on top of Immy.Bot—tying inventory, ticketing, and provisioning into a single, measurable workflow form in Rewst for our Provisioning Engineer. I handed off day-to-day provisioning to a new hire, built the Provisioning ToolBox (15 KB pieces), and closed out the year with fully automated provisioning plus inventory intake.`,
+    dot_position: 50,
+    track: "endpoint-logistics",
+    entry_key: "2025",
+  },
+  {
+    id: "2026+",
+    label: "2026+",
+    phase: "Future State",
+    summary:
+      "Autopilot/White glove for all clients, 3PL integration, office-free logistics",
+    content: `Looking ahead, the vision is complete automation independence. Every client will have Autopilot or White Glove configuration ready from day one. Third-party logistics (3PL) integration will reduce costs while maintaining our rigorous SLAs. The ultimate goal: eliminate any reliance on physical office space for inventory and logistics, enabling a fully distributed, resilient provisioning operation.`,
+    dot_position: 75,
+    track: "endpoint-logistics",
+    entry_key: "2026+",
+  },
+];
+
+/** Lightweight AI Product pills so the DB and fallback share the same track. */
+export const defaultAiProductEntries: TimelineItem[] = [
+  {
+    id: "ai-client-toolbox",
+    label: "Client Toolbox",
+    phase: "Evidence-backed vITM",
+    summary:
+      "Identity, endpoint, security, network, licensing, and service data into QBR-ready decisions.",
+    content: null,
+    dot_position: 72,
+    track: "ai-products",
+    entry_key: "client-toolbox",
+  },
+  {
+    id: "ai-service-desk-toolbox",
+    label: "Service Desk Toolbox",
+    phase: "Technician work + Incident Buddy",
+    summary:
+      "Halo tickets routed to governed automations and 10-domain investigations.",
+    content: null,
+    dot_position: 68,
+    track: "ai-products",
+    entry_key: "service-desk-toolbox",
+  },
+  {
+    id: "ai-iris",
+    label: "Iris",
+    phase: "Governed employee AI",
+    summary:
+      "Company-grounded assistant with durable skills and approval-gated action.",
+    content: null,
+    dot_position: 80,
+    track: "ai-products",
+    entry_key: "iris",
+  },
+  {
+    id: "ai-proxima",
+    label: "Proxima",
+    phase: "Governed agentic engineering",
+    summary:
+      "Approved Vantage work into reviewed branches, draft PRs, and green CI.",
+    content: null,
+    dot_position: 64,
+    track: "ai-products",
+    entry_key: "proxima",
+  },
+  {
+    id: "ai-accessai",
+    label: "accessAI",
+    phase: "AI control plane (pre-GA)",
+    summary:
+      "Identities, models, agents, tools, policy, cost, audit, evaluation, promotion, rollback.",
+    content: null,
+    dot_position: 58,
+    track: "ai-products",
+    entry_key: "accessai",
+  },
+];
+
+export const defaultTimelineData: TimelineItem[] = [
+  ...defaultAiProductEntries,
+  ...defaultLogisticsEntries,
+];
+
+export function normalizeTimelineTrack(
+  track: string | null | undefined,
+): TimelineTrackId {
+  return track === "ai-products" ? "ai-products" : "endpoint-logistics";
+}
+
+export function entriesForTrack(
+  entries: TimelineItem[],
+  track: TimelineTrackId,
+): TimelineItem[] {
+  return entries.filter((entry) => entry.track === track);
+}
+
+export function productOrderKeys(entries: TimelineItem[]): string[] {
+  return entries
+    .filter((entry) => entry.track === "ai-products" && entry.entry_key)
+    .map((entry) => entry.entry_key as string);
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -231,6 +231,8 @@ export const TimelineEntrySchema = z.object({
   content: z.string().nullable(),
   dot_position: z.number(),
   order_index: z.number(),
+  track: z.string().nullable().optional(),
+  entry_key: z.string().nullable().optional(),
   created_at: z.string(),
   updated_at: z.string(),
 });

--- a/src/lib/seo.tsx
+++ b/src/lib/seo.tsx
@@ -28,7 +28,7 @@ const DEFAULT_SEO: SEOSettings = {
   siteUrl: import.meta.env.VITE_SITE_URL || "https://mejohnc.org",
   defaultDescription:
     import.meta.env.VITE_SITE_DESCRIPTION ||
-    "Your website and business tools in one platform.",
+    "Jonathan Christensen is an AI Automation Engineer in San Diego building governed agents, MSP automation, and evidence-preserving IT workflows for lab and production environments.",
   ogImage: "/og-image.png",
   twitterHandle: import.meta.env.VITE_TWITTER_HANDLE || "",
   linkedinUrl: import.meta.env.VITE_LINKEDIN_URL || "",
@@ -113,6 +113,7 @@ interface SEOProps {
   publishedTime?: string;
   modifiedTime?: string;
   author?: string;
+  keywords?: string;
   noIndex?: boolean;
 }
 
@@ -125,6 +126,7 @@ export function useSEO({
   publishedTime,
   modifiedTime,
   author,
+  keywords,
   noIndex = false,
 }: SEOProps = {}) {
   const settings = useSEOSettings();
@@ -169,8 +171,14 @@ export function useSEO({
 
     // Basic meta tags
     setMeta("name", "description", fullDescription);
+    setMeta("name", "author", authorName);
+    if (keywords) {
+      setMeta("name", "keywords", keywords);
+    }
     if (noIndex) {
       setMeta("name", "robots", "noindex, nofollow");
+    } else {
+      setMeta("name", "robots", "index, follow, max-image-preview:large");
     }
 
     // Open Graph tags
@@ -232,19 +240,36 @@ export function useSEO({
     modifiedTime,
     author,
     noIndex,
+    keywords,
     settings,
   ]);
 }
 
 // JSON-LD structured data types
+export const PERSON_KNOWS_ABOUT = [
+  "AI automation",
+  "Governed agents",
+  "MSP operations",
+  "Endpoint logistics",
+  "Microsoft 365",
+  "Azure",
+  "IT laboratory systems",
+] as const;
+
+export const RECRUITING_KEYWORDS =
+  "AI automation engineer, governed agents, MSP, lab IT, Microsoft 365, Azure, endpoint provisioning, centrexIT";
+
 interface PersonSchema {
   type: "Person";
   name: string;
   jobTitle?: string;
+  description?: string;
   url?: string;
   image?: string;
   sameAs?: string[];
   email?: string;
+  knowsAbout?: string[];
+  worksFor?: string;
   address?: {
     locality: string;
     region: string;
@@ -275,11 +300,124 @@ interface BreadcrumbSchema {
   items: { name: string; url: string }[];
 }
 
+interface CreativeWorkSchema {
+  type: "CreativeWork";
+  name: string;
+  description?: string;
+  url?: string;
+  creator?: string;
+  keywords?: string[];
+}
+
+interface OccupationSchema {
+  type: "Occupation";
+  name: string;
+  description?: string;
+  occupationalCategory?: string;
+}
+
+interface FAQSchema {
+  type: "FAQPage";
+  questions: { question: string; answer: string }[];
+}
+
 type SchemaData =
   | PersonSchema
   | ArticleSchema
   | WebsiteSchema
-  | BreadcrumbSchema;
+  | BreadcrumbSchema
+  | CreativeWorkSchema
+  | OccupationSchema
+  | FAQSchema;
+
+export function buildPersonJsonLd(
+  person: PersonSchema,
+  baseUrl: string,
+): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: person.name,
+    jobTitle: person.jobTitle,
+    description: person.description,
+    url: person.url || baseUrl,
+    image: person.image,
+    sameAs: person.sameAs,
+    email: person.email,
+    knowsAbout: person.knowsAbout,
+    worksFor: person.worksFor
+      ? { "@type": "Organization", name: person.worksFor }
+      : undefined,
+    address: person.address
+      ? {
+          "@type": "PostalAddress",
+          addressLocality: person.address.locality,
+          addressRegion: person.address.region,
+          addressCountry: person.address.country,
+        }
+      : undefined,
+  };
+}
+
+export function buildWebsiteJsonLd(site: WebsiteSchema): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: site.name,
+    url: site.url,
+    description: site.description,
+    inLanguage: "en-US",
+  };
+}
+
+export function buildCreativeWorkJsonLd(
+  work: CreativeWorkSchema,
+  baseUrl: string,
+): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CreativeWork",
+    name: work.name,
+    description: work.description,
+    url: work.url
+      ? work.url.startsWith("http")
+        ? work.url
+        : `${baseUrl}${work.url}`
+      : baseUrl,
+    creator: {
+      "@type": "Person",
+      name: work.creator || "Jonathan Christensen",
+    },
+    keywords: work.keywords,
+  };
+}
+
+export function buildOccupationJsonLd(
+  occupation: OccupationSchema,
+): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Occupation",
+    name: occupation.name,
+    description: occupation.description,
+    occupationalCategory: occupation.occupationalCategory,
+  };
+}
+
+export function buildFaqJsonLd(faq: FAQSchema): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq.questions.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  };
+}
 
 export function useJsonLd(schema: SchemaData | SchemaData[]) {
   const settings = useSEOSettings();
@@ -289,7 +427,6 @@ export function useJsonLd(schema: SchemaData | SchemaData[]) {
     const schemas = Array.isArray(schema) ? schema : [schema];
     const scriptId = "json-ld-schema";
 
-    // Remove existing script
     const existing = document.getElementById(scriptId);
     if (existing) {
       existing.remove();
@@ -298,24 +435,7 @@ export function useJsonLd(schema: SchemaData | SchemaData[]) {
     const jsonLdData = schemas.map((s) => {
       switch (s.type) {
         case "Person":
-          return {
-            "@context": "https://schema.org",
-            "@type": "Person",
-            name: s.name,
-            jobTitle: s.jobTitle,
-            url: s.url || BASE_URL,
-            image: s.image,
-            sameAs: s.sameAs,
-            email: s.email,
-            address: s.address
-              ? {
-                  "@type": "PostalAddress",
-                  addressLocality: s.address.locality,
-                  addressRegion: s.address.region,
-                  addressCountry: s.address.country,
-                }
-              : undefined,
-          };
+          return buildPersonJsonLd(s, BASE_URL);
 
         case "Article":
           return {
@@ -341,13 +461,7 @@ export function useJsonLd(schema: SchemaData | SchemaData[]) {
           };
 
         case "Website":
-          return {
-            "@context": "https://schema.org",
-            "@type": "WebSite",
-            name: s.name,
-            url: s.url,
-            description: s.description,
-          };
+          return buildWebsiteJsonLd(s);
 
         case "BreadcrumbList":
           return {
@@ -362,10 +476,18 @@ export function useJsonLd(schema: SchemaData | SchemaData[]) {
                 : `${BASE_URL}${item.url}`,
             })),
           };
+
+        case "CreativeWork":
+          return buildCreativeWorkJsonLd(s, BASE_URL);
+
+        case "Occupation":
+          return buildOccupationJsonLd(s);
+
+        case "FAQPage":
+          return buildFaqJsonLd(s);
       }
     });
 
-    // Create and insert script
     const script = document.createElement("script");
     script.id = scriptId;
     script.type = "application/ld+json";
@@ -380,12 +502,10 @@ export function useJsonLd(schema: SchemaData | SchemaData[]) {
         toRemove.remove();
       }
     };
-    // BASE_URL is derived from settings, which is in deps
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [schema, settings]);
 }
 
-// Hook to get dynamic person schema from settings
 export function usePersonSchema(): PersonSchema {
   const settings = useSEOSettings();
 
@@ -402,20 +522,22 @@ export function usePersonSchema(): PersonSchema {
     type: "Person",
     name: settings.siteName,
     jobTitle: "AI Automation Engineer",
+    description: settings.defaultDescription,
     url: settings.siteUrl,
     image: settings.ogImage.startsWith("http")
       ? settings.ogImage
       : `${settings.siteUrl}${settings.ogImage}`,
     sameAs,
+    knowsAbout: [...PERSON_KNOWS_ABOUT],
+    worksFor: "centrexIT",
     address: {
-      locality: settings.location.city,
-      region: settings.location.state,
-      country: settings.location.country,
+      locality: settings.location.city || "San Diego",
+      region: settings.location.state || "CA",
+      country: settings.location.country || "US",
     },
   };
 }
 
-// Hook to get dynamic website schema from settings
 export function useWebsiteSchema(): WebsiteSchema {
   const settings = useSEOSettings();
 
@@ -427,18 +549,23 @@ export function useWebsiteSchema(): WebsiteSchema {
   };
 }
 
-// Legacy exports for backwards compatibility (static versions)
+const PERSON_DESCRIPTION =
+  "AI Automation Engineer building governed agents, evidence-preserving MSP workflows, and endpoint logistics systems. Background in Azure, Intune, and Microsoft 365 at scale.";
+
 export const personSchema: PersonSchema = {
   type: "Person",
-  name: DEFAULT_SEO.siteName,
+  name: "Jonathan Christensen",
   jobTitle: "AI Automation Engineer",
+  description: PERSON_DESCRIPTION,
   url: DEFAULT_SEO.siteUrl,
   image: `${DEFAULT_SEO.siteUrl}${DEFAULT_SEO.ogImage}`,
   sameAs: [DEFAULT_SEO.linkedinUrl, DEFAULT_SEO.githubUrl].filter(Boolean),
+  knowsAbout: [...PERSON_KNOWS_ABOUT],
+  worksFor: "centrexIT",
   address: {
-    locality: DEFAULT_SEO.location.city,
-    region: DEFAULT_SEO.location.state,
-    country: DEFAULT_SEO.location.country,
+    locality: DEFAULT_SEO.location.city || "San Diego",
+    region: DEFAULT_SEO.location.state || "CA",
+    country: DEFAULT_SEO.location.country || "US",
   },
 };
 
@@ -448,3 +575,50 @@ export const websiteSchema: WebsiteSchema = {
   url: DEFAULT_SEO.siteUrl,
   description: DEFAULT_SEO.defaultDescription,
 };
+
+export const occupationSchema: OccupationSchema = {
+  type: "Occupation",
+  name: "AI Automation Engineer",
+  description:
+    "Designs governed AI products, MSP automation, and lab-ready IT systems. Agents advise and draft; humans retain merge, deploy, and production authority.",
+  occupationalCategory: "15-1252.00",
+};
+
+export const softwareSchema: CreativeWorkSchema = {
+  type: "CreativeWork",
+  name: "centrexIT AI Products",
+  description:
+    "A developing operating system for how an MSP senses demand, chooses investments, governs AI, builds safely, and completes work. Substantial products today; not yet one uniformly integrated platform. accessAI is pre-GA as a universal control plane.",
+  url: "/portfolio?track=ai-products",
+  creator: "Jonathan Christensen",
+  keywords: [
+    "Client Toolbox",
+    "Iris",
+    "Proxima",
+    "accessAI",
+    "Service Desk Toolbox",
+    "governed agents",
+  ],
+};
+
+export const aboutFaqSchema: FAQSchema = {
+  type: "FAQPage",
+  questions: [
+    {
+      question: "What does Jonathan Christensen work on?",
+      answer:
+        "AI automation with a focus on agentic systems, agent management planes, and production workflows that survive cost, latency, and eval scrutiny. Background in enterprise IT — Azure, Intune, and Microsoft 365 at scale — applied to governed AI products at centrexIT.",
+    },
+    {
+      question: "Are the centrexIT AI products a single integrated platform?",
+      answer:
+        "No. The portfolio is a coherent set of substantial products with a credible control-plane architecture. Common contracts, package adoption, and several cross-product governance seams remain pre-GA or target state. accessAI is substantial but pre-GA as a universal control plane.",
+    },
+    {
+      question: "Where is Jonathan based?",
+      answer:
+        "San Diego, California. Open to AI automation, governed-agent, MSP, lab, and IT roles that value evidence-preserving systems over chatbot demos.",
+    },
+  ],
+};
+

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -162,6 +162,8 @@ export const timelineEntrySchema = z.object({
   content: z.string().optional().nullable(),
   dot_position: z.number().min(0).max(100).default(50),
   order_index: z.number().int().default(0),
+  track: z.enum(['ai-products', 'endpoint-logistics']).optional(),
+  entry_key: z.string().max(80).optional().nullable(),
 });
 
 export type TimelineEntryInput = z.infer<typeof timelineEntrySchema>;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -16,7 +16,7 @@ import {
   type ContactIcon,
 } from '@/lib/supabase-queries';
 import { renderMarkdown } from '@/lib/markdown';
-import { useSEO, useJsonLd, personSchema } from '@/lib/seo';
+import { useSEO, useJsonLd, personSchema, aboutFaqSchema, RECRUITING_KEYWORDS } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
 import DOMPurify from 'dompurify';
 
@@ -68,12 +68,13 @@ const About = () => {
 
   useSEO({
     title: 'About',
-    description: 'AI Automation Engineer obsessed with making AI agents actually useful. Building agentic systems, automation pipelines, and AI-powered workflows.',
+    description: 'AI Automation Engineer in San Diego obsessed with making governed agents actually useful. Building agentic systems, MSP automation, and AI-powered workflows for lab and production IT.',
     url: '/about',
     type: 'profile',
+    keywords: RECRUITING_KEYWORDS,
   });
 
-  useJsonLd(personSchema);
+  useJsonLd([personSchema, aboutFaqSchema]);
 
   const [content, setContent] = useState<SiteContent | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,10 +4,11 @@ import { motion } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import PageTransition from '@/components/PageTransition';
-import { useSEO, useJsonLd, personSchema, websiteSchema } from '@/lib/seo';
+import { useSEO, useJsonLd, personSchema, websiteSchema, occupationSchema, RECRUITING_KEYWORDS } from '@/lib/seo';
 import { useSupabaseClient } from '@/lib/supabase';
 import { getSiteContent } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { useReducedMotion } from '@/lib/reduced-motion';
 
 interface HeroContent {
   name: string;
@@ -24,12 +25,16 @@ const defaultHero: HeroContent = {
 const Home = () => {
   const supabase = useSupabaseClient();
   const [hero, setHero] = useState<HeroContent>(defaultHero);
+  const prefersReducedMotion = useReducedMotion();
 
   useSEO({
     url: '/',
+    description:
+      'Jonathan Christensen — AI Automation Engineer in San Diego. Governed agents, MSP automation, endpoint logistics, and lab-ready IT systems.',
+    keywords: RECRUITING_KEYWORDS,
   });
 
-  useJsonLd([personSchema, websiteSchema]);
+  useJsonLd([personSchema, websiteSchema, occupationSchema]);
 
   useEffect(() => {
     async function fetchHero() {
@@ -69,9 +74,9 @@ const Home = () => {
           {/* Name with staggered letter animation */}
           <div className="overflow-hidden mb-4">
             <motion.h1
-              initial={{ y: 100 }}
+              initial={prefersReducedMotion ? { y: 0 } : { y: 100 }}
               animate={{ y: 0 }}
-              transition={{ duration: 0.8, ease: [0.25, 0.46, 0.45, 0.94] }}
+              transition={{ duration: prefersReducedMotion ? 0 : 0.8, ease: [0.25, 0.46, 0.45, 0.94] }}
               className="text-6xl sm:text-7xl md:text-8xl lg:text-9xl font-black text-foreground tracking-tight leading-[0.85]"
             >
               {firstName}
@@ -79,9 +84,9 @@ const Home = () => {
           </div>
           <div className="overflow-hidden mb-8">
             <motion.h1
-              initial={{ y: 100 }}
+              initial={prefersReducedMotion ? { y: 0 } : { y: 100 }}
               animate={{ y: 0 }}
-              transition={{ duration: 0.8, delay: 0.1, ease: [0.25, 0.46, 0.45, 0.94] }}
+              transition={{ duration: prefersReducedMotion ? 0 : 0.8, delay: prefersReducedMotion ? 0 : 0.1, ease: [0.25, 0.46, 0.45, 0.94] }}
               className="text-6xl sm:text-7xl md:text-8xl lg:text-9xl font-black text-foreground tracking-tight leading-[0.85]"
             >
               {lastName}
@@ -123,8 +128,8 @@ const Home = () => {
                 View my work
                 <motion.span
                   className="inline-block ml-2"
-                  animate={{ x: [0, 4, 0] }}
-                  transition={{ duration: 1.5, repeat: Infinity }}
+                  animate={prefersReducedMotion ? undefined : { x: [0, 4, 0] }}
+                  transition={prefersReducedMotion ? undefined : { duration: 1.5, repeat: Infinity }}
                 >
                   <ArrowRight className="w-4 h-4" />
                 </motion.span>

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -6,9 +6,10 @@ import { DownArrowHint } from '@/components/ArrowHints';
 import { useAuth } from '@/lib/auth';
 import { useKeyboardFocus } from '@/lib/keyboard-focus';
 import { useSearchParams } from 'react-router-dom';
-import { useSEO, useJsonLd, personSchema } from '@/lib/seo';
+import { useSEO, useJsonLd, personSchema, websiteSchema, occupationSchema, softwareSchema, RECRUITING_KEYWORDS } from '@/lib/seo';
 import { prefetchTabData } from '@/lib/prefetch';
 import { analytics } from '@/lib/analytics';
+import { resolveTimelineTrack, type TimelineTrackId } from '@/data/timeline-tracks';
 
 // Eager load Work tab (most common landing)
 import { WorkTab } from '@/components/portfolio';
@@ -42,15 +43,56 @@ const Portfolio = () => {
   const [activeTab, setActiveTab] = useState<TabId>(
     tabFromUrl && tabs.some(t => t.id === tabFromUrl) ? tabFromUrl : 'work'
   );
+  const [activeTrack, setActiveTrack] = useState<TimelineTrackId>(() =>
+    resolveTimelineTrack(searchParams.get('track'))
+  );
   useAuth(); // Keep auth context active
 
-  useSEO({
-    title: 'Portfolio',
-    description: 'Explore my work, projects, software, and content. AI automation, Microsoft 365, Azure, and enterprise IT solutions.',
-    url: '/portfolio',
-  });
+  const seoForTab = (() => {
+    if (activeTab === 'content') {
+      return {
+        title: 'Content & Talks',
+        description:
+          'Writing, timestamped talks, and curated AI news from Jonathan Christensen — AI automation, governed agents, and MSP engineering.',
+        url: '/portfolio?tab=content',
+        keywords: RECRUITING_KEYWORDS,
+      };
+    }
+    if (activeTab === 'work' && activeTrack === 'ai-products') {
+      return {
+        title: 'AI Products',
+        description:
+          'centrexIT AI products John Christensen owns or leads: Client Toolbox, Iris, Proxima, accessAI, and Service Desk Toolbox. Governed agents, evidence-preserving workflows, and honest pre-GA claims.',
+        url: '/portfolio?track=ai-products',
+        keywords: RECRUITING_KEYWORDS,
+      };
+    }
+    if (activeTab === 'work' && activeTrack === 'endpoint-logistics') {
+      return {
+        title: 'Endpoint Logistics',
+        description:
+          'Provisioning roadmap: COVID backlog, Immy.Bot, one-touch provisioning, Autopilot and 3PL. Endpoint logistics transformation at centrexIT.',
+        url: '/portfolio?track=endpoint-logistics',
+        keywords: RECRUITING_KEYWORDS,
+      };
+    }
+    return {
+      title: 'Portfolio',
+      description:
+        'Portfolio of Jonathan Christensen, AI Automation Engineer: governed AI products, MSP endpoint logistics, Microsoft 365, Azure, and lab-ready IT systems.',
+      url: '/portfolio',
+      keywords: RECRUITING_KEYWORDS,
+    };
+  })();
 
-  useJsonLd(personSchema);
+  useSEO(seoForTab);
+
+  useJsonLd([
+    personSchema,
+    websiteSchema,
+    occupationSchema,
+    softwareSchema,
+  ]);
 
   // Global keyboard focus context
   const { focusLevel, setFocusLevel } = useKeyboardFocus();
@@ -73,17 +115,31 @@ const Portfolio = () => {
     setFocusLevel('timeline');
   }, [setFocusLevel]);
 
+  const handleTrackChange = useCallback((trackId: TimelineTrackId) => {
+    setActiveTrack(trackId);
+    if (activeTab !== 'work') return;
+    if (trackId === 'ai-products') {
+      setSearchParams({});
+    } else {
+      setSearchParams({ track: trackId });
+    }
+  }, [activeTab, setSearchParams]);
+
   // Update URL when tab changes
   const handleTabChange = useCallback((tabId: TabId) => {
     setActiveTab(tabId);
     focusTabs(); // Clicking a tab focuses the tabs
     analytics.trackTabChange(tabId);
     if (tabId === 'work') {
-      setSearchParams({});
+      if (activeTrack === 'ai-products') {
+        setSearchParams({});
+      } else {
+        setSearchParams({ track: activeTrack });
+      }
     } else {
       setSearchParams({ tab: tabId });
     }
-  }, [setSearchParams, focusTabs]);
+  }, [setSearchParams, focusTabs, activeTrack]);
 
   // Navigate to next/previous tab
   const goToNextTab = useCallback(() => {
@@ -241,7 +297,12 @@ const Portfolio = () => {
           >
             <AnimatePresence mode="wait">
               {activeTab === 'work' && (
-                <WorkTab key="work" onRequestFocusUp={focusTabs} />
+                <WorkTab
+                  key="work"
+                  onRequestFocusUp={focusTabs}
+                  activeTrack={activeTrack}
+                  onTrackChange={handleTrackChange}
+                />
               )}
               {activeTab === 'projects' && (
                 <Suspense key="projects" fallback={<TabLoader />}>

--- a/supabase/migrations/20260822000002_success_roadmap_tracks.sql
+++ b/supabase/migrations/20260822000002_success_roadmap_tracks.sql
@@ -1,0 +1,123 @@
+-- Success Roadmap tracks on the existing provisioning-roadmap timeline.
+-- Adds AI Products + Endpoint Logistics without a new public table.
+-- Existing year entries are tagged endpoint-logistics; AI product pills are seeded.
+-- RLS on timelines / timeline_entries is unchanged (public read of active timelines only).
+
+ALTER TABLE public.timeline_entries
+  ADD COLUMN IF NOT EXISTS track TEXT NOT NULL DEFAULT 'endpoint-logistics';
+
+ALTER TABLE public.timeline_entries
+  ADD COLUMN IF NOT EXISTS entry_key TEXT;
+
+ALTER TABLE public.timeline_entries
+  DROP CONSTRAINT IF EXISTS timeline_entries_track_check;
+
+ALTER TABLE public.timeline_entries
+  ADD CONSTRAINT timeline_entries_track_check
+  CHECK (track IN ('ai-products', 'endpoint-logistics'));
+
+CREATE INDEX IF NOT EXISTS idx_timeline_entries_track
+  ON public.timeline_entries (timeline_id, track, order_index);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_timeline_entries_entry_key
+  ON public.timeline_entries (timeline_id, entry_key)
+  WHERE entry_key IS NOT NULL;
+
+COMMENT ON COLUMN public.timeline_entries.track IS
+  'Success Roadmap track: ai-products (default UI) or endpoint-logistics.';
+
+COMMENT ON COLUMN public.timeline_entries.entry_key IS
+  'Stable key matching typed portfolio briefs or year labels.';
+
+UPDATE public.timelines
+SET
+  name = 'Success Roadmap',
+  description = 'Two tracks: AI Products (governed MSP portfolio) and Endpoint Logistics (provisioning transformation).'
+WHERE slug = 'provisioning-roadmap';
+
+UPDATE public.timeline_entries AS e
+SET
+  track = 'endpoint-logistics',
+  entry_key = COALESCE(e.entry_key, e.label)
+FROM public.timelines AS t
+WHERE e.timeline_id = t.id
+  AND t.slug = 'provisioning-roadmap'
+  AND e.label IN ('2022-2023', '2024', '2025', '2026+');
+
+INSERT INTO public.timeline_entries (
+  timeline_id,
+  label,
+  phase,
+  summary,
+  content,
+  dot_position,
+  order_index,
+  track,
+  entry_key
+)
+SELECT
+  t.id,
+  v.label,
+  v.phase,
+  v.summary,
+  v.content,
+  v.dot_position,
+  v.order_index,
+  'ai-products',
+  v.entry_key
+FROM public.timelines AS t
+CROSS JOIN (
+  VALUES
+    (
+      'Client Toolbox',
+      'Evidence-backed vITM',
+      'Identity, endpoint, security, network, licensing, and service data into QBR-ready decisions.',
+      'See the public AI Products brief for capabilities, stack, and readiness. Owner: John.',
+      72,
+      0,
+      'client-toolbox'
+    ),
+    (
+      'Service Desk Toolbox',
+      'Technician work + Incident Buddy',
+      'Halo tickets routed to governed automations and 10-domain investigations.',
+      'See the public AI Products brief. Owner: Toby.',
+      68,
+      1,
+      'service-desk-toolbox'
+    ),
+    (
+      'Iris',
+      'Governed employee AI',
+      'Company-grounded assistant with durable skills and approval-gated action.',
+      'See the public AI Products brief. Owner: John. accessAI federation is pre-GA.',
+      80,
+      2,
+      'iris'
+    ),
+    (
+      'Proxima',
+      'Governed agentic engineering',
+      'Approved Vantage work into reviewed branches, draft PRs, and green CI.',
+      'See the public AI Products brief. Draft-mode autonomy; humans retain merge and deploy.',
+      64,
+      3,
+      'proxima'
+    ),
+    (
+      'accessAI',
+      'AI control plane (pre-GA)',
+      'Identities, models, agents, tools, policy, cost, audit, evaluation, promotion, rollback.',
+      'See the public AI Products brief. Substantial control plane, not sellable-GA as a universal plane.',
+      58,
+      4,
+      'accessai'
+    )
+) AS v(label, phase, summary, content, dot_position, order_index, entry_key)
+WHERE t.slug = 'provisioning-roadmap'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.timeline_entries AS existing
+    WHERE existing.timeline_id = t.id
+      AND existing.entry_key = v.entry_key
+  );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Public site upgrade for John Christensen / mejohnc.org (HOME / PORTFOLIO / COLLAB). New branch from current `main`. Does not continue or mix with the audit-log RLS work from PR #445; that migration is left untouched.

The Work tab Success Roadmap now has **two tracks**:

1. **AI Products** — first, selected by default, most recent portfolio item
2. **Endpoint Logistics** — the existing provisioning story (COVID backlog → Immy.Bot → one-touch → Autopilot/3PL)

Live already reads `timelines` / `timeline_entries` for slug `provisioning-roadmap`. This PR is not fallback-only: it adds a migration that tags existing year rows as `endpoint-logistics` and seeds AI Product pills on that same timeline.

## What recruiters and AI crawlers will now see

- **Home / About / Portfolio** meta, Open Graph, Twitter, and canonical URLs aimed at AI automation, governed agents, MSP / lab / IT roles — without keyword stuffing.
- **JSON-LD**: Person (job title, `knowsAbout`, worksFor centrexIT), WebSite, Occupation, CreativeWork for the AI Products portfolio. About also includes FAQPage from real site copy (not invented Q&A).
- **AI Products page** (`/portfolio?track=ai-products`): thesis first (developing operating system, honest “not yet one uniformly integrated platform”), then five product briefs with Proven / Pre-GA / Target seams.
- **Endpoint Logistics** (`/portfolio?track=endpoint-logistics`): original year pills 2022-2023, 2024, 2025, 2026+.
- **`/llms.txt`**: concise honest summary, including that accessAI is pre-GA as a universal control plane.
- **Sitemap** includes the new track URLs and Content tab.
- **Talks** under Content with timestamps when present. **No talks exist in Ghost, `blog_posts`, or the live Content tab**, so the section is wired to `src/data/talks.ts` and currently empty. Titles and dates still need to be added — nothing was invented.

## Product briefs included

Client Toolbox (John), Service Desk Toolbox + Incident Buddy (Toby), Iris (John), Proxima (shared platform), accessAI (R&D, pre-GA). Cadre, Spark, Spot, Navigate, Vantage, Knowledge, and AI Triage are named seams in the thesis only.

## Animations / efficiency / security

- Track and product pills use existing framer-motion + theme colors; `prefers-reduced-motion` disables autoplay, slides, and looping CTA motion.
- AI Products panel is lazy-split; no new client fetches of secrets.
- No new public tables. Existing `timeline_entries` RLS unchanged (public read of active timelines only). No GRANT of audit partitions to anon. CSP in `public/_headers` is unchanged except a cache rule for `/llms.txt`.

## Tests

Vitest coverage for track pills (AI Products default, logistics years preserved), thesis + Client Toolbox render, talks date sort, and SEO JSON-LD helpers.

## Live DB steps after merge

Migrations apply on push to `main` via `.github/workflows/migrate.yml`. After merge:

1. Confirm `supabase db push` ran (`20260822000002_success_roadmap_tracks.sql`).
2. Public Work tab should show **AI Products** and **Endpoint Logistics** (not only the React fallback).
3. Optional: add talk titles + ISO dates to `src/data/talks.ts` (or later CMS) — the UI is ready.
4. No Netlify secret changes. Keep the public site public. Do not merge this PR until you have reviewed it.

## Accessibility

New track and product pills are `tablist` / `tab` with arrow-key roving tabindex and `aria-selected`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7573f7d1-c5ee-434a-8bfe-a4e0c6528ccc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7573f7d1-c5ee-434a-8bfe-a4e0c6528ccc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

