### PR TITLE
Rewrite AI Products as personal recruiting copy

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -15,18 +15,18 @@ John builds governed AI products and MSP operations systems. Background in enter
 
 ## AI Products (most recent portfolio item)
 
-centrexIT’s portfolio is a developing operating system for how an MSP senses demand, chooses investments, governs AI, builds safely, completes work, and learns.
+Personal recruiting portfolio of AI work John led or shipped at centrexIT — not a company product catalog.
 
-Products with full briefs:
-- Client Toolbox (owner: John) — evidence-backed vITM workspace
-- Service Desk Toolbox + Incident Buddy (owner: Toby) — technician automations and 10-domain investigations
-- Iris (owner: John) — governed employee AI / agent OS
-- Proxima (shared platform) — governed agentic engineering, draft-mode
-- accessAI (R&D) — AI control plane, pre-GA as a universal control plane
+Products:
+- Client Toolbox — evidence-preserving client reviews a vITM can explain
+- Service Desk Toolbox + Incident Buddy — technician automations and an investigation assistant, built with the service desk team
+- Iris — company-grounded assistant with approval-gated action
+- Proxima — draft-mode delivery: reviewed branches, draft PRs, green CI
+- accessAI — AI control plane, pre-GA as a universal control plane
 
-Named seams without full briefs: Cadre, Spark, Spot, Navigate, Vantage, Knowledge, AI Triage.
+Also in the loop (not full product pages): Cadre, Spark, Spot, Navigate, Vantage, Knowledge, AI Triage.
 
-Honest claim: coherent portfolio with strong product depth and a credible control-plane architecture. Not yet one uniformly integrated or enforced platform. accessAI is substantial but pre-GA. Agents may advise, draft, test, and reconcile. Humans retain merge, deploy, external-send, destructive action, billing, and autonomy promotion.
+Honest claim: a developing set of substantial products, not yet one uniformly integrated platform. accessAI is substantial but pre-GA. Agents advise, draft, and test. People keep merge, deploy, and production authority.
 
 ## Endpoint Logistics
 

--- a/src/components/ProjectTimeline.test.tsx
+++ b/src/components/ProjectTimeline.test.tsx
@@ -118,7 +118,7 @@ describe("Success Roadmap tracks", () => {
     expect(logistics).toHaveAttribute("aria-selected", "false");
     expect(
       await screen.findByRole("heading", {
-        name: /developing operating system/i,
+        name: /governed ai for the msp work i ship/i,
       }),
     ).toBeInTheDocument();
   });
@@ -139,12 +139,33 @@ describe("Success Roadmap tracks", () => {
 
 describe("AI Products briefs", () => {
   it("includes the portfolio thesis and Client Toolbox", () => {
-    expect(portfolioThesis.lead).toMatch(/developing operating system/i);
+    expect(portfolioThesis.lead).toMatch(/not yet one uniformly integrated/i);
+    expect(portfolioThesis.lead).toMatch(/pre-GA/i);
     expect(portfolioThesis.honestClaim).toMatch(/not yet one uniformly integrated/i);
     const toolbox = productBriefs.find((brief) => brief.id === "client-toolbox");
-    expect(toolbox?.owner).toBe("John");
-    expect(toolbox?.capabilities).toHaveLength(6);
-    expect(toolbox?.flow).toHaveLength(5);
+    expect(toolbox).toBeDefined();
+    expect(toolbox).not.toHaveProperty("owner");
+    expect(toolbox?.capabilities.length).toBeGreaterThanOrEqual(3);
+    expect(toolbox?.capabilities.length).toBeLessThanOrEqual(5);
+  });
+
+  it("keeps recruiter-length briefs and an honest pre-GA split", () => {
+    const leadWords = portfolioThesis.lead.trim().split(/\s+/).length;
+    expect(leadWords).toBeGreaterThanOrEqual(40);
+    expect(leadWords).toBeLessThanOrEqual(80);
+
+    for (const brief of productBriefs) {
+      expect(brief.tagline.trim().split(/\s+/).length).toBeLessThanOrEqual(40);
+      expect(brief.capabilities.length).toBeLessThanOrEqual(5);
+      expect(brief.stack.length).toBeGreaterThanOrEqual(4);
+      expect(brief.stack.length).toBeLessThanOrEqual(8);
+      expect(brief).not.toHaveProperty("owner");
+      expect(brief).not.toHaveProperty("readiness");
+    }
+
+    const accessAi = productBriefs.find((brief) => brief.id === "accessai");
+    expect(accessAi?.preGa.length).toBeGreaterThan(0);
+    expect(accessAi?.tagline).toMatch(/pre-GA/i);
   });
 
   it("does not invent full briefs for named seams", () => {
@@ -185,16 +206,19 @@ describe("AI Products briefs", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: /developing operating system/i }),
+      screen.getByRole("heading", { name: /governed ai for the msp work i ship/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/14 normalized briefs/i)).toBeInTheDocument();
+    expect(screen.queryByText(/14 normalized briefs/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/readiness ledger/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/owner toby/i)).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Client Toolbox" })).toHaveAttribute(
       "aria-selected",
       "true",
     );
     expect(
-      screen.getByText(/Evidence-backed vITM workspace/i),
+      screen.getByText(/vITM workspace that turns identity/i),
     ).toBeInTheDocument();
+    expect(screen.getByText(/What I shipped/i)).toBeInTheDocument();
   });
 });
 

--- a/src/components/portfolio/AiProductsPanel.tsx
+++ b/src/components/portfolio/AiProductsPanel.tsx
@@ -6,7 +6,6 @@ import {
   portfolioThesis,
   type LoopStage,
   type ProductBrief,
-  type ReadinessLedger,
 } from "@/data/ai-products";
 import type { TimelineItem } from "@/data/timeline-tracks";
 import { useReducedMotion } from "@/lib/reduced-motion";
@@ -55,19 +54,19 @@ export default function AiProductsPanel({ entries }: AiProductsPanelProps) {
         <div className="flex items-end justify-between gap-4 mb-4">
           <div>
             <span className="font-mono text-xs text-muted-foreground uppercase tracking-widest">
-              Product briefs
+              Products
             </span>
             <p className="text-sm text-muted-foreground mt-1">
-              Five products with named owners. Cadre, Spark, Spot, Navigate,
-              Vantage, Knowledge, and AI Triage appear as seams in the loop
-              above — not as full briefs.
+              Five products I led or shipped. Cadre, Spark, Spot, Navigate,
+              Vantage, Knowledge, and AI Triage stay in the loop as named seams
+              — not a second catalog.
             </p>
           </div>
         </div>
 
         <div
           role="tablist"
-          aria-label="AI product briefs"
+          aria-label="AI products"
           className="flex flex-wrap gap-2 mb-6"
         >
           {briefs.map((brief) => {
@@ -155,7 +154,7 @@ function ThesisCard({
       }}
     >
       <span className="font-mono text-xs text-primary uppercase tracking-widest">
-        Portfolio thesis
+        What I build
       </span>
       <h3
         id="ai-products-thesis"
@@ -202,56 +201,13 @@ function ThesisCard({
         </ol>
       </div>
 
-      <p className="text-foreground leading-relaxed mb-3">{thesis.cohesive}</p>
-      <p className="text-sm text-muted-foreground leading-relaxed mb-8">
-        {thesis.honestClaim}
+      <p className="text-foreground leading-relaxed mb-3">{thesis.honestClaim}</p>
+      <p className="text-sm text-muted-foreground leading-relaxed mb-6">
+        {thesis.agentAuthority}
       </p>
 
-      <div className="grid md:grid-cols-2 gap-6 mb-8">
-        <div>
-          <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
-            Layers
-          </h4>
-          <ul className="space-y-2">
-            {thesis.layers.map((layer) => (
-              <li key={layer.name} className="text-sm">
-                <span className="font-semibold text-foreground">
-                  {layer.name}
-                </span>
-                <span className="text-muted-foreground"> — {layer.detail}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
-            Guardrails
-          </h4>
-          <ul className="flex flex-wrap gap-2 mb-4">
-            {thesis.guardrails.map((item) => (
-              <li
-                key={item}
-                className="text-xs px-2 py-1 rounded border border-border text-foreground"
-              >
-                {item}
-              </li>
-            ))}
-          </ul>
-          <p className="text-sm text-muted-foreground leading-relaxed">
-            {thesis.agentAuthority}
-          </p>
-        </div>
-      </div>
-
-      <p className="text-sm text-foreground mb-6">
-        <span className="font-semibold">Current truth. </span>
-        {thesis.currentTruth}
-      </p>
-
-      <ReadinessLedgerBlock ledger={thesis.operatingEvidence} />
-
-      <p className="text-xs text-muted-foreground mt-6">
-        Named seams: {thesis.namedSeams.join(" · ")}
+      <p className="text-xs text-muted-foreground">
+        Also in the loop: {thesis.namedSeams.join(" · ")}
       </p>
     </motion.section>
   );
@@ -269,12 +225,7 @@ function ProductBriefCard({
       className="p-6 md:p-8 rounded-xl border bg-card/50 backdrop-blur-sm"
       style={{ borderColor: "hsl(var(--border))" }}
     >
-      <div className="flex flex-wrap items-baseline justify-between gap-3 mb-3">
-        <h3 className="text-2xl font-black text-foreground">{brief.name}</h3>
-        <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
-          Owner {brief.owner}
-        </span>
-      </div>
+      <h3 className="text-2xl font-black text-foreground mb-3">{brief.name}</h3>
       <p className="text-muted-foreground leading-relaxed mb-4">
         {brief.tagline}
       </p>
@@ -293,8 +244,8 @@ function ProductBriefCard({
       <LoopMarker stages={brief.loopStages} primary={theme.primary} />
 
       <p className="text-sm text-foreground leading-relaxed my-6">
-        <span className="font-semibold">Primary. </span>
-        {brief.primaryCapability}
+        <span className="font-semibold">What I shipped. </span>
+        {brief.shipped}
       </p>
 
       <div className="grid md:grid-cols-2 gap-8 mb-8">
@@ -313,55 +264,18 @@ function ProductBriefCard({
             ))}
           </ol>
         </div>
-        <div className="space-y-6">
-          <div>
-            <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
-              Flow
-            </h4>
-            <p className="text-sm text-foreground">
-              {brief.flow.join(" → ")}
-            </p>
-          </div>
-          <div>
-            <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
-              Stack
-            </h4>
-            <p className="text-sm text-muted-foreground">{brief.stack.join(" · ")}</p>
-          </div>
+        <div>
+          <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
+            Stack
+          </h4>
+          <p className="text-sm text-muted-foreground">{brief.stack.join(" · ")}</p>
         </div>
       </div>
 
-      {(brief.engineeringNotes || brief.securityNotes) && (
-        <div className="grid md:grid-cols-2 gap-6 mb-8">
-          {brief.engineeringNotes && (
-            <div>
-              <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-2">
-                Engineering
-              </h4>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                {brief.engineeringNotes}
-              </p>
-            </div>
-          )}
-          {brief.securityNotes && (
-            <div>
-              <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-2">
-                Security
-              </h4>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                {brief.securityNotes}
-              </p>
-            </div>
-          )}
-        </div>
-      )}
-
-      <ReadinessLedgerBlock ledger={brief.readiness} />
-
-      <div className="grid md:grid-cols-3 gap-4 mt-6">
+      <div className="grid md:grid-cols-3 gap-4">
         <MaturityColumn label="Proven today" items={brief.proven} />
-        <MaturityColumn label="Pre-GA" items={brief.preGa} />
-        <MaturityColumn label="Target seam" items={brief.target} />
+        <MaturityColumn label="Still coming" items={brief.preGa} />
+        <MaturityColumn label="Later" items={brief.target} />
       </div>
     </article>
   );
@@ -389,31 +303,6 @@ function LoopMarker({
         );
       })}
     </p>
-  );
-}
-
-function ReadinessLedgerBlock({ ledger }: { ledger: ReadinessLedger }) {
-  const rows: [string, string][] = [
-    ["Lifecycle", ledger.lifecycle],
-    ["Adoption", ledger.adoption],
-    ["Production", ledger.production],
-    ["Ownership", ledger.ownership],
-    ["Risk", ledger.risk],
-  ];
-  return (
-    <div>
-      <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
-        Readiness ledger
-      </h4>
-      <dl className="grid sm:grid-cols-2 gap-x-6 gap-y-2">
-        {rows.map(([label, value]) => (
-          <div key={label} className="text-sm">
-            <dt className="inline font-semibold text-foreground">{label}. </dt>
-            <dd className="inline text-muted-foreground">{value}</dd>
-          </div>
-        ))}
-      </dl>
-    </div>
   );
 }
 

--- a/src/components/portfolio/WorkTab.test.tsx
+++ b/src/components/portfolio/WorkTab.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { KeyboardFocusProvider } from "@/lib/keyboard-focus";
+import WorkTab, {
+  defaultCaseStudies,
+  metricSubtitle,
+} from "@/components/portfolio/WorkTab";
+
+vi.mock("@/lib/supabase", () => ({
+  useSupabaseClient: () => null,
+}));
+
+vi.mock("@/lib/supabase-queries", () => ({
+  getCaseStudies: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock("@/components/ProjectTimeline", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/Experience", () => ({
+  default: () => null,
+}));
+
+function renderWorkTab() {
+  return render(
+    <KeyboardFocusProvider>
+      <WorkTab onRequestFocusUp={() => undefined} />
+    </KeyboardFocusProvider>,
+  );
+}
+
+describe("Results case studies", () => {
+  it("leads with the sanctioned +133% card and keeps four public-safe stories", () => {
+    expect(defaultCaseStudies.map((study) => study.metric)).toEqual([
+      "+133%",
+      "2 min",
+      "clean",
+      "50%",
+    ]);
+    expect(defaultCaseStudies[0].title).toMatch(/automation hours/i);
+    expect(defaultCaseStudies[1].after).toMatch(/Immy\.Bot/);
+    expect(defaultCaseStudies[1].after).toMatch(/Rewst/);
+    expect(defaultCaseStudies.some((study) => study.metric === "100%")).toBe(
+      false,
+    );
+  });
+
+  it("does not leak internal strategy notes", () => {
+    const blob = JSON.stringify(defaultCaseStudies);
+    expect(blob).not.toMatch(/184|429|700k|coworker|acquisition|promotion/i);
+    expect(blob).not.toMatch(/no one else performs/i);
+    expect(blob).not.toMatch(/manaual|iommy/i);
+  });
+
+  it("derives the metric subtitle instead of always saying improvement", () => {
+    expect(metricSubtitle("+133%")).toBe("improvement");
+    expect(metricSubtitle("50%")).toBe("improvement");
+    expect(metricSubtitle("2 min")).toBe("from 45 min");
+    expect(metricSubtitle("clean")).toBeNull();
+  });
+
+  it("renders first-person Work intro and the four Results cards", async () => {
+    renderWorkTab();
+
+    expect(
+      screen.getByText(/latest work I led or shipped/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/John owns or leads/i)).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", {
+        name: "Automation hours, same billed labor",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2 min")).toBeInTheDocument();
+    expect(screen.getByText("from 45 min")).toBeInTheDocument();
+    expect(screen.getByText("clean")).toBeInTheDocument();
+    expect(screen.queryByText(/never been higher/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/portfolio/WorkTab.tsx
+++ b/src/components/portfolio/WorkTab.tsx
@@ -1,38 +1,64 @@
-import { useRef, useEffect, useCallback, useState } from 'react';
-import { motion } from 'framer-motion';
-import ProjectTimeline from '@/components/ProjectTimeline';
-import Experience from '@/components/Experience';
-import { useKeyboardFocus } from '@/lib/keyboard-focus';
-import { useSupabaseClient } from '@/lib/supabase';
-import { getCaseStudies, type CaseStudy } from '@/lib/supabase-queries';
-import { captureException } from '@/lib/sentry';
-import { toError } from '@/lib/errors';
-import { Loader2 } from 'lucide-react';
-import { useReducedMotion } from '@/lib/reduced-motion';
-import type { TimelineTrackId } from '@/data/timeline-tracks';
+import { useRef, useEffect, useCallback, useState } from "react";
+import { motion } from "framer-motion";
+import ProjectTimeline from "@/components/ProjectTimeline";
+import Experience from "@/components/Experience";
+import { useKeyboardFocus } from "@/lib/keyboard-focus";
+import { useSupabaseClient } from "@/lib/supabase";
+import { getCaseStudies, type CaseStudy } from "@/lib/supabase-queries";
+import { captureException } from "@/lib/sentry";
+import { toError } from "@/lib/errors";
+import { Loader2 } from "lucide-react";
+import { useReducedMotion } from "@/lib/reduced-motion";
+import type { TimelineTrackId } from "@/data/timeline-tracks";
 
-// Fallback case studies if database is empty
-const defaultCaseStudies = [
-  {
-    metric: "70%",
-    title: "Provisioning Automation",
-    before: "Manual parsing of intake forms across 20+ client domains",
-    after: "End-to-end OCR + Graph API pipeline with zero manual parsing",
-  },
-  {
-    metric: "2→0",
-    title: "Shipping Automation",
-    before: "Manual inventory matching and label generation (2 days)",
-    after: "Same-day: auto-matched devices, ShipEngine labels, Teams notifications",
-  },
-];
-
-interface CaseStudyItem {
+export interface CaseStudyItem {
   metric: string;
   title: string;
   before: string;
   after: string;
 }
+
+/** Subtitle under the huge metric. Percent / +delta → improvement; minutes → baseline; else omit. */
+export function metricSubtitle(metric: string): string | null {
+  const value = metric.trim();
+  if (value.includes("%") || value.startsWith("+")) return "improvement";
+  if (/min/i.test(value)) return "from 45 min";
+  return null;
+}
+
+// Fallback if public.case_studies is empty. Copy matches the 20260822040000 seed.
+export const defaultCaseStudies: CaseStudyItem[] = [
+  {
+    metric: "+133%",
+    title: "Automation hours, same billed labor",
+    before:
+      "More automations used to mean more engineer hours. The desk was already busy.",
+    after:
+      "Governed automations and agents carry the extra load. Automation hours are up 133% while billed hours stayed essentially flat. Humans still approve writeback and anything that spends money.",
+  },
+  {
+    metric: "2 min",
+    title: "User provisioning",
+    before:
+      "A fresh machine was 45 minutes of manual onboarding, config, and babysitting.",
+    after:
+      "Plug in, run the playbook, QC. About two minutes. Immy.Bot and Rewst are the stack; people still do the check.",
+  },
+  {
+    metric: "clean",
+    title: "Inventory billing",
+    before:
+      "Month-end billing lived in Excel. Fields were optional, access was whoever had the file, and a missed row meant a missed invoice.",
+    after:
+      "A governed SharePoint list with required fields and role-based access. The close is a process, not a hunt through a spreadsheet.",
+  },
+  {
+    metric: "50%",
+    title: "Faster inventory updates",
+    before: "Finding a device meant hunting through SharePoint folders.",
+    after: "A three-digit lookup in Teams. Half the time.",
+  },
+];
 
 interface WorkTabProps {
   onRequestFocusUp: () => void;
@@ -49,11 +75,12 @@ export default function WorkTab({
   const { focusLevel, setFocusLevel } = useKeyboardFocus();
   const supabase = useSupabaseClient();
   const prefersReducedMotion = useReducedMotion();
-  const [caseStudies, setCaseStudies] = useState<CaseStudyItem[]>(defaultCaseStudies);
+  const [caseStudies, setCaseStudies] =
+    useState<CaseStudyItem[]>(defaultCaseStudies);
   const [isLoading, setIsLoading] = useState(true);
 
-  const timelineFocused = focusLevel === 'timeline';
-  const workHistoryFocused = focusLevel === 'workHistory';
+  const timelineFocused = focusLevel === "timeline";
+  const workHistoryFocused = focusLevel === "workHistory";
 
   // Fetch case studies from database
   useEffect(() => {
@@ -61,22 +88,23 @@ export default function WorkTab({
       try {
         const data = await getCaseStudies(supabase);
         if (data && data.length > 0) {
-          setCaseStudies(data.map((study: CaseStudy) => ({
-            metric: study.metric,
-            title: study.title,
-            before: study.before_content,
-            after: study.after_content,
-          })));
+          setCaseStudies(
+            data.map((study: CaseStudy) => ({
+              metric: study.metric,
+              title: study.title,
+              before: study.before_content,
+              after: study.after_content,
+            })),
+          );
         }
       } catch (err) {
-        captureException(toError(err), { context: 'WorkTab.fetchCaseStudies' });
+        captureException(toError(err), { context: "WorkTab.fetchCaseStudies" });
         // Keep default case studies on error
       } finally {
         setIsLoading(false);
       }
     }
     fetchData();
-     
   }, [supabase]);
 
   const timelineRequestFocusUp = useCallback(() => {
@@ -84,15 +112,18 @@ export default function WorkTab({
   }, [onRequestFocusUp]);
 
   const focusWorkHistory = useCallback(() => {
-    setFocusLevel('workHistory');
-    workHistoryRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setFocusLevel("workHistory");
+    workHistoryRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
   }, [setFocusLevel]);
 
   const workHistoryRequestFocusUp = useCallback(() => {
-    setFocusLevel('timeline');
-    const mainEl = document.querySelector('main');
+    setFocusLevel("timeline");
+    const mainEl = document.querySelector("main");
     if (mainEl) {
-      mainEl.scrollTo({ top: 0, behavior: 'smooth' });
+      mainEl.scrollTo({ top: 0, behavior: "smooth" });
     }
   }, [setFocusLevel]);
 
@@ -100,18 +131,21 @@ export default function WorkTab({
     if (!workHistoryFocused) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      ) {
         return;
       }
-      if (e.key === 'ArrowUp') {
+      if (e.key === "ArrowUp") {
         e.preventDefault();
         e.stopImmediatePropagation();
         workHistoryRequestFocusUp();
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown, true);
-    return () => window.removeEventListener('keydown', handleKeyDown, true);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
   }, [workHistoryFocused, workHistoryRequestFocusUp]);
 
   return (
@@ -120,7 +154,10 @@ export default function WorkTab({
       initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, x: -24 }}
       animate={{ opacity: 1, x: 0 }}
       exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, x: 24 }}
-      transition={{ duration: prefersReducedMotion ? 0 : 0.3, ease: 'easeInOut' }}
+      transition={{
+        duration: prefersReducedMotion ? 0 : 0.3,
+        ease: "easeInOut",
+      }}
     >
       <div className="mb-12">
         <span className="font-mono text-sm text-primary uppercase tracking-widest">
@@ -130,9 +167,10 @@ export default function WorkTab({
           AI products and endpoint logistics
         </h2>
         <p className="text-muted-foreground max-w-3xl">
-          Two tracks on one roadmap. AI Products is the latest portfolio item —
-          governed MSP apps John owns or leads. Endpoint Logistics keeps the
-          provisioning story from COVID backlog through Autopilot and 3PL.
+          Two tracks on one roadmap. AI Products is the latest work I led or
+          shipped — governed agents and evidence-preserving workflows; accessAI
+          is still pre-GA. Endpoint Logistics keeps the provisioning story from
+          COVID backlog through Autopilot and 3PL.
         </p>
       </div>
 
@@ -163,35 +201,50 @@ export default function WorkTab({
         </div>
       ) : (
         <div className="space-y-12">
-          {caseStudies.map((study, index) => (
-            <motion.div
-              key={index}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.3 + index * 0.1 }}
-              className="grid md:grid-cols-[200px_1fr] gap-8 items-start"
-            >
-              <div>
-                <div className="font-mono text-5xl md:text-6xl font-black text-primary leading-none">
-                  {study.metric}
-                </div>
-                <div className="text-sm text-muted-foreground mt-2">improvement</div>
-              </div>
-              <div>
-                <h3 className="text-xl font-bold text-foreground mb-4">{study.title}</h3>
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div className="border-l-2 border-muted pl-4">
-                    <div className="font-mono text-xs text-muted-foreground uppercase tracking-wider mb-1">Before</div>
-                    <p className="text-muted-foreground text-sm">{study.before}</p>
+          {caseStudies.map((study, index) => {
+            const subtitle = metricSubtitle(study.metric);
+            return (
+              <motion.div
+                key={study.title}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.3 + index * 0.1 }}
+                className="grid md:grid-cols-[200px_1fr] gap-8 items-start"
+              >
+                <div>
+                  <div className="font-mono text-5xl md:text-6xl font-black text-primary leading-none">
+                    {study.metric}
                   </div>
-                  <div className="border-l-2 border-primary pl-4">
-                    <div className="font-mono text-xs text-primary uppercase tracking-wider mb-1">After</div>
-                    <p className="text-foreground text-sm">{study.after}</p>
+                  {subtitle && (
+                    <div className="text-sm text-muted-foreground mt-2">
+                      {subtitle}
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <h3 className="text-xl font-bold text-foreground mb-4">
+                    {study.title}
+                  </h3>
+                  <div className="grid md:grid-cols-2 gap-6">
+                    <div className="border-l-2 border-muted pl-4">
+                      <div className="font-mono text-xs text-muted-foreground uppercase tracking-wider mb-1">
+                        Before
+                      </div>
+                      <p className="text-muted-foreground text-sm">
+                        {study.before}
+                      </p>
+                    </div>
+                    <div className="border-l-2 border-primary pl-4">
+                      <div className="font-mono text-xs text-primary uppercase tracking-wider mb-1">
+                        After
+                      </div>
+                      <p className="text-foreground text-sm">{study.after}</p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </motion.div>
-          ))}
+              </motion.div>
+            );
+          })}
         </div>
       )}
 

--- a/src/data/ai-products.ts
+++ b/src/data/ai-products.ts
@@ -6,32 +6,19 @@ export const LOOP_STAGE_LABELS: Record<LoopStage, string> = {
   sense: "Sense",
   decide: "Decide",
   govern: "Govern",
-  build: "Build+prove",
-  operate: "Operate+learn",
+  build: "Build",
+  operate: "Operate",
 };
-
-export interface ReadinessLedger {
-  lifecycle: string;
-  adoption: string;
-  production: string;
-  ownership: string;
-  risk: string;
-}
 
 export interface ProductBrief {
   id: string;
   name: string;
-  owner: string;
   tagline: string;
   chips: string[];
   loopStages: LoopStage[];
   capabilities: string[];
-  primaryCapability: string;
+  shipped: string;
   stack: string[];
-  flow: string[];
-  engineeringNotes?: string;
-  securityNotes?: string;
-  readiness: ReadinessLedger;
   proven: string[];
   preGa: string[];
   target: string[];
@@ -42,80 +29,46 @@ export interface PortfolioThesis {
   lead: string;
   tags: string[];
   loop: { stage: LoopStage; detail: string }[];
-  cohesive: string;
   honestClaim: string;
-  layers: { name: string; detail: string }[];
-  guardrails: string[];
   agentAuthority: string;
-  currentTruth: string;
-  operatingEvidence: ReadinessLedger;
   namedSeams: string[];
 }
 
 export const portfolioThesis: PortfolioThesis = {
-  title: "A developing operating system for MSP work",
-  lead: "centrexIT’s portfolio is a developing operating system for how an MSP senses demand, chooses investments, governs AI, builds safely, completes work, and learns. Products are substantial today; common contracts, package adoption, and several cross-product governance seams remain pre-GA or target state.",
+  title: "Governed AI for the MSP work I ship",
+  lead: "I build AI products for MSP work: evidence-preserving client reviews, technician assistance, a company-grounded assistant, and a delivery agent that stays in draft until a human merges. These are substantial products I led or shipped at centrexIT — not yet one uniformly integrated platform. accessAI, the shared control plane, is pre-GA.",
   tags: [
-    "14 normalized briefs",
     "Evidence-preserving workflows",
+    "Governed agents",
     "Human production authority",
-    "Shared governance model",
+    "Honest pre-GA claims",
   ],
   loop: [
     {
       stage: "sense",
-      detail:
-        "Spark captures employee/meeting signals; Spot finds client opportunity; Service Desk and AI Triage capture ticket evidence; Client Toolbox assembles client posture; Iris captures employee intent and feedback.",
+      detail: "Pull ticket, meeting, and client signals without dropping the source.",
     },
     {
       stage: "decide",
-      detail:
-        "Client Toolbox → client strategy; Navigate governs company strategy/KPIs; Vantage scores demand, governs PRDs and ROI, assigns ownership, measures realized value.",
+      detail: "Turn that evidence into work a human can defend.",
     },
     {
       stage: "govern",
-      detail:
-        "accessAI is the shared control-plane for identity, models, agents, tools, policy, runs, cost, audit, evaluation, promotion, rollback.",
+      detail: "Decide which identities, models, and agents may run. accessAI is still pre-GA.",
     },
     {
       stage: "build",
-      detail:
-        "Proxima governs delivery automation; Cadre supplies durable threads, paired execution hosts, workspace tools, evaluations, engineering evidence.",
+      detail: "Draft delivery stays in review until CI is green and a person merges.",
     },
     {
       stage: "operate",
-      detail:
-        "Service Desk Toolbox completes technician work; AI Triage improves routing; Knowledge governs documentation; Iris orchestrates context, durable work, specialists, approval-gated action.",
+      detail: "Technicians finish the work; writeback waits for a human.",
     },
   ],
-  cohesive:
-    "One governed operating loop from human signal to proven value. The defensible asset is not a chatbot. It is domain-specific apps + evidence-preserving decision flows + governed AI + agentic delivery inside deterministic controls + shared human-control design language.",
   honestClaim:
-    "Coherent portfolio with strong product depth and a credible control-plane architecture — not yet one uniformly integrated or enforced platform.",
-  layers: [
-    { name: "Signal", detail: "Spark + operational evidence" },
-    { name: "Decision", detail: "Client Toolbox + Vantage" },
-    { name: "Control", detail: "accessAI" },
-    { name: "Delivery", detail: "Proxima + development standard" },
-    { name: "Work", detail: "Service Desk + Iris" },
-  ],
-  guardrails: [
-    "Tenant safety",
-    "Bounded agents",
-    "Deterministic evidence",
-    "Human control",
-  ],
+    "A developing set of substantial products — not yet one uniformly integrated platform.",
   agentAuthority:
-    "Agents may advise, draft, test, and reconcile. Humans retain merge, deploy, external-send, destructive-action, billing, and autonomy-promotion.",
-  currentTruth:
-    "Strong products; uneven shared enforcement. accessAI is substantial but pre-GA as a universal control plane.",
-  operatingEvidence: {
-    lifecycle: "Portfolio convergence",
-    adoption: "Product-level evidence, one baseline pending",
-    production: "Mixed live / pre-GA / target",
-    ownership: "Leadership + named product owners",
-    risk: "Uneven shared-contract enforcement",
-  },
+    "Agents advise, draft, and test. People keep merge, deploy, and production authority.",
   namedSeams: [
     "Cadre",
     "Spark",
@@ -131,290 +84,161 @@ export const productBriefs: ProductBrief[] = [
   {
     id: "client-toolbox",
     name: "Client Toolbox",
-    owner: "John",
     tagline:
-      "Evidence-backed vITM workspace converting identity, endpoint, security, network, licensing, and service data into a scoped client portfolio, explainable health, prioritized opportunities, and QBR-ready decisions.",
+      "A vITM workspace that turns identity, endpoint, and security evidence into a client book you can explain — scores, gaps, and next conversations.",
     chips: [
       "Assigned client book",
-      "Explainable controls",
-      "QBR lifecycle",
+      "Explainable scores",
       "Evidence provenance",
     ],
     loopStages: ["sense", "decide", "operate"],
     capabilities: [
-      "Assigned client book",
-      "Client 360",
-      "Transparent standards (every score → control, observation, source, evidence age, coverage, confidence)",
-      "Risk / opportunity",
-      "QBR lifecycle",
-      "Governed AI teammate “Buddy” (source systems remain authoritative)",
+      "A scoped book of clients, not a generic dashboard",
+      "Scores that point back to a control, a source, and how fresh the evidence is",
+      "Gaps lower confidence instead of looking clean",
+      "A governed AI teammate that drafts; source systems stay authoritative",
     ],
-    primaryCapability:
-      "One evidence spine from source system to QBR. Honest gaps reduce confidence instead of reading clean.",
+    shipped:
+      "Designed and shipped the evidence spine: collection, scoring, and the workspace used to review a client.",
     stack: [
       "React",
       "TypeScript",
-      "Vite",
-      "Azure SWA",
+      "Azure Static Web Apps",
       "Entra ID",
       "Supabase",
-      "PostgreSQL RLS",
-      "Rewst collectors",
+      "PostgreSQL",
+      "Rewst",
       "Azure AI Foundry",
-      "Teams",
     ],
-    flow: [
-      "Collect",
-      "Reconcile identities",
-      "Score",
-      "Review",
-      "Communicate QBR",
-    ],
-    engineeringNotes:
-      "One issue per PR; locked builds, migration replay, typecheck, lint, tests, SWA smoke, security contracts, screenshots, perf budgets.",
-    securityNotes:
-      "Entra roles, signed principals, RLS, service-only mutations, scoped machine creds, audit.",
-    readiness: {
-      lifecycle: "Toolbox Next staging",
-      adoption: "Assigned-client workflow, baseline pending",
-      production: "Live collection and QBR workspace",
-      ownership: "John",
-      risk: "Portfolio-wide outcome linkage incomplete",
-    },
-    proven: [
-      "Collection",
-      "Provenance",
-      "Controls",
-      "Workspaces",
-      "QBR",
-    ],
+    proven: ["Collection", "Provenance", "Scoring workspace"],
     preGa: [],
-    target: ["Universal outcome linkage to Vantage"],
+    target: ["Shared outcome tracking with the rest of the portfolio"],
   },
   {
     id: "service-desk-toolbox",
     name: "Service Desk Toolbox + Incident Buddy",
-    owner: "Toby",
     tagline:
-      "Technician app that routes Halo tickets to governed automations and uses Incident Buddy for 10-domain investigations, then writes results back.",
+      "Technician app, built with the service desk team, that routes tickets into guided automations and an investigation assistant. Humans review before writeback.",
     chips: [
-      "20+ automation forms",
-      "Rewst-hosted shell",
-      "Halo-connected work",
-      "10-domain investigation",
+      "Ticket-linked automations",
+      "Incident Buddy",
+      "Human writeback",
     ],
     loopStages: ["sense", "operate"],
     capabilities: [
-      "Application shell",
-      "20+ guided forms via Rewst (identity, Exchange, provisioning, security, service)",
-      "Halo ticket linking",
-      "Incident Buddy across identity, access, mail, endpoint, security, network, automation, ticket, client, infrastructure",
-      "Automation program metrics",
-      "Teams bot is intentionally narrow (chat + EOD numbers)",
+      "Guided automations for common identity, mail, and access work",
+      "Ticket context stays attached to the run",
+      "Incident Buddy investigates across the usual MSP domains",
+      "Humans review findings before anything is written back",
     ],
-    primaryCapability:
-      "Raise ticket quality with cross-system context. Human reviews findings before Halo writeback.",
+    shipped:
+      "Shipped with the service desk team: ticket-linked automations and an investigation assistant that does not write back until a human reviews.",
     stack: [
-      "Custom Toolbox shell",
-      "Rewst host / auth / forms",
-      "Halo SOR",
+      "Rewst",
+      "Halo",
       "Azure AI Foundry",
-      "Teams",
+      "Microsoft Teams",
+      "TypeScript",
     ],
-    flow: [
-      "Intake Halo",
-      "Route",
-      "Investigate 10 domains",
-      "Human review",
-      "Record + measure",
-    ],
-    readiness: {
-      lifecycle: "Operational product",
-      adoption: "20+ forms in use",
-      production: "Live technician app",
-      ownership: "Toby",
-      risk: "Portfolio outcome backbone still target",
-    },
-    proven: ["Shell", "Catalog", "Ticket linking", "Incident Buddy"],
+    proven: ["Technician shell", "Ticket linking", "Incident Buddy"],
     preGa: [],
-    target: ["Portfolio outcome backbone"],
+    target: ["Shared outcome tracking with the rest of the portfolio"],
   },
   {
     id: "iris",
     name: "Iris",
-    owner: "John",
     tagline:
-      "One assistant that understands company, client, ticket, meeting, and operational context, then researches, creates, remembers, schedules, investigates, and takes approved action from Teams or Iris OS.",
+      "A company-grounded assistant in Teams and Iris OS. It researches, remembers, and drafts — and only acts after someone approves.",
     chips: [
       "Teams + Iris OS",
-      "Company-grounded answers",
-      "Durable skills",
-      "Approved action",
+      "Company context",
+      "Approval-gated action",
     ],
     loopStages: ["sense", "operate"],
     capabilities: [
-      "Teams + Iris OS (chat, role-composed home, apps, pins, files, skills, voice, search, PWA)",
-      "Grounds in handbook, people, approved Teams channels, MeetingOS, live Halo, ticket history, client records",
-      "Research / create with citations, OCR, signed expiring artifacts",
-      "Reminders, memory, skills, chains",
-      "Specialists (Incident Buddy, vITM tools)",
-      "Governed action via brokers (mail, calendar, MeetingOS, Halo, Rewst) with payload-bound approval and audit",
+      "Answers grounded in handbook, people, tickets, and approved channels",
+      "Research and drafts with citations",
+      "Durable skills, reminders, and memory",
+      "Specialists sit behind the same approval gate",
     ],
-    primaryCapability:
-      "Personal AI with company context and permission to act.",
+    shipped:
+      "Led Iris: the Teams bot, the Iris OS shell, and the approval-gated action path.",
     stack: [
-      "Bot Framework",
-      "Adaptive Cards",
       "React",
       "TypeScript",
-      "Vite",
-      "Cuelume",
-      "PWA SWA",
-      "iris-sdk",
-      "Azure Functions Node 22 v4",
-      "Durable Functions",
+      "Azure Functions",
       "Azure AI Foundry",
-      "Azure Tables",
-      "Blob",
-      "AI Search",
-      "Rewst",
+      "Microsoft Graph",
       "Halo",
-      "Graph",
-      "accessAI",
+      "Rewst",
+      "Bot Framework",
     ],
-    flow: [
-      "Ask",
-      "Resolve identity / scope",
-      "Ground",
-      "Execute",
-      "Govern + learn",
-    ],
-    readiness: {
-      lifecycle: "Integrated product, federation pre-GA",
-      adoption: "Teams + Iris OS in use",
-      production: "Live assistant; accessAI federation pre-GA",
-      ownership: "John",
-      risk: "accessAI federation",
-    },
-    proven: ["Manager", "Teams", "Iris OS"],
+    proven: ["Teams bot", "Iris OS"],
     preGa: ["accessAI federation"],
-    target: ["Full agent-OS citizenship"],
+    target: ["Tighter shared-control-plane integration"],
   },
   {
     id: "proxima",
     name: "Proxima",
-    owner: "Shared platform",
     tagline:
-      "Turns approved Vantage work and GitHub evidence into reviewed branches, draft PRs, green CI, traceable delivery records, and concise human decisions.",
+      "Takes approved engineering work and returns a reviewed branch, a draft PR, and green CI. The model never marks its own work done.",
     chips: [
-      "Vantage-governed intent",
       "GitHub-native delivery",
-      "CI-bound completion",
-      "Draft-mode autonomy",
+      "Draft-mode only",
+      "Human merge authority",
     ],
     loopStages: ["build"],
     capabilities: [
-      "Steward approved Vantage work",
-      "Review PR estate (small unambiguous fixes only)",
-      "Build drafts in a fresh clone bound to true head SHA",
-      "Repair against real CI (up to two passes; model never self-declares success)",
-      "Reconcile to Vantage / Halo via signed Rewst bridge",
-      "Teams surfaces decisions, not noise",
+      "Implements approved work in a fresh clone bound to a real commit",
+      "Opens draft PRs and repairs against actual CI",
+      "Surfaces decisions in Teams instead of a chat firehose",
+      "Humans keep merge, deploy, and anything that spends money",
     ],
-    primaryCapability:
-      "Agentic delivery inside a deterministic shell. Humans retain merge, deploy, risky, and cost-incurring action.",
+    shipped:
+      "Helped design the draft-mode delivery loop: agents implement and verify against real CI; people still merge.",
     stack: [
-      "Forge monorepo",
-      "pnpm",
-      "Turbo",
-      "Node",
+      "TypeScript",
       "Python",
       "Docker",
-      "GitHub App / CLI",
-      "Azure CLI",
-      "Supabase CLI",
+      "GitHub",
+      "Node",
+      "Azure",
+      "Supabase",
     ],
-    flow: [
-      "Intake",
-      "Claim",
-      "Implement",
-      "Verify exact SHA",
-      "Repair + reconcile",
-    ],
-    engineeringNotes:
-      "CI is automatic; production is governed. Draft-mode autonomy — the model never self-declares success.",
-    readiness: {
-      lifecycle: "Draft-mode, autonomy pre-GA",
-      adoption: "Delivery loop in use for approved work",
-      production: "Draft delivery live; autonomy maturity pre-GA",
-      ownership: "Shared platform",
-      risk: "Autonomy promotion still human-gated",
-    },
     proven: ["Draft delivery loop"],
-    preGa: ["Autonomy maturity"],
-    target: ["Portfolio conformance operator"],
+    preGa: ["Broader autonomy"],
+    target: ["Shared delivery standard across products"],
   },
   {
     id: "accessai",
     name: "accessAI",
-    owner: "R&D",
     tagline:
-      "Defines which identities, models, agents, tools, policies, compute destinations, and deployment bindings may operate; records execution, cost, audit, evaluation, promotion, rollback.",
+      "Pre-GA control plane for which identities, models, agents, and tools may run — plus cost, audit, evaluation, and rollback.",
     chips: [
       "Multi-model governance",
       "Tenant-safe execution",
-      "Agent delivery control",
-      "Cost + audit + evaluation",
+      "Cost + audit",
+      "Pre-GA",
     ],
     loopStages: ["govern"],
     capabilities: [
-      "Multi-provider (Azure OpenAI, Anthropic, OpenAI, Foundry)",
-      "Entra / MSAL JWT, API keys, tenant resolution, API RBAC, Postgres RLS",
-      "Recipes / harnesses / destinations",
-      "Builtin and Foundry execution with memory, tools, MCP, policy, approvals, kill switches",
-      "Append-only audit, evals, promotion, cost, telemetry, rollback",
-      "Central Exchange + Agent Factory",
+      "Routes work across Azure OpenAI, Anthropic, OpenAI, and Foundry",
+      "Fail-closed identity and tenant isolation",
+      "Records runs, cost, evals, and promotions",
+      "Not an end-user assistant, and not sellable-GA yet",
     ],
-    primaryCapability:
-      "Control plane defines what/why; providers execute how. Shared infrastructure IP — not an end-user assistant or foundation model. Not sellable-GA yet (no releases/tags, 0.0.0 packages, incomplete golden path, no live second-tenant acceptance).",
+    shipped:
+      "Helped define the control-plane model — what may run, under whose authority, and how it gets promoted. Still pre-GA as a universal control plane.",
     stack: [
-      "Node 22",
       "TypeScript",
       "Hono",
-      "React 19",
-      "Vite 8",
-      "Tailwind 4",
-      "PostgreSQL 16 + pgvector",
-      "Forced RLS",
+      "React",
+      "PostgreSQL",
       "Azure Container Apps",
-      "SWA",
       "Key Vault",
-      "Vitest",
-      "Playwright",
-      "CodeQL",
-      "ZAP",
-      "Trivy",
     ],
-    flow: [
-      "Discover",
-      "Bind",
-      "Authorize fail-closed",
-      "Execute",
-      "Promote or roll back",
-    ],
-    engineeringNotes:
-      "Progressive deploy 5% → 25% → manually approved 100%.",
-    securityNotes:
-      "Forced RLS, fail-closed authorization, append-only audit, kill switches, tenant-safe execution.",
-    readiness: {
-      lifecycle: "Substantial control plane, pre-GA",
-      adoption: "Not sellable-GA; no live second-tenant acceptance",
-      production: "Broad implementation; universal use pre-GA",
-      ownership: "R&D",
-      risk: "Portfolio-wide enforcement is target state",
-    },
-    proven: ["Broad control-plane implementation"],
-    preGa: ["Sellability / universal use"],
+    proven: ["Control-plane implementation"],
+    preGa: ["Universal use"],
     target: ["Portfolio-wide enforcement"],
   },
 ];

--- a/src/data/timeline-tracks.ts
+++ b/src/data/timeline-tracks.ts
@@ -8,9 +8,9 @@ export const TIMELINE_TRACKS = [
   {
     id: "ai-products",
     label: "AI Products",
-    heading: "Governed MSP operating loop",
+    heading: "AI products I lead or ship",
     summary:
-      "centrexIT products John owns or leads: evidence-preserving workflows, a shared control plane, and human production authority.",
+      "Work I led or shipped at centrexIT: evidence-preserving workflows, governed agents, and a pre-GA control plane. Not yet one platform.",
   },
   {
     id: "endpoint-logistics",
@@ -101,9 +101,9 @@ export const defaultAiProductEntries: TimelineItem[] = [
   {
     id: "ai-client-toolbox",
     label: "Client Toolbox",
-    phase: "Evidence-backed vITM",
+    phase: "Evidence-backed client reviews",
     summary:
-      "Identity, endpoint, security, network, licensing, and service data into QBR-ready decisions.",
+      "A vITM workspace that turns identity, endpoint, and security evidence into a client book you can explain.",
     content: null,
     dot_position: 72,
     track: "ai-products",
@@ -114,7 +114,7 @@ export const defaultAiProductEntries: TimelineItem[] = [
     label: "Service Desk Toolbox",
     phase: "Technician work + Incident Buddy",
     summary:
-      "Halo tickets routed to governed automations and 10-domain investigations.",
+      "Ticket-linked automations and an investigation assistant, built with the service desk team.",
     content: null,
     dot_position: 68,
     track: "ai-products",
@@ -136,7 +136,7 @@ export const defaultAiProductEntries: TimelineItem[] = [
     label: "Proxima",
     phase: "Governed agentic engineering",
     summary:
-      "Approved Vantage work into reviewed branches, draft PRs, and green CI.",
+      "Draft PRs and green CI for approved work; humans still merge.",
     content: null,
     dot_position: 64,
     track: "ai-products",
@@ -147,7 +147,7 @@ export const defaultAiProductEntries: TimelineItem[] = [
     label: "accessAI",
     phase: "AI control plane (pre-GA)",
     summary:
-      "Identities, models, agents, tools, policy, cost, audit, evaluation, promotion, rollback.",
+      "Pre-GA control plane for models, agents, policy, cost, and audit.",
     content: null,
     dot_position: 58,
     track: "ai-products",

--- a/src/lib/seo.tsx
+++ b/src/lib/seo.tsx
@@ -587,9 +587,9 @@ export const occupationSchema: OccupationSchema = {
 
 export const softwareSchema: CreativeWorkSchema = {
   type: "CreativeWork",
-  name: "centrexIT AI Products",
+  name: "AI products John Christensen led or shipped",
   description:
-    "A developing operating system for how an MSP senses demand, chooses investments, governs AI, builds safely, and completes work. Substantial products today; not yet one uniformly integrated platform. accessAI is pre-GA as a universal control plane.",
+    "Governed AI for MSP work: evidence-preserving client reviews, technician assistance, a company-grounded assistant, and draft-mode delivery. Substantial products today; not yet one uniformly integrated platform. accessAI is pre-GA as a universal control plane.",
   url: "/portfolio?track=ai-products",
   creator: "Jonathan Christensen",
   keywords: [
@@ -613,7 +613,7 @@ export const aboutFaqSchema: FAQSchema = {
     {
       question: "Are the centrexIT AI products a single integrated platform?",
       answer:
-        "No. The portfolio is a coherent set of substantial products with a credible control-plane architecture. Common contracts, package adoption, and several cross-product governance seams remain pre-GA or target state. accessAI is substantial but pre-GA as a universal control plane.",
+        "No. They are a developing set of substantial products John led or shipped — client reviews, technician assistance, a company-grounded assistant, draft-mode delivery, and a pre-GA control plane. accessAI is not yet a universal control plane, and the portfolio is not yet one uniformly integrated platform.",
     },
     {
       question: "Where is Jonathan based?",

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -62,7 +62,7 @@ const Portfolio = () => {
       return {
         title: 'AI Products',
         description:
-          'centrexIT AI products John Christensen owns or leads: Client Toolbox, Iris, Proxima, accessAI, and Service Desk Toolbox. Governed agents, evidence-preserving workflows, and honest pre-GA claims.',
+          'AI work John Christensen led or shipped: Client Toolbox, Iris, Proxima, accessAI, and Service Desk Toolbox. Governed agents and evidence-preserving workflows; accessAI is pre-GA.',
         url: '/portfolio?track=ai-products',
         keywords: RECRUITING_KEYWORDS,
       };

--- a/supabase/migrations/20260822040000_public_case_studies_results.sql
+++ b/supabase/migrations/20260822040000_public_case_studies_results.sql
@@ -1,0 +1,143 @@
+-- Public Results cards: recruiter-safe copy for the Work tab.
+-- Updates the three live case_studies rows and inserts the +133% lead card.
+-- Does not change RLS or table shape. Idempotent by id.
+
+CREATE TEMP TABLE _public_case_studies_seed (
+  id uuid PRIMARY KEY,
+  metric text NOT NULL,
+  title text NOT NULL,
+  before_content text NOT NULL,
+  after_content text NOT NULL,
+  order_index integer NOT NULL
+);
+
+INSERT INTO _public_case_studies_seed (
+  id,
+  metric,
+  title,
+  before_content,
+  after_content,
+  order_index
+) VALUES
+  (
+    '6f2c8a91-4d3e-4b7a-9c15-8e0a1f3b5d72',
+    '+133%',
+    'Automation hours, same billed labor',
+    'More automations used to mean more engineer hours. The desk was already busy.',
+    'Governed automations and agents carry the extra load. Automation hours are up 133% while billed hours stayed essentially flat. Humans still approve writeback and anything that spends money.',
+    0
+  ),
+  (
+    'a235ceb3-0933-4df8-b356-628342ddbaa4',
+    '2 min',
+    'User provisioning',
+    'A fresh machine was 45 minutes of manual onboarding, config, and babysitting.',
+    'Plug in, run the playbook, QC. About two minutes. Immy.Bot and Rewst are the stack; people still do the check.',
+    1
+  ),
+  (
+    '5eeee2cc-d732-434e-b24f-8c60eebc365b',
+    'clean',
+    'Inventory billing',
+    'Month-end billing lived in Excel. Fields were optional, access was whoever had the file, and a missed row meant a missed invoice.',
+    'A governed SharePoint list with required fields and role-based access. The close is a process, not a hunt through a spreadsheet.',
+    2
+  ),
+  (
+    '3cc0a438-7630-4858-8df9-fca25e126962',
+    '50%',
+    'Faster inventory updates',
+    'Finding a device meant hunting through SharePoint folders.',
+    'A three-digit lookup in Teams. Half the time.',
+    3
+  );
+
+UPDATE public.case_studies AS live
+SET
+  metric = seed.metric,
+  title = seed.title,
+  before_content = seed.before_content,
+  after_content = seed.after_content,
+  order_index = seed.order_index,
+  updated_at = now()
+FROM _public_case_studies_seed AS seed
+WHERE live.id = seed.id;
+
+DO $$
+DECLARE
+  has_tenant boolean;
+  existing_tenant uuid;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'case_studies'
+      AND column_name = 'tenant_id'
+  ) INTO has_tenant;
+
+  IF has_tenant THEN
+    SELECT tenant_id INTO existing_tenant
+    FROM public.case_studies
+    WHERE id IN (
+      'a235ceb3-0933-4df8-b356-628342ddbaa4',
+      '5eeee2cc-d732-434e-b24f-8c60eebc365b',
+      '3cc0a438-7630-4858-8df9-fca25e126962',
+      '6f2c8a91-4d3e-4b7a-9c15-8e0a1f3b5d72'
+    )
+    LIMIT 1;
+
+    existing_tenant := COALESCE(
+      existing_tenant,
+      '00000000-0000-0000-0000-000000000001'::uuid
+    );
+
+    INSERT INTO public.case_studies (
+      id,
+      tenant_id,
+      metric,
+      title,
+      before_content,
+      after_content,
+      order_index
+    )
+    SELECT
+      seed.id,
+      existing_tenant,
+      seed.metric,
+      seed.title,
+      seed.before_content,
+      seed.after_content,
+      seed.order_index
+    FROM _public_case_studies_seed AS seed
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.case_studies AS live
+      WHERE live.id = seed.id
+    );
+  ELSE
+    INSERT INTO public.case_studies (
+      id,
+      metric,
+      title,
+      before_content,
+      after_content,
+      order_index
+    )
+    SELECT
+      seed.id,
+      seed.metric,
+      seed.title,
+      seed.before_content,
+      seed.after_content,
+      seed.order_index
+    FROM _public_case_studies_seed AS seed
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.case_studies AS live
+      WHERE live.id = seed.id
+    );
+  END IF;
+END $$;
+
+DROP TABLE _public_case_studies_seed;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
John’s note: this should sound like a personal recruiting site, not a paste of internal centrexIT product briefs.

## Base
Rebased onto current `main` at `9890a6221360d7f6a4ca4a460545c1cfb319d16b` (includes merged #448 Sentry `toError` / `maybeSingle` and #447 migration filenames). This PR does not revert that work. `seo.tsx` still uses `captureException(toError(err))`; only CreativeWork/FAQ recruiting copy changed there.

## What changed
- Rewrote `portfolioThesis` and each `productBriefs` entry in first-person recruiting voice.
- Slimmed the AI Products UI: name, short pitch, chips, what I shipped, a few capabilities, recognizable stack, proven vs still-coming.
- Dropped Owner rows, the five-row readiness ledger, engineering/security essays, and internal jargon (`14 normalized briefs`, coworker owners, laundry-list SKUs, form-count flexes).
- Kept the honest claim: developing set of substantial products, not yet one platform; accessAI is pre-GA; agents advise/draft, humans keep production authority.
- Named seams (Cadre, Spark, Spot, Navigate, Vantage, Knowledge, AI Triage) stay as one “also in the loop” line.
- Updated timeline track copy, `llms.txt`, GEO/SEO JSON-LD/FAQ, and snapshot tests. No invented talks. No `projects` site_content row. No RLS changes.

## Results cards (this follow-up)
- Four public-safe Work tab cards, AI-era first: **+133%** automation hours at flat billed labor; **2 min** user provisioning (from 45 min); **clean** inventory billing (Excel → governed lists / RBAC); **50%** faster inventory updates (SharePoint hunt → three-digit Teams lookup).
- Metric subtitle is derived: `%` / `+` → “improvement”; minutes → “from 45 min”; otherwise omitted. “2 min” is no longer labeled an improvement.
- Work tab intro is first-person, matching the AI Products voice.
- `defaultCaseStudies` matches the live seed. New migration `20260822040000_public_case_studies_results.sql` UPDATEs the three existing ids and INSERTs the +133% row (idempotent). Does not rewrite `foundation.sql` or touch RLS.

Sanctioned numbers only. No internal names, promotion/comp, acquisition language, or repo internals.

## How to review
Open `/portfolio` (Work). Read the AI Products thesis and the Results cards in ~20 seconds. A recruiter who does not know centrexIT internals should understand what John builds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8652e3b6-bf49-40e2-9ab2-6f619239026f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8652e3b6-bf49-40e2-9ab2-6f619239026f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

