### PR TITLE
Cut named-seams catalog language from AI Products

### DIFF
--- a/src/components/ProjectTimeline.test.tsx
+++ b/src/components/ProjectTimeline.test.tsx
@@ -13,8 +13,17 @@ import {
   normalizeTimelineTrack,
   resolveTimelineTrack,
 } from "@/data/timeline-tracks";
-import { orderProductBriefs, portfolioThesis, productBriefs } from "@/data/ai-products";
-import { formatTalkTimestamp, sortTalksByDateDesc, talks, type Talk } from "@/data/talks";
+import {
+  orderProductBriefs,
+  portfolioThesis,
+  productBriefs,
+} from "@/data/ai-products";
+import {
+  formatTalkTimestamp,
+  sortTalksByDateDesc,
+  talks,
+  type Talk,
+} from "@/data/talks";
 import TalksSection from "@/components/portfolio/TalksSection";
 import {
   buildCreativeWorkJsonLd,
@@ -95,7 +104,9 @@ describe("Success Roadmap tracks", () => {
   it("defaults unknown track query values to AI Products", () => {
     expect(resolveTimelineTrack(null)).toBe("ai-products");
     expect(resolveTimelineTrack("nope")).toBe("ai-products");
-    expect(resolveTimelineTrack("endpoint-logistics")).toBe("endpoint-logistics");
+    expect(resolveTimelineTrack("endpoint-logistics")).toBe(
+      "endpoint-logistics",
+    );
   });
 
   it("treats missing DB track as endpoint logistics so live year pills stay on that track", () => {
@@ -104,9 +115,10 @@ describe("Success Roadmap tracks", () => {
   });
 
   it("keeps the provisioning year history on Endpoint Logistics", () => {
-    const years = entriesForTrack(defaultTimelineData, "endpoint-logistics").map(
-      (entry) => entry.label,
-    );
+    const years = entriesForTrack(
+      defaultTimelineData,
+      "endpoint-logistics",
+    ).map((entry) => entry.label);
     expect(years).toEqual(["2022-2023", "2024", "2025", "2026+"]);
   });
 
@@ -141,8 +153,12 @@ describe("AI Products briefs", () => {
   it("includes the portfolio thesis and Client Toolbox", () => {
     expect(portfolioThesis.lead).toMatch(/not yet one uniformly integrated/i);
     expect(portfolioThesis.lead).toMatch(/pre-GA/i);
-    expect(portfolioThesis.honestClaim).toMatch(/not yet one uniformly integrated/i);
-    const toolbox = productBriefs.find((brief) => brief.id === "client-toolbox");
+    expect(portfolioThesis.honestClaim).toMatch(
+      /not yet one uniformly integrated/i,
+    );
+    const toolbox = productBriefs.find(
+      (brief) => brief.id === "client-toolbox",
+    );
     expect(toolbox).toBeDefined();
     expect(toolbox).not.toHaveProperty("owner");
     expect(toolbox?.capabilities.length).toBeGreaterThanOrEqual(3);
@@ -168,7 +184,7 @@ describe("AI Products briefs", () => {
     expect(accessAi?.tagline).toMatch(/pre-GA/i);
   });
 
-  it("does not invent full briefs for named seams", () => {
+  it("only briefs the five public products", () => {
     const ids = productBriefs.map((brief) => brief.id);
     expect(ids).toEqual([
       "client-toolbox",
@@ -177,8 +193,7 @@ describe("AI Products briefs", () => {
       "proxima",
       "accessai",
     ]);
-    expect(portfolioThesis.namedSeams).toContain("Vantage");
-    expect(portfolioThesis.namedSeams).toContain("Cadre");
+    expect(portfolioThesis).not.toHaveProperty("namedSeams");
   });
 
   it("orders briefs from timeline entry keys when present", () => {
@@ -206,7 +221,9 @@ describe("AI Products briefs", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: /governed ai for the msp work i ship/i }),
+      screen.getByRole("heading", {
+        name: /governed ai for the msp work i ship/i,
+      }),
     ).toBeInTheDocument();
     expect(screen.queryByText(/14 normalized briefs/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/readiness ledger/i)).not.toBeInTheDocument();
@@ -215,6 +232,12 @@ describe("AI Products briefs", () => {
       "aria-selected",
       "true",
     );
+    expect(
+      screen.getByText("Five products I led or shipped."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/named seams/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/second catalog/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/also in the loop/i)).not.toBeInTheDocument();
     expect(
       screen.getByText(/vITM workspace that turns identity/i),
     ).toBeInTheDocument();
@@ -267,9 +290,13 @@ describe("SEO helpers", () => {
   });
 
   it("builds Website, Occupation, and CreativeWork JSON-LD", () => {
-    expect(buildWebsiteJsonLd({ type: "Website", name: "MeJohnC", url: "https://mejohnc.org" })["@type"]).toBe(
-      "WebSite",
-    );
+    expect(
+      buildWebsiteJsonLd({
+        type: "Website",
+        name: "MeJohnC",
+        url: "https://mejohnc.org",
+      })["@type"],
+    ).toBe("WebSite");
     expect(buildOccupationJsonLd(occupationSchema).name).toBe(
       "AI Automation Engineer",
     );

--- a/src/components/portfolio/AiProductsPanel.tsx
+++ b/src/components/portfolio/AiProductsPanel.tsx
@@ -57,9 +57,7 @@ export default function AiProductsPanel({ entries }: AiProductsPanelProps) {
               Products
             </span>
             <p className="text-sm text-muted-foreground mt-1">
-              Five products I led or shipped. Cadre, Spark, Spot, Navigate,
-              Vantage, Knowledge, and AI Triage stay in the loop as named seams
-              — not a second catalog.
+              Five products I led or shipped.
             </p>
           </div>
         </div>
@@ -86,7 +84,9 @@ export default function AiProductsPanel({ entries }: AiProductsPanelProps) {
                     return;
                   }
                   event.preventDefault();
-                  const index = briefs.findIndex((item) => item.id === brief.id);
+                  const index = briefs.findIndex(
+                    (item) => item.id === brief.id,
+                  );
                   const delta = event.key === "ArrowRight" ? 1 : -1;
                   const next =
                     briefs[(index + delta + briefs.length) % briefs.length];
@@ -201,13 +201,11 @@ function ThesisCard({
         </ol>
       </div>
 
-      <p className="text-foreground leading-relaxed mb-3">{thesis.honestClaim}</p>
-      <p className="text-sm text-muted-foreground leading-relaxed mb-6">
-        {thesis.agentAuthority}
+      <p className="text-foreground leading-relaxed mb-3">
+        {thesis.honestClaim}
       </p>
-
-      <p className="text-xs text-muted-foreground">
-        Also in the loop: {thesis.namedSeams.join(" · ")}
+      <p className="text-sm text-muted-foreground leading-relaxed">
+        {thesis.agentAuthority}
       </p>
     </motion.section>
   );
@@ -268,7 +266,9 @@ function ProductBriefCard({
           <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-3">
             Stack
           </h4>
-          <p className="text-sm text-muted-foreground">{brief.stack.join(" · ")}</p>
+          <p className="text-sm text-muted-foreground">
+            {brief.stack.join(" · ")}
+          </p>
         </div>
       </div>
 
@@ -295,7 +295,10 @@ function LoopMarker({
         const active = stages.includes(stage);
         return (
           <span key={stage}>
-            <span style={{ color: active ? primary : undefined }} className={active ? "font-semibold" : ""}>
+            <span
+              style={{ color: active ? primary : undefined }}
+              className={active ? "font-semibold" : ""}
+            >
               {LOOP_STAGE_LABELS[stage]}
             </span>
             {index < LOOP_ORDER.length - 1 ? " → " : ""}
@@ -306,13 +309,7 @@ function LoopMarker({
   );
 }
 
-function MaturityColumn({
-  label,
-  items,
-}: {
-  label: string;
-  items: string[];
-}) {
+function MaturityColumn({ label, items }: { label: string; items: string[] }) {
   return (
     <div className="rounded-lg border border-border p-4 bg-background/40">
       <h4 className="font-mono text-xs uppercase tracking-widest text-muted-foreground mb-2">

--- a/src/data/ai-products.ts
+++ b/src/data/ai-products.ts
@@ -31,7 +31,6 @@ export interface PortfolioThesis {
   loop: { stage: LoopStage; detail: string }[];
   honestClaim: string;
   agentAuthority: string;
-  namedSeams: string[];
 }
 
 export const portfolioThesis: PortfolioThesis = {
@@ -46,7 +45,8 @@ export const portfolioThesis: PortfolioThesis = {
   loop: [
     {
       stage: "sense",
-      detail: "Pull ticket, meeting, and client signals without dropping the source.",
+      detail:
+        "Pull ticket, meeting, and client signals without dropping the source.",
     },
     {
       stage: "decide",
@@ -54,11 +54,13 @@ export const portfolioThesis: PortfolioThesis = {
     },
     {
       stage: "govern",
-      detail: "Decide which identities, models, and agents may run. accessAI is still pre-GA.",
+      detail:
+        "Decide which identities, models, and agents may run. accessAI is still pre-GA.",
     },
     {
       stage: "build",
-      detail: "Draft delivery stays in review until CI is green and a person merges.",
+      detail:
+        "Draft delivery stays in review until CI is green and a person merges.",
     },
     {
       stage: "operate",
@@ -69,15 +71,6 @@ export const portfolioThesis: PortfolioThesis = {
     "A developing set of substantial products — not yet one uniformly integrated platform.",
   agentAuthority:
     "Agents advise, draft, and test. People keep merge, deploy, and production authority.",
-  namedSeams: [
-    "Cadre",
-    "Spark",
-    "Spot",
-    "Navigate",
-    "Vantage",
-    "Knowledge",
-    "AI Triage",
-  ],
 };
 
 export const productBriefs: ProductBrief[] = [
@@ -119,11 +112,7 @@ export const productBriefs: ProductBrief[] = [
     name: "Service Desk Toolbox + Incident Buddy",
     tagline:
       "Technician app, built with the service desk team, that routes tickets into guided automations and an investigation assistant. Humans review before writeback.",
-    chips: [
-      "Ticket-linked automations",
-      "Incident Buddy",
-      "Human writeback",
-    ],
+    chips: ["Ticket-linked automations", "Incident Buddy", "Human writeback"],
     loopStages: ["sense", "operate"],
     capabilities: [
       "Guided automations for common identity, mail, and access work",
@@ -149,11 +138,7 @@ export const productBriefs: ProductBrief[] = [
     name: "Iris",
     tagline:
       "A company-grounded assistant in Teams and Iris OS. It researches, remembers, and drafts — and only acts after someone approves.",
-    chips: [
-      "Teams + Iris OS",
-      "Company context",
-      "Approval-gated action",
-    ],
+    chips: ["Teams + Iris OS", "Company context", "Approval-gated action"],
     loopStages: ["sense", "operate"],
     capabilities: [
       "Answers grounded in handbook, people, tickets, and approved channels",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
John flagged the AI Products intro as too meta.

## Change
- Keep **Five products I led or shipped.**
- Delete the Cadre / Spark / Spot / Navigate / Vantage / Knowledge / AI Triage “named seams / not a second catalog” sentence. No replacement disclaimer.
- Remove the thesis footer **Also in the loop: Cadre · Spark · …**
- Update tests that asserted those strings.

## Out of scope
No case-study, Results, or Sentry/`toError`/`maybeSingle` changes. Branched from current `main` (`c4b1935`, merged #449). Does not push onto the merged #449 branch.

## How to review
Open `/portfolio?track=ai-products`. The five product pills should be the product list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8652e3b6-bf49-40e2-9ab2-6f619239026f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8652e3b6-bf49-40e2-9ab2-6f619239026f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

