### PR TITLE
fix: stop Sentry `Error: [object Object]` and 406 on missing site_content

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -5,6 +5,7 @@ import { useKeyboardFocus } from '@/lib/keyboard-focus';
 import { useSupabaseClient } from '@/lib/supabase';
 import { getWorkHistory, type WorkHistoryEntry } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { Loader2 } from 'lucide-react';
 
 interface ExperienceProps {
@@ -105,7 +106,7 @@ const Experience = ({ focused = false }: ExperienceProps) => {
           })));
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: 'Experience.fetchWorkHistory',
         });
         setError('Unable to load work history');

--- a/src/components/ProjectTimeline.tsx
+++ b/src/components/ProjectTimeline.tsx
@@ -6,6 +6,7 @@ import { useKeyboardFocus } from '@/lib/keyboard-focus';
 import { useSupabaseClient } from '@/lib/supabase';
 import { getTimelineWithEntries, type TimelineEntry } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { useReducedMotion } from '@/lib/reduced-motion';
 import {
   DEFAULT_TIMELINE_SLUG,
@@ -239,7 +240,7 @@ const ProjectTimeline = ({
           }
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: 'ProjectTimeline.fetchTimeline',
           slug,
         });

--- a/src/components/admin/AdminSearch.tsx
+++ b/src/components/admin/AdminSearch.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Search, FileText, Package, FolderOpen, X, Command } from 'lucide-react';
 import { getBlogPosts, getApps, getProjects, type BlogPost, type App, type Project } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 interface SearchResult {
   id: string;
@@ -108,7 +109,7 @@ export default function AdminSearch() {
       setResults([...blogResults, ...appResults, ...projectResults].slice(0, 10));
       setSelectedIndex(0);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AdminSearch.performSearch' });
+      captureException(toError(err), { context: 'AdminSearch.performSearch' });
     } finally {
       setIsLoading(false);
     }

--- a/src/components/admin/AgentPlatformHealth.tsx
+++ b/src/components/admin/AgentPlatformHealth.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { getAgentPlatformStats, type AgentPlatformStats } from '@/lib/agent-platform-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 export default function AgentPlatformHealth() {
   const { supabase } = useAuthenticatedSupabase();
@@ -23,7 +24,7 @@ export default function AgentPlatformHealth() {
         const data = await getAgentPlatformStats(supabase);
         setStats(data);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: 'AgentPlatformHealth.fetchStats',
         });
       } finally {

--- a/src/components/admin/AuditLogViewer.tsx
+++ b/src/components/admin/AuditLogViewer.tsx
@@ -13,6 +13,7 @@ import {
   type AuditLog,
 } from '@/lib/audit';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { DEFAULT_AUDIT_LOG_LIMIT, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY, ANIMATION } from '@/lib/constants';
 
 interface AuditLogViewerProps {
@@ -36,7 +37,7 @@ export default function AuditLogViewer({
         const data = await getRecentAuditLogs(limit);
         setLogs(data);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: 'AuditLogViewer.fetchLogs',
         });
       } finally {

--- a/src/components/admin/ImageUploader.tsx
+++ b/src/components/admin/ImageUploader.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Upload, X, Link as LinkIcon, Loader2, Image } from "lucide-react";
 import { uploadFile } from "@/lib/supabase-queries";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { Button } from "@/components/ui/button";
 import { useTenant } from "@/lib/tenant";
 
@@ -56,7 +57,7 @@ const ImageUploader = ({
       const url = await uploadFile(file, path, undefined, tenantId);
       onChange(url);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "ImageUploader.upload",
       });
       setError("Failed to upload image");

--- a/src/components/admin/VersionHistory.tsx
+++ b/src/components/admin/VersionHistory.tsx
@@ -17,6 +17,7 @@ import {
   type ContentVersion,
 } from "@/lib/audit";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 interface VersionHistoryProps {
   tableName: string;
@@ -41,7 +42,7 @@ export default function VersionHistory({
         const data = await getContentVersions(tableName, recordId);
         setVersions(data);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "VersionHistory.fetchVersions",
         });
       } finally {
@@ -71,7 +72,7 @@ export default function VersionHistory({
       setVersions(data);
       onRestore?.();
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "VersionHistory.restore",
       });
       toast.error("Failed to restore version");

--- a/src/components/admin/metrics/GitHubMetricsCard.tsx
+++ b/src/components/admin/metrics/GitHubMetricsCard.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/lib/github-metrics';
 import { MetricsAreaChart } from '@/components/admin/charts';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 interface GitHubMetricsCardProps {
   owner: string;
@@ -48,7 +49,7 @@ export default function GitHubMetricsCard({
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to fetch GitHub metrics';
       setError(message);
-      captureException(err instanceof Error ? err : new Error(message), {
+      captureException(toError(err), {
         context: 'GitHubMetricsCard.fetchMetrics',
         extra: { owner, repo },
       });

--- a/src/components/admin/metrics/SupabaseStatsCard.tsx
+++ b/src/components/admin/metrics/SupabaseStatsCard.tsx
@@ -16,6 +16,7 @@ import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { getSupabaseTableStats, type SupabaseTableStats } from '@/lib/metrics-queries';
 import { MetricsBarChart } from '@/components/admin/charts';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 interface SupabaseStatsCardProps {
   showChart?: boolean;
@@ -43,7 +44,7 @@ export default function SupabaseStatsCard({ showChart = true }: SupabaseStatsCar
       const data = await getSupabaseTableStats(supabase);
       setStats(data);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: 'SupabaseStatsCard.fetchStats',
       });
     } finally {

--- a/src/components/desktop/OnboardingWizard.tsx
+++ b/src/components/desktop/OnboardingWizard.tsx
@@ -38,6 +38,7 @@ import { useBilling } from "@/hooks/useBilling";
 import { useTenantSupabase } from "@/lib/supabase";
 import { uploadFile } from "@/lib/supabase-queries";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { useReducedMotion } from "@/lib/reduced-motion";
 import {
   appRegistry,
@@ -133,7 +134,7 @@ export default function OnboardingWizard({
       const url = await uploadFile(file, path, supabase, tenant.id);
       setBranding((prev) => ({ ...prev, logo_url: url }));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "OnboardingWizard.logoUpload",
       });
     } finally {

--- a/src/components/desktop/Spotlight.tsx
+++ b/src/components/desktop/Spotlight.tsx
@@ -50,6 +50,7 @@ import { useTenant } from "@/lib/tenant";
 import { searchFileSystem } from "@/lib/desktop-queries";
 import { getBlogPosts, getProjects } from "@/lib/supabase-queries";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import type { FileSystemNode } from "@/lib/desktop-schemas";
 
 const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -259,7 +260,7 @@ export default function Spotlight({ isOpen, onClose }: SpotlightProps) {
         ]);
         setSelectedIndex(0);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Spotlight.search",
         });
       } finally {

--- a/src/components/marketing/AIContentSuggestions.tsx
+++ b/src/components/marketing/AIContentSuggestions.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Sparkles, Copy, Check, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { generateContentSuggestions, isAIConfigured, type ContentSuggestion } from '@/lib/ai-service';
 
 interface AIContentSuggestionsProps {
@@ -33,7 +34,7 @@ export function AIContentSuggestions({ contentType, context, onSelect }: AIConte
         setError('AI service not configured. Showing example suggestions.');
       }
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: 'AIContentSuggestions.generateSuggestions',
       });
       setError('Failed to generate suggestions. Please try again.');

--- a/src/components/portfolio/ContentTab.tsx
+++ b/src/components/portfolio/ContentTab.tsx
@@ -20,6 +20,7 @@ import {
   type NewsSource,
 } from "@/lib/supabase-queries";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { useReducedMotion } from "@/lib/reduced-motion";
 
 type ContentSource = "all" | "me" | "news";
@@ -91,7 +92,7 @@ export default function ContentTab() {
         setLocalPosts(local);
         setCuratedNews(curated);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "ContentTab.fetchPosts",
         });
       } finally {

--- a/src/components/portfolio/ProjectsTab.tsx
+++ b/src/components/portfolio/ProjectsTab.tsx
@@ -14,6 +14,7 @@ import {
   type SiteContent,
 } from "@/lib/supabase-queries";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 export default function ProjectsTab() {
   const [projects, setProjects] = useState<Project[]>([]);
@@ -32,7 +33,7 @@ export default function ProjectsTab() {
         setProjects(projectsData);
         setProjectsContent(contentData);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "ProjectsTab.fetchProjects",
         });
       } finally {

--- a/src/components/portfolio/SoftwareTab.tsx
+++ b/src/components/portfolio/SoftwareTab.tsx
@@ -10,6 +10,7 @@ import {
   type AppSuite,
 } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 export default function SoftwareTab() {
   const [apps, setApps] = useState<(App & { suite: AppSuite | null })[]>([]);
@@ -26,7 +27,7 @@ export default function SoftwareTab() {
         setApps(appsData);
         setSuites(suitesData);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), { context: 'SoftwareTab.fetchApps' });
+        captureException(toError(err), { context: 'SoftwareTab.fetchApps' });
       } finally {
         setIsLoading(false);
       }

--- a/src/components/portfolio/WorkTab.tsx
+++ b/src/components/portfolio/WorkTab.tsx
@@ -6,6 +6,7 @@ import { useKeyboardFocus } from '@/lib/keyboard-focus';
 import { useSupabaseClient } from '@/lib/supabase';
 import { getCaseStudies, type CaseStudy } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { Loader2 } from 'lucide-react';
 import { useReducedMotion } from '@/lib/reduced-motion';
 import type { TimelineTrackId } from '@/data/timeline-tracks';
@@ -68,7 +69,7 @@ export default function WorkTab({
           })));
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), { context: 'WorkTab.fetchCaseStudies' });
+        captureException(toError(err), { context: 'WorkTab.fetchCaseStudies' });
         // Keep default case studies on error
       } finally {
         setIsLoading(false);

--- a/src/features/calendar/pages/CalendarPage.tsx
+++ b/src/features/calendar/pages/CalendarPage.tsx
@@ -17,6 +17,7 @@ import {
 import type { CalendarEventSource, CalendarEventColor } from "@/lib/schemas";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import AdminLayout from "@/components/AdminLayout";
 import type { CalendarItem, CalendarView } from "../types";
 import { CalendarHeader } from "../components/CalendarHeader";
@@ -79,7 +80,7 @@ const CalendarPage = () => {
       setCalendarItems(items);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "CalendarPage.fetchData" },
       );
     } finally {
@@ -140,7 +141,7 @@ const CalendarPage = () => {
       await fetchData();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "CalendarPage.handleDeleteEvent" },
       );
     }
@@ -187,7 +188,7 @@ const CalendarPage = () => {
       await fetchData();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "CalendarPage.handleSubmitEvent" },
       );
     } finally {

--- a/src/features/crm/pages/ContactDetailPage.tsx
+++ b/src/features/crm/pages/ContactDetailPage.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { ContactDetail } from "../components/ContactDetail";
 import { InteractionLog } from "../components/InteractionLog";
 import { InteractionForm } from "../components/InteractionForm";
@@ -72,7 +73,7 @@ const ContactDetailPage = () => {
       setFollowUps(followUpsData);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "ContactDetailPage.loadContactData",
         },
@@ -104,7 +105,7 @@ const ContactDetailPage = () => {
       loadContactData();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "ContactDetailPage.createInteraction",
         },
@@ -135,7 +136,7 @@ const ContactDetailPage = () => {
       loadContactData();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "ContactDetailPage.createFollowUp",
         },
@@ -150,7 +151,7 @@ const ContactDetailPage = () => {
       loadContactData();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "ContactDetailPage.completeFollowUp",
         },

--- a/src/features/crm/pages/ContactsPage.tsx
+++ b/src/features/crm/pages/ContactsPage.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { ContactList } from "../components/ContactList";
 import { ContactForm } from "../components/ContactForm";
 import type { Contact } from "../schemas";
@@ -52,7 +53,7 @@ const ContactsPage = () => {
       setContacts(data);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "ContactsPage.loadContacts",
         },
@@ -131,7 +132,7 @@ const ContactsPage = () => {
       loadContacts();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "ContactsPage.saveContact",
         },
@@ -147,7 +148,7 @@ const ContactsPage = () => {
       loadContacts();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "ContactsPage.deleteContact",
         },

--- a/src/features/crm/pages/DealsPage.tsx
+++ b/src/features/crm/pages/DealsPage.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { DealCard } from "../components/DealCard";
 import { DealForm } from "../components/DealForm";
 import type { DealWithDetails, Deal } from "../schemas";
@@ -41,7 +42,7 @@ const DealsPage = () => {
       setDeals(data);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "DealsPage.loadDeals",
         },

--- a/src/features/crm/pages/PipelinePage.tsx
+++ b/src/features/crm/pages/PipelinePage.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { DealPipeline } from "../components/DealPipeline";
 import { DealForm } from "../components/DealForm";
 import type {
@@ -54,7 +55,7 @@ const PipelinePage = () => {
       }
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "PipelinePage.loadPipelines",
         },
@@ -77,7 +78,7 @@ const PipelinePage = () => {
       setDeals(dealsData);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "PipelinePage.loadPipelineData",
         },

--- a/src/features/generative-ui/pages/GenerativePage.tsx
+++ b/src/features/generative-ui/pages/GenerativePage.tsx
@@ -44,6 +44,7 @@ import {
 } from "../services/genui-queries";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   CENTREX_BRAND_COLORS,
   CENTREX_COMPONENT_CATALOG,
@@ -115,7 +116,7 @@ export default function GenerativePage() {
       setDataSources(dataSourcesData);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "GenerativePage.fetchData",
         },
@@ -163,7 +164,7 @@ export default function GenerativePage() {
       setStats(statsData);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "GenerativePage.handleDeletePanel",
         },
@@ -185,7 +186,7 @@ export default function GenerativePage() {
       );
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "GenerativePage.handlePublishPanel",
         },
@@ -237,7 +238,7 @@ export default function GenerativePage() {
       setDataSources((prev) => prev.filter((s) => s.id !== id));
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "GenerativePage.handleSourceDelete",
         },

--- a/src/features/generative-ui/services/generation-service.ts
+++ b/src/features/generative-ui/services/generation-service.ts
@@ -7,6 +7,7 @@
 
 import type { GeneratedUI } from "../schemas";
 import { getTenantId } from "@/lib/ai-service";
+import { toError } from '@/lib/errors';
 
 // ============================================
 // TYPES
@@ -628,7 +629,7 @@ export async function generateWithStreaming(
     callbacks?.onComplete?.(ui);
     return { success: true, ui };
   } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
+    const err = toError(error);
     callbacks?.onError?.(err);
 
     // Fallback

--- a/src/features/metrics/components/MetricsDashboard.tsx
+++ b/src/features/metrics/components/MetricsDashboard.tsx
@@ -24,6 +24,7 @@ import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { ANIMATION } from '@/lib/constants';
 import { WidgetCard } from './WidgetCard';
 import { ChartWidget } from './ChartWidget';
@@ -81,7 +82,7 @@ export function MetricsDashboard({ onAddSource, onSourceClick }: MetricsDashboar
       setMetricsData(dataPoints);
       setMetricNames(names);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'MetricsDashboard.loadData',
       });
     } finally {

--- a/src/features/news/pages/FeedPage.tsx
+++ b/src/features/news/pages/FeedPage.tsx
@@ -15,6 +15,7 @@ import { NewsServiceSupabase } from '@/services/news';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { type NewsArticleWithSource, type NewsCategory } from '../schemas';
 
 const newsService = new NewsServiceSupabase();
@@ -38,7 +39,7 @@ export default function FeedPage() {
       setArticles(articlesData);
       setCategories(categoriesData);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'FeedPage.fetchData',
       });
     } finally {
@@ -52,7 +53,7 @@ export default function FeedPage() {
       const articlesData = await newsService.getArticles({ client: supabase }, options);
       setArticles(articlesData);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'FeedPage.fetchArticles',
       });
     }
@@ -73,7 +74,7 @@ export default function FeedPage() {
       await newsService.markArticleRead({ client: supabase }, id);
       setArticles((prev) => prev.map((a) => (a.id === id ? { ...a, is_read: true } : a)));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'FeedPage.handleArticleRead',
       });
     }
@@ -86,7 +87,7 @@ export default function FeedPage() {
         prev.map((a) => (a.id === id ? { ...a, is_bookmarked: !bookmarked } : a))
       );
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'FeedPage.handleArticleBookmark',
       });
     }
@@ -97,7 +98,7 @@ export default function FeedPage() {
       await newsService.curateArticle({ client: supabase }, id, !curated);
       setArticles((prev) => prev.map((a) => (a.id === id ? { ...a, is_curated: !curated } : a)));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'FeedPage.handleArticleCurate',
       });
     }

--- a/src/features/news/pages/SourcesPage.tsx
+++ b/src/features/news/pages/SourcesPage.tsx
@@ -14,6 +14,7 @@ import { NewsServiceSupabase } from "@/services/news";
 import { useTenantSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { type NewsSource, type NewsCategory } from "../schemas";
 
 const newsService = new NewsServiceSupabase();
@@ -41,7 +42,7 @@ export default function SourcesPage() {
       setCategories(categoriesData);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SourcesPage.fetchData",
         },
@@ -75,7 +76,7 @@ export default function SourcesPage() {
       setSources((prev) => [...prev, created]);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SourcesPage.handleSourceCreate",
         },
@@ -93,7 +94,7 @@ export default function SourcesPage() {
       setSources((prev) => prev.map((s) => (s.id === id ? updated : s)));
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SourcesPage.handleSourceUpdate",
         },
@@ -115,7 +116,7 @@ export default function SourcesPage() {
       setSources((prev) => prev.filter((s) => s.id !== id));
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SourcesPage.handleSourceDelete",
         },

--- a/src/features/nps/pages/AnalysisPage.tsx
+++ b/src/features/nps/pages/AnalysisPage.tsx
@@ -9,6 +9,7 @@
 import { useEffect, useState } from 'react';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { useSEO } from '@/lib/seo';
 import AdminLayout from '@/components/AdminLayout';
 import { NpsServiceSupabase } from '@/services/nps';
@@ -41,7 +42,7 @@ const AnalysisPage = () => {
         setRecentSurveys(surveysResult.data);
         setTrends(trendsData);
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)), {
+        captureException(toError(error), {
           context: 'AnalysisPage.fetchAnalysis',
         });
       } finally {

--- a/src/features/nps/pages/CampaignsPage.tsx
+++ b/src/features/nps/pages/CampaignsPage.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { useSEO } from "@/lib/seo";
 import AdminLayout from "@/components/AdminLayout";
 import { Button } from "@/components/ui/button";
@@ -89,7 +90,7 @@ const CampaignsPage = () => {
       setContacts(contactsResult);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "CampaignsPage.loadData",
         },
@@ -135,7 +136,7 @@ const CampaignsPage = () => {
       loadData();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "CampaignsPage.handleCreateCampaign",
         },

--- a/src/features/nps/pages/ResponsesPage.tsx
+++ b/src/features/nps/pages/ResponsesPage.tsx
@@ -11,6 +11,7 @@ import { useSearchParams } from 'react-router-dom';
 import { X, Loader2, Sparkles, Mail, Phone, ClipboardList } from 'lucide-react';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { useSEO } from '@/lib/seo';
 import AdminLayout from '@/components/AdminLayout';
 import { Button } from '@/components/ui/button';
@@ -61,7 +62,7 @@ const ResponsesPage = () => {
         setResponses(responsesResult.data);
         setDetractors(detractorsData);
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)), {
+        captureException(toError(error), {
           context: 'ResponsesPage.fetchResponses',
         });
       } finally {
@@ -93,7 +94,7 @@ const ResponsesPage = () => {
 
       setFollowUpSuggestions(mappedSuggestions);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'ResponsesPage.handleFollowup',
       });
       // Provide default suggestions on error

--- a/src/features/nps/pages/SurveysPage.tsx
+++ b/src/features/nps/pages/SurveysPage.tsx
@@ -12,6 +12,7 @@ import { Plus, TrendingUp } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { useSEO } from '@/lib/seo';
 import AdminLayout from '@/components/AdminLayout';
 import { Button } from '@/components/ui/button';
@@ -35,7 +36,7 @@ const SurveysPage = () => {
         const result = await service.getSurveys({ client: supabase });
         setSurveys(result.data);
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)), {
+        captureException(toError(error), {
           context: 'SurveysPage.fetchSurveys',
         });
       } finally {

--- a/src/features/tasks/pages/TaskEditPage.tsx
+++ b/src/features/tasks/pages/TaskEditPage.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import AdminLayout from "@/components/AdminLayout";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { TaskForm, TaskComments, TaskReminders } from "../components";
 
 const TaskEditPage = () => {
@@ -50,7 +51,7 @@ const TaskEditPage = () => {
       }
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "TaskEditPage.fetchData" },
       );
       navigate("/admin/tasks");
@@ -77,7 +78,7 @@ const TaskEditPage = () => {
       navigate("/admin/tasks");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "TaskEditPage.handleSubmit" },
       );
       toast.error("Failed to save task. Please try again.");

--- a/src/features/tasks/pages/TasksKanbanPage.tsx
+++ b/src/features/tasks/pages/TasksKanbanPage.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import AdminLayout from '@/components/AdminLayout';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { KanbanBoard } from '../components';
 
 const TasksKanbanPage = () => {
@@ -33,7 +34,7 @@ const TasksKanbanPage = () => {
       const tasksData = await getTasks({}, supabase);
       setTasks(tasksData);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), { context: 'TasksKanbanPage.fetchData' });
+      captureException(toError(error), { context: 'TasksKanbanPage.fetchData' });
     } finally {
       setIsLoading(false);
     }
@@ -50,7 +51,7 @@ const TasksKanbanPage = () => {
     try {
       await updateTaskStatus(taskId, newStatus, supabase);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), { context: 'TasksKanbanPage.handleTaskMove' });
+      captureException(toError(error), { context: 'TasksKanbanPage.handleTaskMove' });
       // Revert on error
       fetchData();
     }
@@ -63,7 +64,7 @@ const TasksKanbanPage = () => {
       await deleteTask(taskId, supabase);
       setTasks(tasks.filter((t) => t.id !== taskId));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), { context: 'TasksKanbanPage.handleDelete' });
+      captureException(toError(error), { context: 'TasksKanbanPage.handleDelete' });
     }
   };
 

--- a/src/features/tasks/pages/TasksPage.tsx
+++ b/src/features/tasks/pages/TasksPage.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import AdminLayout from "@/components/AdminLayout";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { TaskCard } from "../components";
 import { useRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
 
@@ -89,7 +90,7 @@ const TasksPage = () => {
       setStats(statsData);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "TasksPage.fetchData" },
       );
     } finally {
@@ -107,7 +108,7 @@ const TasksPage = () => {
       setSelectedTasks(selectedTasks.filter((id) => id !== taskId));
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "TasksPage.handleDelete" },
       );
     }
@@ -127,7 +128,7 @@ const TasksPage = () => {
       setSelectedTasks([]);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "TasksPage.handleBulkDelete" },
       );
     }

--- a/src/hooks/useDataFetching.ts
+++ b/src/hooks/useDataFetching.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 /**
  * Data Fetching Hooks
@@ -104,18 +105,15 @@ export function useDataFetching<T>(
         onSuccess?.(result);
       }
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An error occurred';
+      const normalized = toError(err);
 
       if (isMountedRef.current) {
-        setError(errorMessage);
-        onError?.(err instanceof Error ? err : new Error(errorMessage));
+        setError(normalized.message);
+        onError?.(normalized);
       }
 
       // Log to Sentry
-      captureException(
-        err instanceof Error ? err : new Error(errorMessage),
-        { context: errorContext }
-      );
+      captureException(normalized, { context: errorContext });
     } finally {
       if (isMountedRef.current) {
         setIsLoading(false);
@@ -210,14 +208,11 @@ export function useMutation<TData, TVariables>(
       onSuccess?.(result, variables);
       return result;
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'An error occurred';
-      setError(errorMessage);
-      onError?.(err instanceof Error ? err : new Error(errorMessage), variables);
+      const normalized = toError(err);
+      setError(normalized.message);
+      onError?.(normalized, variables);
 
-      captureException(
-        err instanceof Error ? err : new Error(errorMessage),
-        { context: errorContext, variables }
-      );
+      captureException(normalized, { context: errorContext, variables });
 
       return undefined;
     } finally {

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useSupabaseClient } from '@/lib/supabase';
 import { generateSlug } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 interface UseEditorOptions<T> {
   initialData: T;
@@ -43,7 +44,7 @@ export function useEditor<T extends Record<string, unknown>>({
       setFormData(data);
       setAutoSlug(false);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: `useEditor.fetch${entityName}`,
       });
       setError(`${entityName} not found`);
@@ -107,7 +108,7 @@ export function useEditor<T extends Record<string, unknown>>({
 
       return true;
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: `useEditor.save${entityName}`,
       });
       setError(`Failed to save ${entityName}. Make sure you have permission.`);

--- a/src/lib/ai-service.ts
+++ b/src/lib/ai-service.ts
@@ -6,6 +6,7 @@
  */
 
 import { captureException } from "@/lib/sentry";
+import { toError } from "./errors";
 
 // ============================================
 // TYPES
@@ -145,7 +146,7 @@ async function callClaudeAPI(
     };
   } catch (error) {
     captureException(
-      error instanceof Error ? error : new Error(String(error)),
+      toError(error),
       {
         context: "aiService.callClaudeAPI",
       },

--- a/src/lib/analytics-metrics.ts
+++ b/src/lib/analytics-metrics.ts
@@ -17,6 +17,7 @@
  */
 
 import { captureException } from '@/lib/sentry';
+import { toError } from './errors';
 
 // ============================================
 // TYPES
@@ -316,7 +317,7 @@ export async function getAnalyticsOverview(
       engagementRate: parseFloat(metrics[6]?.value || '0'),
     };
   } catch (error) {
-    captureException(error instanceof Error ? error : new Error(String(error)), {
+    captureException(toError(error), {
       context: 'analytics.getAnalyticsOverview',
     });
     console.error('Failed to fetch analytics overview:', error);
@@ -358,7 +359,7 @@ export async function getTopPages(
       views: parseInt(row.metricValues?.[0]?.value || '0', 10),
     }));
   } catch (error) {
-    captureException(error instanceof Error ? error : new Error(String(error)), {
+    captureException(toError(error), {
       context: 'analytics.getTopPages',
     });
     console.error('Failed to fetch top pages:', error);
@@ -399,7 +400,7 @@ export async function getTrafficSources(
       sessions: parseInt(row.metricValues?.[0]?.value || '0', 10),
     }));
   } catch (error) {
-    captureException(error instanceof Error ? error : new Error(String(error)), {
+    captureException(toError(error), {
       context: 'analytics.getTrafficSources',
     });
     console.error('Failed to fetch traffic sources:', error);
@@ -447,7 +448,7 @@ export async function getDeviceBreakdown(
       };
     });
   } catch (error) {
-    captureException(error instanceof Error ? error : new Error(String(error)), {
+    captureException(toError(error), {
       context: 'analytics.getDeviceBreakdown',
     });
     console.error('Failed to fetch device breakdown:', error);

--- a/src/lib/email-service.ts
+++ b/src/lib/email-service.ts
@@ -8,6 +8,7 @@
  */
 
 import { captureException } from "./sentry";
+import { toError } from "./errors";
 import type { EmailBranding } from "./email-templates";
 import {
   renderWelcomeEmail,
@@ -96,7 +97,7 @@ class EmailService {
       }
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "EmailService.send",
           provider: this.provider,
@@ -343,7 +344,7 @@ class EmailService {
       return false;
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "EmailService.verify",
         },

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -6,6 +6,7 @@ import {
   formatErrorForLogging,
   handleSupabaseError,
   handleQueryResult,
+  toError,
 } from './errors';
 import { SUPABASE_ERROR_CODES } from './constants';
 
@@ -197,6 +198,54 @@ describe('Error Utilities', () => {
       expect(() => {
         handleQueryResult(null, error, { operation: 'test', fallback: null });
       }).toThrow(SupabaseQueryError);
+    });
+  });
+
+  describe('toError', () => {
+    it('returns the same Error instance', () => {
+      const original = new Error('already an error');
+      expect(toError(original)).toBe(original);
+    });
+
+    it('serializes Postgrest-shaped objects with message, code, details, and hint', () => {
+      const result = toError({
+        message: 'JWT expired',
+        code: 'PGRST301',
+        details: 'The JWT expired',
+        hint: 'Sign in again',
+        status: 401,
+      });
+
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toContain('JWT expired');
+      expect(result.message).toContain('PGRST301');
+      expect(result.message).toContain('The JWT expired');
+      expect(result.message).toContain('Sign in again');
+      expect(result.message).toContain('401');
+      expect(result.message).not.toContain('[object Object]');
+    });
+
+    it('JSON.stringifies nested objects that have no Postgrest fields', () => {
+      const result = toError({ nested: { a: 1, b: 'two' } });
+      expect(result.message).toBe(JSON.stringify({ nested: { a: 1, b: 'two' } }));
+      expect(result.message).not.toContain('[object Object]');
+    });
+
+    it('handles null and undefined', () => {
+      expect(toError(null).message).toBe('null');
+      expect(toError(undefined).message).toBe('undefined');
+    });
+
+    it('handles strings and numbers', () => {
+      expect(toError('Failed to fetch').message).toBe('Failed to fetch');
+      expect(toError(406).message).toBe('406');
+    });
+
+    it('does not use String(object) for a plain object', () => {
+      expect(String({ message: 'JWT expired', code: 'PGRST301' })).toBe('[object Object]');
+      expect(toError({ message: 'JWT expired', code: 'PGRST301' }).message).not.toBe(
+        '[object Object]'
+      );
     });
   });
 });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -15,6 +15,35 @@ function formatErrorField(value: unknown): string {
   }
 }
 
+function stringifyUnknown(value: unknown, fallback: string): string {
+  try {
+    const json = JSON.stringify(value);
+    return json ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function errorFromObject(obj: Record<string, unknown>): Error {
+  const message = typeof obj.message === 'string' ? obj.message.trim() : '';
+  const extras: string[] = [];
+
+  for (const field of POSTGREST_ERROR_FIELDS) {
+    const fieldValue = obj[field];
+    if (fieldValue === undefined || fieldValue === null || fieldValue === '') {
+      continue;
+    }
+    extras.push(`${field}: ${formatErrorField(fieldValue)}`);
+  }
+
+  if (message || extras.length > 0) {
+    const extraSuffix = extras.length > 0 ? ` (${extras.join(', ')})` : '';
+    return new Error(`${message || 'Unknown error'}${extraSuffix}`);
+  }
+
+  return new Error(stringifyUnknown(obj, 'Unserializable error object'));
+}
+
 /**
  * Convert any thrown value into an `Error` with a useful `.message`.
  *
@@ -45,35 +74,10 @@ export function toError(value: unknown): Error {
   }
 
   if (valueType === 'object') {
-    const obj = value as Record<string, unknown>;
-    const message = typeof obj.message === 'string' ? obj.message.trim() : '';
-    const extras: string[] = [];
-
-    for (const field of POSTGREST_ERROR_FIELDS) {
-      const fieldValue = obj[field];
-      if (fieldValue === undefined || fieldValue === null || fieldValue === '') {
-        continue;
-      }
-      extras.push(`${field}: ${formatErrorField(fieldValue)}`);
-    }
-
-    if (message || extras.length > 0) {
-      const extraSuffix = extras.length > 0 ? ` (${extras.join(', ')})` : '';
-      return new Error(`${message || 'Unknown error'}${extraSuffix}`);
-    }
-
-    try {
-      return new Error(JSON.stringify(obj));
-    } catch {
-      return new Error('Unserializable error object');
-    }
+    return errorFromObject(value as Record<string, unknown>);
   }
 
-  try {
-    return new Error(JSON.stringify(value));
-  } catch {
-    return new Error('Unknown error');
-  }
+  return new Error(stringifyUnknown(value, 'Unknown error'));
 }
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -2,6 +2,80 @@ import { PostgrestError } from '@supabase/supabase-js';
 import { captureException } from './sentry';
 import { SUPABASE_ERROR_CODES } from './constants';
 
+const POSTGREST_ERROR_FIELDS = ['code', 'details', 'hint', 'status'] as const;
+
+function formatErrorField(value: unknown): string {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '[unserializable]';
+  }
+}
+
+/**
+ * Convert any thrown value into an `Error` with a useful `.message`.
+ *
+ * PostgREST / Supabase errors are plain objects (`{ message, code, details, hint }`),
+ * not `instanceof Error`. `new Error(String(obj))` becomes `"Error: [object Object]"`
+ * in Sentry — this helper never does that.
+ */
+export function toError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return new Error(String(value));
+  }
+
+  const valueType = typeof value;
+  if (valueType === 'string') {
+    return new Error(value);
+  }
+  if (
+    valueType === 'number' ||
+    valueType === 'boolean' ||
+    valueType === 'bigint' ||
+    valueType === 'symbol'
+  ) {
+    return new Error(String(value));
+  }
+
+  if (valueType === 'object') {
+    const obj = value as Record<string, unknown>;
+    const message = typeof obj.message === 'string' ? obj.message.trim() : '';
+    const extras: string[] = [];
+
+    for (const field of POSTGREST_ERROR_FIELDS) {
+      const fieldValue = obj[field];
+      if (fieldValue === undefined || fieldValue === null || fieldValue === '') {
+        continue;
+      }
+      extras.push(`${field}: ${formatErrorField(fieldValue)}`);
+    }
+
+    if (message || extras.length > 0) {
+      const extraSuffix = extras.length > 0 ? ` (${extras.join(', ')})` : '';
+      return new Error(`${message || 'Unknown error'}${extraSuffix}`);
+    }
+
+    try {
+      return new Error(JSON.stringify(obj));
+    } catch {
+      return new Error('Unserializable error object');
+    }
+  }
+
+  try {
+    return new Error(JSON.stringify(value));
+  } catch {
+    return new Error('Unknown error');
+  }
+}
+
 /**
  * Error Handling Strategy
  *
@@ -82,7 +156,7 @@ export function formatErrorForLogging(error: unknown, context: string): string {
   if (error instanceof Error) {
     return `[${context}] ${error.message}`;
   }
-  return `[${context}] Unknown error: ${String(error)}`;
+  return `[${context}] Unknown error: ${toError(error).message}`;
 }
 
 /**

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -9,6 +9,7 @@
  */
 
 import * as Sentry from "@sentry/react";
+import { toError } from "./errors";
 
 // Log levels
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -166,7 +167,7 @@ class Logger {
   /**
    * Output log entry
    */
-  private output(entry: LogEntry): void {
+  private output(entry: LogEntry, originalError?: Error): void {
     if (!this.shouldLog(entry.level)) return;
 
     // In production, output structured JSON
@@ -184,9 +185,10 @@ class Logger {
           console.log(output);
       }
 
-      // Send errors to Sentry
-      if (entry.level === "error" && entry.error) {
-        Sentry.captureException(new Error(entry.error.message), {
+      // Send errors to Sentry. Prefer the original Error instance so we keep
+      // name/stack/type instead of wrapping a possibly-non-string message.
+      if (entry.level === "error" && (originalError || entry.error)) {
+        Sentry.captureException(originalError ?? toError(entry.error), {
           extra: {
             ...entry.metadata,
             correlationId: entry.correlationId,
@@ -236,10 +238,14 @@ class Logger {
 
   error(
     message: string,
-    error?: Error,
+    error?: unknown,
     metadata?: Record<string, unknown>,
   ): void {
-    this.output(this.formatEntry("error", message, metadata, error));
+    const normalized = error !== undefined ? toError(error) : undefined;
+    this.output(
+      this.formatEntry("error", message, metadata, normalized),
+      normalized,
+    );
   }
 
   /**
@@ -260,7 +266,7 @@ class Logger {
       return result;
     } catch (error) {
       const duration = Math.round(performance.now() - start);
-      this.error(`Failed: ${action}`, error as Error, {
+      this.error(`Failed: ${action}`, error, {
         ...metadata,
         duration,
       });
@@ -294,8 +300,11 @@ export const log = {
     logger.info(message, metadata),
   warn: (message: string, metadata?: Record<string, unknown>) =>
     logger.warn(message, metadata),
-  error: (message: string, error?: Error, metadata?: Record<string, unknown>) =>
-    logger.error(message, error, metadata),
+  error: (
+    message: string,
+    error?: unknown,
+    metadata?: Record<string, unknown>,
+  ) => logger.error(message, error, metadata),
   time: <T>(
     action: string,
     fn: () => Promise<T>,

--- a/src/lib/prefetch.ts
+++ b/src/lib/prefetch.ts
@@ -6,6 +6,7 @@ import {
   getBlogPosts,
 } from "./supabase-queries";
 import { captureException } from "./sentry";
+import { toError } from "./errors";
 
 // Cache for prefetched data
 const prefetchCache = new Map<string, { data: unknown; timestamp: number }>();
@@ -34,7 +35,7 @@ const prefetchFunctions: Record<PrefetchKey, () => Promise<void>> = {
         timestamp: Date.now(),
       });
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "prefetch.projects",
       });
     }
@@ -52,7 +53,7 @@ const prefetchFunctions: Record<PrefetchKey, () => Promise<void>> = {
         timestamp: Date.now(),
       });
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "prefetch.software",
       });
     }
@@ -67,7 +68,7 @@ const prefetchFunctions: Record<PrefetchKey, () => Promise<void>> = {
         timestamp: Date.now(),
       });
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "prefetch.content",
       });
     }

--- a/src/lib/pwa.tsx
+++ b/src/lib/pwa.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useState, useEffect, createContext, useContext, ReactNode } from 'react';
 import { captureException } from './sentry';
+import { toError } from './errors';
 import { STORAGE_KEYS } from './constants';
 
 interface BeforeInstallPromptEvent extends Event {
@@ -83,7 +84,7 @@ export function PWAProvider({ children }: PWAProviderProps) {
         return true;
       }
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), { context: 'PWA.install' });
+      captureException(toError(error), { context: 'PWA.install' });
     }
 
     return false;

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -2,6 +2,7 @@
 // To enable: Set VITE_SENTRY_DSN in your .env file
 
 import * as Sentry from '@sentry/react';
+import { toError } from './errors';
 
 const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN;
 
@@ -34,16 +35,18 @@ export function initSentry(): void {
 }
 
 export function captureException(
-  error: Error,
+  error: unknown,
   context?: Record<string, unknown>
 ): void {
+  const normalized = toError(error);
+
   // Log to console only in development
   if (import.meta.env.DEV) {
-    console.error('[Error]', error, context);
+    console.error('[Error]', normalized, context);
   }
 
   if (import.meta.env.PROD && SENTRY_DSN) {
-    Sentry.captureException(error, { extra: context });
+    Sentry.captureException(normalized, { extra: context });
   }
 }
 

--- a/src/lib/seo.tsx
+++ b/src/lib/seo.tsx
@@ -9,6 +9,7 @@ import {
 import { useSupabaseClient } from "./supabase";
 import { getSiteContent } from "./supabase-queries";
 import { captureException } from "./sentry";
+import { toError } from "./errors";
 
 // SEO Settings interface (matches Settings page)
 interface SEOSettings {
@@ -76,7 +77,7 @@ export function SEOProvider({ children }: { children: ReactNode }) {
           }
         } catch (err) {
           captureException(
-            err instanceof Error ? err : new Error(String(err)),
+            toError(err),
             { context: "SEO.loadSettings" },
           );
         }

--- a/src/lib/site-content-queries.test.ts
+++ b/src/lib/site-content-queries.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PostgrestError } from '@supabase/supabase-js';
+import { SUPABASE_ERROR_CODES } from './constants';
+import { SupabaseQueryError } from './errors';
+
+vi.mock('./sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('./supabase', () => ({
+  getSupabase: vi.fn(),
+  supabase: {},
+}));
+
+import { getSiteContent } from './site-content-queries';
+
+function mockClient(result: { data: unknown; error: unknown }) {
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const eq = vi.fn(() => ({ maybeSingle }));
+  const select = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ select }));
+  return { from, maybeSingle };
+}
+
+describe('getSiteContent', () => {
+  it('returns null for a missing site_content key without throwing', async () => {
+    const client = mockClient({ data: null, error: null });
+
+    await expect(getSiteContent('projects', client as never)).resolves.toBeNull();
+    expect(client.from).toHaveBeenCalledWith('site_content');
+    expect(client.maybeSingle).toHaveBeenCalled();
+  });
+
+  it('returns null for PGRST116 (0 rows) without throwing', async () => {
+    const error: PostgrestError = {
+      message: 'JSON object requested, multiple (or no) rows returned',
+      details: 'The result contains 0 rows',
+      hint: null,
+      code: SUPABASE_ERROR_CODES.NOT_FOUND,
+    };
+
+    await expect(
+      getSiteContent('projects', mockClient({ data: null, error }) as never)
+    ).resolves.toBeNull();
+  });
+
+  it('throws SupabaseQueryError for real query failures', async () => {
+    const error: PostgrestError = {
+      message: 'JWT expired',
+      details: null,
+      hint: null,
+      code: 'PGRST301',
+    };
+
+    await expect(
+      getSiteContent('hero', mockClient({ data: null, error }) as never)
+    ).rejects.toBeInstanceOf(SupabaseQueryError);
+  });
+
+  it('returns the row when present', async () => {
+    const row = { key: 'hero', title: 'Hero', content: '{}' };
+
+    await expect(
+      getSiteContent('hero', mockClient({ data: row, error: null }) as never)
+    ).resolves.toEqual(row);
+  });
+});

--- a/src/lib/site-content-queries.ts
+++ b/src/lib/site-content-queries.ts
@@ -1,6 +1,6 @@
 import { SupabaseClient } from '@supabase/supabase-js';
 import { getSupabase, supabase } from './supabase';
-import { handleQueryResult } from './errors';
+import { handleQueryResult, SupabaseQueryError } from './errors';
 import { SUPABASE_ERROR_CODES } from './constants';
 import {
   WorkHistoryEntrySchema,
@@ -41,9 +41,13 @@ export async function getSiteContent(key: string, client: SupabaseClient = getSu
     .from('site_content')
     .select('*')
     .eq('key', key)
-    .single();
+    .maybeSingle();
 
-  if (error && error.code !== SUPABASE_ERROR_CODES.NOT_FOUND) throw error;
+  // maybeSingle() returns 200 + null for 0 rows (no HTTP 406 / PGRST116).
+  // Still swallow PGRST116 if a client or proxy surfaces it.
+  if (error && error.code !== SUPABASE_ERROR_CODES.NOT_FOUND) {
+    throw new SupabaseQueryError(error, 'getSiteContent');
+  }
   return data as SiteContent | null;
 }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -2,6 +2,7 @@ import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { useSession, useOrganization } from "@clerk/clerk-react";
 import { useMemo, useCallback, useEffect, useRef } from "react";
 import { captureException } from "./sentry";
+import { toError } from "./errors";
 import { STORAGE_KEYS } from "./constants";
 import { useTenant } from "./tenant";
 
@@ -62,7 +63,7 @@ export function getSupabaseSettings(): SupabaseSettings {
         }
       }
     } catch (e) {
-      captureException(e instanceof Error ? e : new Error(String(e)), {
+      captureException(toError(e), {
         context: "Supabase.parseSettings",
       });
     }
@@ -212,7 +213,7 @@ export function useAuthenticatedSupabase(): {
       const token = await session.getToken({ template: "supabase" });
       return token;
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "useAuthenticatedSupabase.getToken",
       });
       return null;
@@ -276,7 +277,7 @@ export function useTenantSupabase(): {
     try {
       return await session.getToken({ template: "supabase" });
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "useTenantSupabase.getToken",
       });
       return null;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -18,6 +18,7 @@ import {
 import { renderMarkdown } from '@/lib/markdown';
 import { useSEO, useJsonLd, personSchema, aboutFaqSchema, RECRUITING_KEYWORDS } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import DOMPurify from 'dompurify';
 
 // Icon mapping for contact links
@@ -114,7 +115,7 @@ Background in enterprise IT—Azure, Intune, M365 at scale. Now applying that sy
           setContactLinks(linksData);
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), { context: 'About.fetchData' });
+        captureException(toError(err), { context: 'About.fetchData' });
       } finally {
         setIsLoading(false);
       }
@@ -228,7 +229,7 @@ Background in enterprise IT—Azure, Intune, M365 at scale. Now applying that sy
       setContent(saved);
       setIsEditing(false);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'About.save' });
+      captureException(toError(err), { context: 'About.save' });
     } finally {
       setIsSaving(false);
     }

--- a/src/pages/AppDetail.tsx
+++ b/src/pages/AppDetail.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { getAppsBySlug, type App, type AppSuite } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { useSEO, useJsonLd, personSchema } from '@/lib/seo';
 
 const AppDetail = () => {
@@ -37,7 +38,7 @@ const AppDetail = () => {
         const data = await getAppsBySlug(slug);
         setApp(data);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AppDetail.fetchApp', slug });
+        captureException(toError(err), { context: 'AppDetail.fetchApp', slug });
         setError('App not found');
       } finally {
         setIsLoading(false);

--- a/src/pages/AppSuite.tsx
+++ b/src/pages/AppSuite.tsx
@@ -7,6 +7,7 @@ import AppCard from '@/components/AppCard';
 import { Button } from '@/components/ui/button';
 import { getAppsBySuiteSlug, type App, type AppSuite as AppSuiteType } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 const AppSuite = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -24,7 +25,7 @@ const AppSuite = () => {
         setSuite(data.suite);
         setApps(data.apps);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AppSuite.fetchSuite', slug });
+        captureException(toError(err), { context: 'AppSuite.fetchSuite', slug });
         setError('Suite not found');
       } finally {
         setIsLoading(false);

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -20,6 +20,7 @@ import { formatDate } from "@/lib/markdown";
 import { useSEO, useJsonLd } from "@/lib/seo";
 import { analytics } from "@/lib/analytics";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 // Display type
 interface DisplayPost {
@@ -99,7 +100,7 @@ const BlogPostPage = () => {
 
         setError("Post not found");
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "BlogPost.fetchPost",
           slug,
         });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import { useSEO, useJsonLd, personSchema, websiteSchema, occupationSchema, RECRU
 import { useSupabaseClient } from '@/lib/supabase';
 import { getSiteContent } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { useReducedMotion } from '@/lib/reduced-motion';
 
 interface HeroContent {
@@ -53,7 +54,7 @@ const Home = () => {
           }
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: 'Home.fetchHeroContent',
         });
       }

--- a/src/pages/PublicPage.tsx
+++ b/src/pages/PublicPage.tsx
@@ -7,6 +7,7 @@ import { getSiteBuilderPageBySlug, getSiteBuilderPageComponents } from '@/lib/si
 import type { SiteBuilderPage, SiteBuilderPageComponent } from '@/lib/schemas';
 import { BLOCK_COMPONENTS } from '@/components/site-builder/blocks';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 export default function PublicPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -45,7 +46,7 @@ export default function PublicPage() {
       const componentsData = await getSiteBuilderPageComponents(pageData.id, supabase);
       setComponents(componentsData);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: 'PublicPage.loadPage',
       });
       setError('Page not found');

--- a/src/pages/admin/AuditLog.tsx
+++ b/src/pages/admin/AuditLog.tsx
@@ -27,6 +27,7 @@ import { Input } from '@/components/ui/input';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import {
   getAuditEvents,
   exportAuditEvents,
@@ -207,7 +208,7 @@ export default function AuditLog() {
         setTotalCount((prev) => (reset ? data.length : prev + data.length));
         setHasNewEvents(false);
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)));
+        captureException(toError(error));
         console.error('Failed to load audit events:', error);
       } finally {
         setLoading(false);
@@ -313,7 +314,7 @@ export default function AuditLog() {
       a.click();
       URL.revokeObjectURL(url);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)));
+      captureException(toError(error));
       console.error('Failed to export audit events:', error);
     }
   };

--- a/src/pages/admin/CampaignEditor.tsx
+++ b/src/pages/admin/CampaignEditor.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import AdminLayout from "@/components/AdminLayout";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   getEmailCampaignById,
   createEmailCampaign,
@@ -79,7 +80,7 @@ const CampaignEditor = () => {
         }
       } catch (error) {
         captureException(
-          error instanceof Error ? error : new Error(String(error)),
+          toError(error),
           {
             context: "CampaignEditor.fetchData",
           },
@@ -124,7 +125,7 @@ const CampaignEditor = () => {
       navigate("/admin/marketing/campaigns");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "CampaignEditor.handleSubmit",
         },
@@ -144,7 +145,7 @@ const CampaignEditor = () => {
       navigate("/admin/marketing/campaigns");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "CampaignEditor.handleDelete",
         },
@@ -161,7 +162,7 @@ const CampaignEditor = () => {
       navigate("/admin/marketing/campaigns");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "CampaignEditor.handleSchedule",
         },
@@ -197,7 +198,7 @@ const CampaignEditor = () => {
       }
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "CampaignEditor.handleSendNow",
         },

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -9,6 +9,7 @@ import AuditLogViewer from '@/components/admin/AuditLogViewer';
 import AgentPlatformHealth from '@/components/admin/AgentPlatformHealth';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 interface Stats {
   appsCount: number;
@@ -49,7 +50,7 @@ const AdminDashboard = () => {
           draftPostsCount: draftsResult.count ?? 0,
         });
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)), { context: 'Dashboard.fetchStats' });
+        captureException(toError(error), { context: 'Dashboard.fetchStats' });
       } finally {
         setIsLoading(false);
       }

--- a/src/pages/admin/DataManagement.tsx
+++ b/src/pages/admin/DataManagement.tsx
@@ -16,6 +16,7 @@ import { Card } from "@/components/ui/card";
 import { useSEO } from "@/lib/seo";
 import { useTenant } from "@/lib/tenant";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 interface DataType {
   id: string;
@@ -164,7 +165,7 @@ export default function DataManagement() {
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "Export failed";
       setError(errorMessage);
-      captureException(err instanceof Error ? err : new Error(errorMessage));
+      captureException(toError(err));
     } finally {
       setExporting(false);
     }
@@ -236,9 +237,7 @@ export default function DataManagement() {
       } catch (err) {
         setError("Invalid JSON file or unsupported format");
         setSelectedFile(null);
-        captureException(
-          err instanceof Error ? err : new Error("Import preview failed"),
-        );
+        captureException(toError(err));
       }
     };
     reader.readAsText(file);
@@ -273,7 +272,7 @@ export default function DataManagement() {
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "Import failed";
       setError(errorMessage);
-      captureException(err instanceof Error ? err : new Error(errorMessage));
+      captureException(toError(err));
     } finally {
       setImporting(false);
     }

--- a/src/pages/admin/IntegrationHub.tsx
+++ b/src/pages/admin/IntegrationHub.tsx
@@ -25,6 +25,7 @@ import { Badge } from "@/components/ui/badge";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   getIntegrations,
   createIntegration,
@@ -216,7 +217,7 @@ export default function IntegrationHub() {
       setAgents(agentsData);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "IntegrationHub.loadData",
         },
@@ -241,7 +242,7 @@ export default function IntegrationHub() {
       );
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "IntegrationHub.loadIntegrationAgents",
         },
@@ -313,7 +314,7 @@ export default function IntegrationHub() {
       setShowAddModal(false);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "IntegrationHub.createIntegration",
         },
@@ -335,7 +336,7 @@ export default function IntegrationHub() {
       setShowDeleteModal(false);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "IntegrationHub.deleteIntegration",
         },
@@ -375,7 +376,7 @@ export default function IntegrationHub() {
       setShowGrantModal(false);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "IntegrationHub.grantAccess",
         },
@@ -396,7 +397,7 @@ export default function IntegrationHub() {
       await loadData();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "IntegrationHub.revokeAccess",
         },
@@ -438,7 +439,7 @@ export default function IntegrationHub() {
       window.location.href = data.auth_url;
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "IntegrationHub.oauthConnect" },
       );
       console.error("Failed to initiate OAuth:", error);
@@ -461,7 +462,7 @@ export default function IntegrationHub() {
       await loadData();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "IntegrationHub.testConnection",
         },

--- a/src/pages/admin/Marketing.tsx
+++ b/src/pages/admin/Marketing.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import AdminLayout from '@/components/AdminLayout';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { getMarketingStats } from '@/lib/marketing-queries';
 import { emailService, sendTestEmail } from '@/lib/email-service';
 import type { MarketingStats } from '@/lib/schemas';
@@ -33,7 +34,7 @@ const Marketing = () => {
         const data = await getMarketingStats(supabase);
         setStats(data);
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)), {
+        captureException(toError(error), {
           context: 'Marketing.fetchStats',
         });
       } finally {
@@ -61,7 +62,7 @@ const Marketing = () => {
         setTestResult({ success: false, message: result.error || 'Failed to send test email' });
       }
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'Marketing.handleSendTestEmail',
       });
       setTestResult({ success: false, message: 'Error sending test email' });

--- a/src/pages/admin/MarketingCampaigns.tsx
+++ b/src/pages/admin/MarketingCampaigns.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import AdminLayout from '@/components/AdminLayout';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { getEmailCampaigns } from '@/lib/marketing-queries';
 import type { EmailCampaign } from '@/lib/schemas';
 
@@ -30,7 +31,7 @@ const MarketingCampaigns = () => {
         );
         setCampaigns(data);
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)), {
+        captureException(toError(error), {
           context: 'MarketingCampaigns.fetchCampaigns',
         });
       } finally {

--- a/src/pages/admin/MarketingNPS.tsx
+++ b/src/pages/admin/MarketingNPS.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import AdminLayout from '@/components/AdminLayout';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { getNPSSurveys } from '@/lib/marketing-queries';
 import type { NPSSurvey } from '@/lib/schemas';
 
@@ -26,7 +27,7 @@ const MarketingNPS = () => {
         const data = await getNPSSurveys(undefined, supabase);
         setSurveys(data);
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)), {
+        captureException(toError(error), {
           context: 'MarketingNPS.fetchSurveys',
         });
       } finally {

--- a/src/pages/admin/MarketingSubscribers.tsx
+++ b/src/pages/admin/MarketingSubscribers.tsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input";
 import AdminLayout from "@/components/AdminLayout";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   getEmailSubscribers,
   bulkImportSubscribers,
@@ -57,7 +58,7 @@ const MarketingSubscribers = () => {
         setSubscribers(data);
       } catch (error) {
         captureException(
-          error instanceof Error ? error : new Error(String(error)),
+          toError(error),
           {
             context: "MarketingSubscribers.fetchSubscribers",
           },
@@ -225,7 +226,7 @@ const MarketingSubscribers = () => {
       setSubscribers(data);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "MarketingSubscribers.handleImport",
         },

--- a/src/pages/admin/MarketingTemplates.tsx
+++ b/src/pages/admin/MarketingTemplates.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import AdminLayout from '@/components/AdminLayout';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { getEmailTemplates } from '@/lib/marketing-queries';
 import type { EmailTemplate } from '@/lib/schemas';
 
@@ -26,7 +27,7 @@ const MarketingTemplates = () => {
         const data = await getEmailTemplates(undefined, supabase);
         setTemplates(data);
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)), {
+        captureException(toError(error), {
           context: 'MarketingTemplates.fetchTemplates',
         });
       } finally {

--- a/src/pages/admin/NPSSurveyDetail.tsx
+++ b/src/pages/admin/NPSSurveyDetail.tsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input";
 import AdminLayout from "@/components/AdminLayout";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   getNPSSurveyById,
   createNPSSurvey,
@@ -80,7 +81,7 @@ const NPSSurveyDetail = () => {
         }
       } catch (error) {
         captureException(
-          error instanceof Error ? error : new Error(String(error)),
+          toError(error),
           {
             context: "NPSSurveyDetail.fetchData",
           },
@@ -118,7 +119,7 @@ const NPSSurveyDetail = () => {
       navigate("/admin/marketing/nps");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "NPSSurveyDetail.handleSubmit",
         },
@@ -143,7 +144,7 @@ const NPSSurveyDetail = () => {
       navigate("/admin/marketing/nps");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "NPSSurveyDetail.handleDelete",
         },
@@ -163,7 +164,7 @@ const NPSSurveyDetail = () => {
       }
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "NPSSurveyDetail.handleStatusChange",
         },

--- a/src/pages/admin/Profile.tsx
+++ b/src/pages/admin/Profile.tsx
@@ -34,6 +34,7 @@ import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { useTheme } from "@/lib/theme";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   getSiteContent,
   upsertSiteContent,
@@ -136,7 +137,7 @@ const HeroTab = () => {
           }
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Profile.fetchHero",
         });
       } finally {
@@ -160,7 +161,7 @@ const HeroTab = () => {
       );
       setContent(saved);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.saveHero",
       });
     } finally {
@@ -261,7 +262,7 @@ const AboutTab = () => {
           setBody(data.content);
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Profile.fetchAbout",
         });
       } finally {
@@ -281,7 +282,7 @@ const AboutTab = () => {
       );
       setContent(saved);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.saveAbout",
       });
     } finally {
@@ -358,7 +359,7 @@ const ContactTab = () => {
         const data = await getContactLinks(supabase);
         setLinks(data);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Profile.fetchContacts",
         });
       } finally {
@@ -394,7 +395,7 @@ const ContactTab = () => {
       }
       resetForm();
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.saveContact",
       });
     }
@@ -417,7 +418,7 @@ const ContactTab = () => {
       await deleteContactLink(id, supabase);
       setLinks(links.filter((l) => l.id !== id));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.deleteContact",
       });
     }
@@ -607,7 +608,7 @@ const WorkHistoryTab = () => {
         const data = await getWorkHistory(supabase);
         setEntries(data);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Profile.fetchWorkHistory",
         });
       } finally {
@@ -648,7 +649,7 @@ const WorkHistoryTab = () => {
       }
       resetForm();
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.saveWorkHistory",
       });
       setError(
@@ -675,7 +676,7 @@ const WorkHistoryTab = () => {
       await deleteWorkHistoryEntry(id, supabase);
       setEntries(entries.filter((e) => e.id !== id));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.deleteWorkHistory",
       });
       setError(
@@ -907,7 +908,7 @@ const CaseStudiesTab = () => {
         const data = await getCaseStudies(supabase);
         setStudies(data);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Profile.fetchCaseStudies",
         });
       } finally {
@@ -943,7 +944,7 @@ const CaseStudiesTab = () => {
       }
       resetForm();
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.saveCaseStudy",
       });
       setError("Failed to save case study. Make sure you have permission.");
@@ -967,7 +968,7 @@ const CaseStudiesTab = () => {
       await deleteCaseStudy(id, supabase);
       setStudies(studies.filter((s) => s.id !== id));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.deleteCaseStudy",
       });
       setError("Failed to delete case study. Make sure you have permission.");
@@ -1436,7 +1437,7 @@ const TimelinesTab = () => {
           setSelectedTimeline(data[0]);
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Profile.fetchTimelines",
         });
       } finally {
@@ -1454,7 +1455,7 @@ const TimelinesTab = () => {
         const data = await getTimelineEntries(selectedTimeline.id, supabase);
         setEntries(data);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Profile.fetchTimelineEntries",
         });
       } finally {
@@ -1512,7 +1513,7 @@ const TimelinesTab = () => {
       }
       resetTimelineForm();
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.saveTimeline",
       });
       setError("Failed to save timeline. Make sure you have permission.");
@@ -1541,7 +1542,7 @@ const TimelinesTab = () => {
         setSelectedTimeline(remaining[0] || null);
       }
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.deleteTimeline",
       });
       setError("Failed to delete timeline. Make sure you have permission.");
@@ -1572,7 +1573,7 @@ const TimelinesTab = () => {
       }
       resetEntryForm();
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.saveEntry",
       });
       setError("Failed to save entry. Make sure you have permission.");
@@ -1597,7 +1598,7 @@ const TimelinesTab = () => {
       await deleteTimelineEntry(id, supabase);
       setEntries(entries.filter((e) => e.id !== id));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Profile.deleteEntry",
       });
       setError("Failed to delete entry. Make sure you have permission.");

--- a/src/pages/admin/Scheduler.tsx
+++ b/src/pages/admin/Scheduler.tsx
@@ -23,6 +23,7 @@ import { Badge } from '@/components/ui/badge';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import {
   getScheduledWorkflows,
   getSchedulerHealth,
@@ -251,7 +252,7 @@ export default function Scheduler() {
       const message = err instanceof Error ? err.message : 'Failed to load scheduler data';
       setError(message);
       captureException(
-        err instanceof Error ? err : new Error(String(err)),
+        toError(err),
         { context: 'Scheduler.loadData' }
       );
     } finally {
@@ -268,7 +269,7 @@ export default function Scheduler() {
       setRunHistory(runs);
     } catch (err) {
       captureException(
-        err instanceof Error ? err : new Error(String(err)),
+        toError(err),
         { context: 'Scheduler.loadRunHistory', workflowId }
       );
     } finally {
@@ -299,7 +300,7 @@ export default function Scheduler() {
       setHealth(healthData);
     } catch (err) {
       captureException(
-        err instanceof Error ? err : new Error(String(err)),
+        toError(err),
         { context: 'Scheduler.handleToggleActive', workflowId: workflow.id }
       );
       setError(err instanceof Error ? err.message : 'Failed to update workflow status');
@@ -324,7 +325,7 @@ export default function Scheduler() {
       setError(null);
     } catch (err) {
       captureException(
-        err instanceof Error ? err : new Error(String(err)),
+        toError(err),
         { context: 'Scheduler.handleRunNow', workflowId: workflow.id }
       );
       setError(err instanceof Error ? err.message : 'Failed to trigger workflow');

--- a/src/pages/admin/SubscriberDetail.tsx
+++ b/src/pages/admin/SubscriberDetail.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import AdminLayout from "@/components/AdminLayout";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   getEmailSubscriberById,
   createEmailSubscriber,
@@ -75,7 +76,7 @@ const SubscriberDetail = () => {
         }
       } catch (error) {
         captureException(
-          error instanceof Error ? error : new Error(String(error)),
+          toError(error),
           {
             context: "SubscriberDetail.fetchData",
           },
@@ -136,7 +137,7 @@ const SubscriberDetail = () => {
       navigate("/admin/marketing/subscribers");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SubscriberDetail.handleSubmit",
         },
@@ -156,7 +157,7 @@ const SubscriberDetail = () => {
       navigate("/admin/marketing/subscribers");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SubscriberDetail.handleDelete",
         },

--- a/src/pages/admin/TemplateEditor.tsx
+++ b/src/pages/admin/TemplateEditor.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import AdminLayout from "@/components/AdminLayout";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   getEmailTemplateById,
   createEmailTemplate,
@@ -68,7 +69,7 @@ const TemplateEditor = () => {
         }
       } catch (error) {
         captureException(
-          error instanceof Error ? error : new Error(String(error)),
+          toError(error),
           {
             context: "TemplateEditor.fetchTemplate",
           },
@@ -125,7 +126,7 @@ const TemplateEditor = () => {
       navigate("/admin/marketing/templates");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "TemplateEditor.handleSubmit",
         },
@@ -145,7 +146,7 @@ const TemplateEditor = () => {
       navigate("/admin/marketing/templates");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "TemplateEditor.handleDelete",
         },

--- a/src/pages/admin/WorkflowEditor.tsx
+++ b/src/pages/admin/WorkflowEditor.tsx
@@ -11,6 +11,7 @@ import { Separator } from '@/components/ui/separator';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { getWorkflowById, updateWorkflow, deleteWorkflow, getWorkflowRuns } from '@/lib/agent-platform-queries';
 import IntegrationActionForm from '@/components/admin/IntegrationActionForm';
 import type { Workflow, WorkflowRun } from '@/lib/schemas';
@@ -116,7 +117,7 @@ const WorkflowEditor = () => {
         const runs = await getWorkflowRuns(id, 20, supabase);
         setWorkflowRuns(runs);
       } catch (error) {
-        captureException(error instanceof Error ? error : new Error(String(error)), {
+        captureException(toError(error), {
           context: 'WorkflowEditor.fetchWorkflow',
         });
       } finally {
@@ -153,7 +154,7 @@ const WorkflowEditor = () => {
       setSaveMessage({ type: 'success', text: 'Workflow saved successfully' });
       setTimeout(() => setSaveMessage(null), 3000);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'WorkflowEditor.handleSubmit',
       });
       setSaveMessage({ type: 'error', text: 'Failed to save workflow. Please try again.' });
@@ -170,7 +171,7 @@ const WorkflowEditor = () => {
       await deleteWorkflow(id, supabase);
       navigate('/admin/workflows');
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'WorkflowEditor.handleDelete',
       });
       setSaveMessage({ type: 'error', text: 'Failed to delete workflow.' });
@@ -203,7 +204,7 @@ const WorkflowEditor = () => {
         setWorkflowRuns(runs);
       }, 2000);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'WorkflowEditor.handleTestRun',
       });
       setTestResult({

--- a/src/pages/admin/Workflows.tsx
+++ b/src/pages/admin/Workflows.tsx
@@ -24,6 +24,7 @@ import WorkflowTemplateGallery from "@/components/admin/WorkflowTemplateGallery"
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   getWorkflows,
   createWorkflow,
@@ -73,7 +74,7 @@ const Workflows = () => {
       setWorkflows(data);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "Workflows.fetchWorkflows" },
       );
     } finally {
@@ -110,7 +111,7 @@ const Workflows = () => {
       );
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "Workflows.toggleActive", workflowId: workflow.id },
       );
     }
@@ -155,7 +156,7 @@ const Workflows = () => {
       navigate(`/admin/workflows/${created.id}`);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "Workflows.createWorkflow" },
       );
     } finally {
@@ -207,7 +208,7 @@ const Workflows = () => {
       navigate(`/admin/workflows/${created.id}`);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "Workflows.installTemplate", templateId: template.id },
       );
       toast.error("Failed to install template");
@@ -237,7 +238,7 @@ const Workflows = () => {
       toast.success(`Workflow "${workflow.name}" started`);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         { context: "Workflows.runNow", workflowId: workflow.id },
       );
       toast.error("Failed to run workflow");

--- a/src/pages/admin/ai-manager/index.tsx
+++ b/src/pages/admin/ai-manager/index.tsx
@@ -24,6 +24,7 @@ import { Input } from "@/components/ui/input";
 import AdminLayout from "@/components/AdminLayout";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import ReactMarkdown from "react-markdown";
 
 // Backend modes for AI interaction
@@ -180,7 +181,7 @@ const AIManager = () => {
       setMessages(allMessages);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "AIManager.loadSession",
         },
@@ -419,7 +420,7 @@ Note: In API mode, you don't have access to tools like file operations or git co
         ]);
       } catch (error) {
         captureException(
-          error instanceof Error ? error : new Error(String(error)),
+          toError(error),
           {
             context: "AIManager.sendMessage.api",
           },
@@ -473,7 +474,7 @@ Note: In API mode, you don't have access to tools like file operations or git co
         clearTimeout(responseTimeoutRef.current);
       }
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "AIManager.sendMessage",
         },
@@ -506,7 +507,7 @@ Note: In API mode, you don't have access to tools like file operations or git co
       setPendingConfirmation(null);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "AIManager.handleConfirmation",
         },

--- a/src/pages/admin/apps/editor.tsx
+++ b/src/pages/admin/apps/editor.tsx
@@ -19,6 +19,7 @@ import {
   type AppSuite
 } from '@/lib/supabase-queries';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import { useSEO } from '@/lib/seo';
 
 type AppFormData = Omit<App, 'id' | 'created_at' | 'updated_at' | 'suite'>;
@@ -60,7 +61,7 @@ const AppEditor = () => {
       const data = await getAppSuites(supabase);
       setSuites(data);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AppEditor.fetchSuites' });
+      captureException(toError(err), { context: 'AppEditor.fetchSuites' });
     }
   }, [supabase]);
 
@@ -86,7 +87,7 @@ const AppEditor = () => {
       });
       setAutoSlug(false);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AppEditor.fetchApp' });
+      captureException(toError(err), { context: 'AppEditor.fetchApp' });
       setError('App not found');
     } finally {
       setIsLoading(false);
@@ -148,7 +149,7 @@ const AppEditor = () => {
         }));
       }
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AppEditor.saveApp' });
+      captureException(toError(err), { context: 'AppEditor.saveApp' });
       setError('Failed to save app. Make sure you have permission.');
     } finally {
       setIsSaving(false);

--- a/src/pages/admin/apps/index.tsx
+++ b/src/pages/admin/apps/index.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/supabase-queries";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 const statusLabels: Record<string, string> = {
   planned: "Planned",
@@ -69,7 +70,7 @@ const AdminAppsList = () => {
       setApps(appsData);
       setSuites(suitesData);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminApps.fetchData",
       });
     } finally {
@@ -89,7 +90,7 @@ const AdminAppsList = () => {
       await deleteApp(id, supabase);
       setApps(apps.filter((a) => a.id !== id));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminApps.deleteApp",
       });
     } finally {
@@ -113,7 +114,7 @@ const AdminAppsList = () => {
       await deleteAppSuite(id, supabase);
       setSuites(suites.filter((s) => s.id !== id));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminApps.deleteSuite",
       });
     } finally {
@@ -150,7 +151,7 @@ const AdminAppsList = () => {
       setApps(apps.filter((a) => !selectedIds.has(a.id)));
       setSelectedIds(new Set());
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminApps.bulkDelete",
       });
     } finally {
@@ -169,7 +170,7 @@ const AdminAppsList = () => {
       );
       setSelectedIds(new Set());
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminApps.bulkUpdate",
       });
     } finally {
@@ -188,7 +189,7 @@ const AdminAppsList = () => {
       );
       setSelectedIds(new Set());
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminApps.bulkArchive",
       });
     } finally {

--- a/src/pages/admin/apps/suite-editor.tsx
+++ b/src/pages/admin/apps/suite-editor.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/supabase-queries';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 type SuiteFormData = Omit<AppSuite, 'id' | 'created_at' | 'updated_at'>;
 
@@ -56,7 +57,7 @@ const SuiteEditor = () => {
       });
       setAutoSlug(false);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'SuiteEditor.fetchSuite' });
+      captureException(toError(err), { context: 'SuiteEditor.fetchSuite' });
       setError('Suite not found');
     } finally {
       setIsLoading(false);
@@ -104,7 +105,7 @@ const SuiteEditor = () => {
       }
       navigate('/admin/apps');
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'SuiteEditor.saveSuite' });
+      captureException(toError(err), { context: 'SuiteEditor.saveSuite' });
       setError('Failed to save suite. Make sure you have permission.');
     } finally {
       setIsSaving(false);

--- a/src/pages/admin/blog/editor.tsx
+++ b/src/pages/admin/blog/editor.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/lib/supabase-queries";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 type PostFormData = Omit<BlogPost, "id" | "created_at" | "updated_at">;
 
@@ -87,7 +88,7 @@ const BlogEditor = () => {
         });
         setAutoSlug(false);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "BlogEditor.fetchPost",
         });
         setError("Post not found");
@@ -179,7 +180,7 @@ const BlogEditor = () => {
         published_at: publishedAt,
       }));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "BlogEditor.savePost",
       });
       setError("Failed to save post. Make sure you have permission.");

--- a/src/pages/admin/blog/index.tsx
+++ b/src/pages/admin/blog/index.tsx
@@ -36,6 +36,7 @@ import {
 import { formatDate } from "@/lib/markdown";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 type ContentTab = "all" | "me" | "news";
 type ArticleWithSource = NewsArticle & { source: NewsSource | null };
@@ -115,7 +116,7 @@ const AdminContentList = () => {
       setLocalPosts(posts);
       setCuratedNews(curated);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminContent.fetchData",
       });
     } finally {
@@ -172,7 +173,7 @@ const AdminContentList = () => {
       await deleteBlogPost(id, supabase);
       setLocalPosts(localPosts.filter((p) => p.id !== id));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminContent.deletePost",
       });
     } finally {
@@ -186,7 +187,7 @@ const AdminContentList = () => {
       await curateArticle(id, false, undefined, supabase!);
       setCuratedNews(curatedNews.filter((a) => a.id !== id));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminContent.uncurate",
       });
     } finally {
@@ -226,7 +227,7 @@ const AdminContentList = () => {
       setLocalPosts(localPosts.filter((p) => !selectedIds.has(p.id)));
       setSelectedIds(new Set());
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminContent.bulkDelete",
       });
     } finally {
@@ -255,7 +256,7 @@ const AdminContentList = () => {
       );
       setSelectedIds(new Set());
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminContent.bulkPublish",
       });
     } finally {
@@ -278,7 +279,7 @@ const AdminContentList = () => {
       );
       setSelectedIds(new Set());
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "AdminContent.bulkUnpublish",
       });
     } finally {

--- a/src/pages/admin/bookmarks/index.tsx
+++ b/src/pages/admin/bookmarks/index.tsx
@@ -35,6 +35,7 @@ import { Badge } from "@/components/ui/badge";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import {
   getBookmarks,
   getBookmarkStats,
@@ -182,7 +183,7 @@ const AdminBookmarks = () => {
       );
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "AdminBookmarks.loadData",
         },

--- a/src/pages/admin/contacts/index.tsx
+++ b/src/pages/admin/contacts/index.tsx
@@ -30,6 +30,7 @@ import { Badge } from '@/components/ui/badge';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import {
   getContacts,
   getContactLists,
@@ -151,7 +152,7 @@ const AdminContacts = () => {
       setFollowUps(upcomingFollowUps);
       setOverdueFollowUps(overdueData);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminContacts.loadData',
       });
     } finally {
@@ -218,7 +219,7 @@ const AdminContacts = () => {
       setShowContactForm(false);
       loadData();
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminContacts.saveContact',
       });
     } finally {
@@ -233,7 +234,7 @@ const AdminContacts = () => {
       await deleteContact(id, supabase);
       loadData();
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminContacts.deleteContact',
       });
     }
@@ -246,7 +247,7 @@ const AdminContacts = () => {
       await completeFollowUp(id, undefined, undefined, supabase);
       loadData();
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminContacts.completeFollowUp',
       });
     }

--- a/src/pages/admin/metrics/index.tsx
+++ b/src/pages/admin/metrics/index.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/metrics-queries";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { ANIMATION } from "@/lib/constants";
 
 const TIME_RANGES: { label: string; value: TimeRange }[] = [
@@ -79,7 +80,7 @@ export default function AdminMetrics() {
       setMetricNames(names);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "AdminMetrics.loadData",
         },

--- a/src/pages/admin/news/index.tsx
+++ b/src/pages/admin/news/index.tsx
@@ -40,6 +40,7 @@ import { Button } from '@/components/ui/button';
 import { useAuthenticatedSupabase } from '@/lib/supabase';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 import {
   getNewsDashboardTabs,
   getNewsArticles,
@@ -226,7 +227,7 @@ const AdminNewsDashboard = () => {
         setActiveFeedTab(tabsData[0].slug);
       }
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.fetchData',
       });
     } finally {
@@ -261,7 +262,7 @@ const AdminNewsDashboard = () => {
       const articlesData = await getNewsArticles(options, supabase);
       setArticles(articlesData);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.fetchArticles',
       });
     } finally {
@@ -321,7 +322,7 @@ const AdminNewsDashboard = () => {
       results.forEach(r => newColumnArticles[r.id] = r.articles);
       setColumnArticles(newColumnArticles);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.fetchAllColumnArticles',
       });
     } finally {
@@ -341,7 +342,7 @@ const AdminNewsDashboard = () => {
       const articles = await fetchColumnArticles(config);
       setColumnArticles(prev => ({ ...prev, [config.id]: articles }));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.fetchSingleColumnArticles',
       });
     } finally {
@@ -398,7 +399,7 @@ const AdminNewsDashboard = () => {
       const statsData = await getNewsStats(supabase);
       setStats(statsData);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleMarkRead',
       });
     }
@@ -410,7 +411,7 @@ const AdminNewsDashboard = () => {
       await toggleArticleBookmark(id, !isBookmarked, supabase);
       setArticles(prev => prev.map(a => a.id === id ? { ...a, is_bookmarked: !isBookmarked } : a));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleToggleBookmark',
       });
     }
@@ -423,7 +424,7 @@ const AdminNewsDashboard = () => {
       setArticles(prev => prev.map(a => ids.includes(a.id) ? { ...a, is_curated: true } : a));
       setSelectedIds(new Set());
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleCurate',
       });
     }
@@ -436,7 +437,7 @@ const AdminNewsDashboard = () => {
       setArticles(prev => prev.filter(a => !ids.includes(a.id)));
       setSelectedIds(new Set());
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleArchive',
       });
     }
@@ -473,7 +474,7 @@ const AdminNewsDashboard = () => {
       const statsData = await getNewsStats(supabase);
       setStats(statsData);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleCurateSingle',
       });
     }
@@ -522,7 +523,7 @@ const AdminNewsDashboard = () => {
       await deleteNewsSource(id, supabase);
       setSources(prev => prev.filter(s => s.id !== id));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleSourceDelete',
       });
     }
@@ -571,7 +572,7 @@ const AdminNewsDashboard = () => {
       setFilters(prev => [created, ...prev]);
       setNewFilterValue('');
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleAddFilter',
       });
     } finally {
@@ -585,7 +586,7 @@ const AdminNewsDashboard = () => {
       const updated = await updateNewsFilter(filter.id, { is_active: !filter.is_active }, supabase);
       setFilters(prev => prev.map(f => f.id === filter.id ? updated : f));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleToggleFilter',
       });
     }
@@ -597,7 +598,7 @@ const AdminNewsDashboard = () => {
       await deleteNewsFilter(id, supabase);
       setFilters(prev => prev.filter(f => f.id !== id));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleDeleteFilter',
       });
     }
@@ -631,7 +632,7 @@ const AdminNewsDashboard = () => {
 
       resetTabForm();
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleTabSubmit',
       });
     }
@@ -643,7 +644,7 @@ const AdminNewsDashboard = () => {
       await deleteNewsDashboardTab(tab.id, supabase);
       setFeedTabs(prev => prev.filter(t => t.id !== tab.id));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleTabDelete',
       });
     }
@@ -655,7 +656,7 @@ const AdminNewsDashboard = () => {
       const updated = await updateNewsDashboardTab(tab.id, { is_active: !tab.is_active }, supabase);
       setFeedTabs(prev => prev.map(t => t.id === tab.id ? updated : t));
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleTabToggleActive',
       });
     }
@@ -703,7 +704,7 @@ const AdminNewsDashboard = () => {
     try {
       await reorderNewsDashboardTabs(feedTabs.map(t => t.id), supabase);
     } catch (error) {
-      captureException(error instanceof Error ? error : new Error(String(error)), {
+      captureException(toError(error), {
         context: 'AdminNewsDashboard.handleDragEnd',
       });
     }

--- a/src/pages/admin/platform/Dashboard.tsx
+++ b/src/pages/admin/platform/Dashboard.tsx
@@ -14,6 +14,7 @@ import AdminLayout from "@/components/AdminLayout";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 interface PlatformStats {
   total_tenants: number;
@@ -38,7 +39,7 @@ const PlatformDashboard = () => {
         if (error) throw error;
         setStats(data as PlatformStats);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "PlatformDashboard.fetchStats",
         });
       } finally {

--- a/src/pages/admin/platform/TenantDetail.tsx
+++ b/src/pages/admin/platform/TenantDetail.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import type { Tenant } from "@/lib/schemas";
 
 const TenantDetailPage = () => {
@@ -39,7 +40,7 @@ const TenantDetailPage = () => {
         if (error) throw error;
         setTenant(data as Tenant);
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "TenantDetail.fetch",
         });
       } finally {
@@ -62,7 +63,7 @@ const TenantDetailPage = () => {
       if (error) throw error;
       setTenant({ ...tenant, is_active: !tenant.is_active });
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "TenantDetail.toggleStatus",
       });
     } finally {

--- a/src/pages/admin/platform/TenantList.tsx
+++ b/src/pages/admin/platform/TenantList.tsx
@@ -14,6 +14,7 @@ import { Badge } from "@/components/ui/badge";
 import { useAuthenticatedSupabase } from "@/lib/supabase";
 import { useSEO } from "@/lib/seo";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import type { Tenant } from "@/lib/schemas";
 
 const PAGE_SIZE = 20;
@@ -39,7 +40,7 @@ const TenantListPage = () => {
       if (error) throw error;
       setTenants((data as Tenant[]) || []);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "TenantList.fetch",
       });
     } finally {
@@ -68,7 +69,7 @@ const TenantListPage = () => {
         ),
       );
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "TenantList.toggleStatus",
       });
     } finally {

--- a/src/pages/admin/projects/editor.tsx
+++ b/src/pages/admin/projects/editor.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/supabase-queries';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 type ProjectFormData = Omit<Project, 'id' | 'created_at' | 'updated_at'>;
 
@@ -71,7 +72,7 @@ const ProjectEditor = () => {
       });
       setAutoSlug(false);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'ProjectEditor.fetchProject' });
+      captureException(toError(err), { context: 'ProjectEditor.fetchProject' });
       setError('Project not found');
     } finally {
       setIsLoading(false);
@@ -141,7 +142,7 @@ const ProjectEditor = () => {
         status,
       }));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'ProjectEditor.saveProject' });
+      captureException(toError(err), { context: 'ProjectEditor.saveProject' });
       setError('Failed to save project. Make sure you have permission.');
     } finally {
       setIsSaving(false);

--- a/src/pages/admin/projects/index.tsx
+++ b/src/pages/admin/projects/index.tsx
@@ -10,6 +10,7 @@ import { getProjects, deleteProject, bulkDeleteProjects, bulkUpdateProjectStatus
 import { formatDate } from '@/lib/markdown';
 import { useSEO } from '@/lib/seo';
 import { captureException } from '@/lib/sentry';
+import { toError } from '@/lib/errors';
 
 const AdminProjectsList = () => {
   useSEO({ title: 'Manage Projects', noIndex: true });
@@ -31,7 +32,7 @@ const AdminProjectsList = () => {
       const data = await getProjects(true, supabase);
       setProjects(data);
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AdminProjects.fetchProjects' });
+      captureException(toError(err), { context: 'AdminProjects.fetchProjects' });
     } finally {
       setIsLoading(false);
     }
@@ -49,7 +50,7 @@ const AdminProjectsList = () => {
       await deleteProject(id, supabase);
       setProjects(projects.filter((p) => p.id !== id));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AdminProjects.deleteProject' });
+      captureException(toError(err), { context: 'AdminProjects.deleteProject' });
     } finally {
       setDeletingId(null);
     }
@@ -83,7 +84,7 @@ const AdminProjectsList = () => {
       setProjects(projects.filter((p) => !selectedIds.has(p.id)));
       setSelectedIds(new Set());
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AdminProjects.bulkDelete' });
+      captureException(toError(err), { context: 'AdminProjects.bulkDelete' });
     } finally {
       setIsBulkProcessing(false);
     }
@@ -98,7 +99,7 @@ const AdminProjectsList = () => {
       ));
       setSelectedIds(new Set());
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AdminProjects.bulkPublish' });
+      captureException(toError(err), { context: 'AdminProjects.bulkPublish' });
     } finally {
       setIsBulkProcessing(false);
     }
@@ -113,7 +114,7 @@ const AdminProjectsList = () => {
       ));
       setSelectedIds(new Set());
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), { context: 'AdminProjects.bulkUnpublish' });
+      captureException(toError(err), { context: 'AdminProjects.bulkUnpublish' });
     } finally {
       setIsBulkProcessing(false);
     }

--- a/src/pages/admin/settings/PlatformSettings.tsx
+++ b/src/pages/admin/settings/PlatformSettings.tsx
@@ -35,6 +35,7 @@ import { getAnalyticsSettings, saveAnalyticsSettings } from "@/lib/analytics";
 import { useSEO, clearSEOCache } from "@/lib/seo";
 import { getSiteContent, upsertSiteContent } from "@/lib/supabase-queries";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { useI18n } from "@/lib/i18n";
 
 interface SEOSettings {
@@ -207,7 +208,7 @@ const PlatformSettings = () => {
           setSeo({ ...defaultSEO, ...parsed });
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Settings.loadSEO",
         });
       }
@@ -223,7 +224,7 @@ const PlatformSettings = () => {
           }
         }
       } catch (err) {
-        captureException(err instanceof Error ? err : new Error(String(err)), {
+        captureException(toError(err), {
           context: "Settings.loadAnalytics",
         });
       }
@@ -254,7 +255,7 @@ const PlatformSettings = () => {
     } catch (err) {
       setSeoStatus("error");
       setSeoMessage("Failed");
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Settings.saveSEO",
       });
     }
@@ -361,7 +362,7 @@ const PlatformSettings = () => {
     } catch (err) {
       setGaStatus("error");
       setGaMessage("Failed");
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "Settings.saveAnalytics",
       });
     }

--- a/src/pages/admin/settings/sections/BrandSection.tsx
+++ b/src/pages/admin/settings/sections/BrandSection.tsx
@@ -6,6 +6,7 @@ import { uploadFile } from "@/lib/supabase-queries";
 import { useTenantSupabase } from "@/lib/supabase";
 import { useTenant } from "@/lib/tenant";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import type { TenantBranding } from "@/lib/tenant-settings";
 
 const BrandSection = () => {
@@ -32,7 +33,7 @@ const BrandSection = () => {
       const url = await uploadFile(file, path, supabase, tenant.id);
       setBranding((prev) => ({ ...prev, [field]: url }));
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: `BrandSection.upload.${field}`,
       });
     } finally {

--- a/src/pages/admin/settings/sections/PlanSection.tsx
+++ b/src/pages/admin/settings/sections/PlanSection.tsx
@@ -14,6 +14,7 @@ import { useAIUsage } from "@/hooks/useAIUsage";
 import { useTenant } from "@/lib/tenant";
 import { type PlanTier } from "@/lib/billing";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 const PLAN_DISPLAY: Record<PlanTier, { label: string; color: string }> = {
   free: { label: "Free", color: "bg-gray-500/20 text-gray-400" },
@@ -56,7 +57,7 @@ const PlanSection = () => {
         throw new Error(data.error || "Failed to open portal");
       }
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "PlanSection.openStripePortal",
       });
     } finally {
@@ -81,7 +82,7 @@ const PlanSection = () => {
         window.location.href = data.url;
       }
     } catch (err) {
-      captureException(err instanceof Error ? err : new Error(String(err)), {
+      captureException(toError(err), {
         context: "PlanSection.openCheckout",
       });
     }

--- a/src/pages/admin/site-builder/editor.tsx
+++ b/src/pages/admin/site-builder/editor.tsx
@@ -29,6 +29,7 @@ import type {
   SiteBuilderPageVersion,
 } from "@/lib/schemas";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 import { PageCanvas } from "@/components/site-builder/PageCanvas";
 import { ComponentLibrary } from "@/components/site-builder/ComponentLibrary";
 import { PropertyEditor } from "@/components/site-builder/PropertyEditor";
@@ -92,7 +93,7 @@ export default function SiteBuilderEditor() {
       }
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderEditor.loadData",
         },
@@ -149,7 +150,7 @@ export default function SiteBuilderEditor() {
       toast.success("Page saved successfully!");
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderEditor.handleSave",
         },
@@ -185,7 +186,7 @@ export default function SiteBuilderEditor() {
       setComponents([...components, newComponent]);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderEditor.handleAddComponent",
         },
@@ -212,7 +213,7 @@ export default function SiteBuilderEditor() {
       setSelectedComponent(updated);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderEditor.handleUpdateComponent",
         },
@@ -232,7 +233,7 @@ export default function SiteBuilderEditor() {
       }
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderEditor.handleDeleteComponent",
         },
@@ -252,7 +253,7 @@ export default function SiteBuilderEditor() {
       setComponents([...components, duplicated]);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderEditor.handleDuplicateComponent",
         },
@@ -274,7 +275,7 @@ export default function SiteBuilderEditor() {
       setComponents(reorderedComponents);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderEditor.handleReorder",
         },
@@ -292,7 +293,7 @@ export default function SiteBuilderEditor() {
       loadData();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderEditor.handleCreateVersion",
         },

--- a/src/pages/admin/site-builder/index.tsx
+++ b/src/pages/admin/site-builder/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/site-builder-queries";
 import type { SiteBuilderPage } from "@/lib/schemas";
 import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
 
 export default function SiteBuilderIndex() {
   useSEO({ title: "Site Builder", noIndex: true });
@@ -37,7 +38,7 @@ export default function SiteBuilderIndex() {
       setPages(data);
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderIndex.loadPages",
         },
@@ -56,7 +57,7 @@ export default function SiteBuilderIndex() {
       setPages(pages.filter((p) => p.id !== id));
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderIndex.handleDelete",
         },
@@ -77,7 +78,7 @@ export default function SiteBuilderIndex() {
       loadPages();
     } catch (error) {
       captureException(
-        error instanceof Error ? error : new Error(String(error)),
+        toError(error),
         {
           context: "SiteBuilderIndex.handleTogglePublish",
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes production Sentry issue [`Error: [object Object]`](https://mejohncorg.sentry.io/issues/7685890837/) (event `4517db516d9b4ad78ec25983ff95260b` on `/`).

Supabase `PostgrestError` is a plain object, so catch sites that did `new Error(String(err))` recorded `[object Object]`. Missing `site_content` keys (including `projects`) used `.single()` and returned HTTP 406 / PGRST116.

**Changes**
- Add `toError(unknown)` in `src/lib/errors.ts` so PostgREST-shaped `{ message, code, details, hint, status }` become a real `Error` message
- `captureException` now accepts `unknown` and always passes `toError(error)` to Sentry
- Replace `err instanceof Error ? err : new Error(String(err))` call sites with `toError(...)`
- `getSiteContent` uses `.maybeSingle()`; 0-row / PGRST116 returns `null` (no throw, no Sentry). Real errors throw `SupabaseQueryError`
- Logger captures the original `Error` instead of `new Error(entry.error.message)`
- Homepage hero/SEO still fall back to defaults on fetch failure; Sentry now gets the real message (e.g. `Failed to fetch` or `JSON object requested, multiple (or no) rows returned` plus code)

Does not add a `projects` row, change RLS, or touch talks / AI Products.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65468fb3-7e2b-4bf0-9f66-65e32132bf21?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65468fb3-7e2b-4bf0-9f66-65e32132bf21&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

