### PR TITLE
Recast public AI Products copy to stranger-readable categories

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -15,14 +15,16 @@ John built an app platform, several individual apps, and an agent and compute fe
 
 ## AI Products (most recent portfolio item)
 
-Personal recruiting portfolio of AI work John led or shipped at centrexIT — not a company product catalog.
+Personal recruiting portfolio of product categories John has shipped in at centrexIT — not a company product catalog.
 
-Products:
-- Client Toolbox — evidence-preserving client reviews a vITM can explain
-- Service Desk Toolbox + Incident Buddy — technician automations and an investigation assistant, built with the service desk team
-- Iris — company-grounded assistant with approval-gated action
-- Proxima — draft-mode delivery: reviewed branches, draft PRs, green CI
-- accessAI — control plane for identities, models, agents, and tools
+Categories:
+- Service Delivery — technician automations with human writeback, built with the service desk team
+- Portfolio Management — evidence-preserving client reviews a person can explain
+- Deep Research / Technical investigations — investigation assistant; people review findings before writeback
+- Multimodal Enterprise Agent — company-grounded assistant people talk to, with approval-gated action
+- Agentic Application OS Platform — the OS he stewarded for governed agents and apps
+- Agent and Compute Federation Platform — identities, models, agents, tools, cost, audit, eval, rollback; not an end-user assistant
+- DevOps Teammate — draft-mode delivery: reviewed branches, draft PRs, green CI; never marks its own work done
 
 Honest claim: a developing set of substantial products, not yet one uniformly integrated platform. Agents advise, draft, and test. People keep merge, deploy, and production authority.
 

--- a/src/components/ProjectTimeline.test.tsx
+++ b/src/components/ProjectTimeline.test.tsx
@@ -152,8 +152,18 @@ describe("Success Roadmap tracks", () => {
   });
 });
 
+const PUBLIC_CATEGORY_TITLES = [
+  "Service Delivery",
+  "Portfolio Management",
+  "Deep Research / Technical investigations",
+  "Multimodal Enterprise Agent",
+  "Agentic Application OS Platform",
+  "Agent and Compute Federation Platform",
+  "DevOps Teammate",
+] as const;
+
 describe("AI Products briefs", () => {
-  it("includes the portfolio thesis and Client Toolbox", () => {
+  it("includes the portfolio thesis and seven public categories", () => {
     expect(portfolioThesis.lead).toMatch(/app platform/i);
     expect(portfolioThesis.lead).toMatch(/individual apps/i);
     expect(portfolioThesis.lead).toMatch(/federation/i);
@@ -170,13 +180,19 @@ describe("AI Products briefs", () => {
     expect(portfolioThesis.honestClaim).toMatch(
       /not yet one uniformly integrated/i,
     );
-    const toolbox = productBriefs.find(
+    expect(productBriefs.map((brief) => brief.name)).toEqual([
+      ...PUBLIC_CATEGORY_TITLES,
+    ]);
+    expect(defaultAiProductEntries.map((entry) => entry.label)).toEqual([
+      ...PUBLIC_CATEGORY_TITLES,
+    ]);
+    const portfolio = productBriefs.find(
       (brief) => brief.id === "client-toolbox",
     );
-    expect(toolbox).toBeDefined();
-    expect(toolbox).not.toHaveProperty("owner");
-    expect(toolbox?.capabilities.length).toBeGreaterThanOrEqual(3);
-    expect(toolbox?.capabilities.length).toBeLessThanOrEqual(5);
+    expect(portfolio?.name).toBe("Portfolio Management");
+    expect(portfolio).not.toHaveProperty("owner");
+    expect(portfolio?.capabilities.length).toBeGreaterThanOrEqual(3);
+    expect(portfolio?.capabilities.length).toBeLessThanOrEqual(5);
   });
 
   it("keeps recruiter-length briefs without launch-status or internal sequels", () => {
@@ -195,9 +211,11 @@ describe("AI Products briefs", () => {
       expect(brief).not.toHaveProperty("target");
     }
 
-    const accessAi = productBriefs.find((brief) => brief.id === "accessai");
-    expect(accessAi?.tagline).toMatch(/control plane/i);
-    expect(accessAi?.tagline).not.toMatch(/pre-GA|preGA|general.?availab/i);
+    const federation = productBriefs.find((brief) => brief.id === "accessai");
+    expect(federation?.name).toBe("Agent and Compute Federation Platform");
+    expect(federation?.tagline).toMatch(/control plane/i);
+    expect(federation?.tagline).not.toMatch(/pre-GA|preGA|general.?availab/i);
+    expect(federation?.tagline).not.toMatch(/accessAI/i);
   });
 
   it("keeps internal process language off public product copy", () => {
@@ -214,19 +232,58 @@ describe("AI Products briefs", () => {
 
     expect(publicCopy).not.toMatch(/pre-GA|preGA|general.?availab/i);
     expect(publicCopy).not.toMatch(
-      /\b(Cadre|Spark|Spot|Vantage|Navigate|AI Triage)\b/,
+      /\b(Cadre|Spark|Spot|Vantage|Navigate|Knowledge|AI Triage)\b/,
     );
     expect(publicCopy).not.toMatch(/Still coming/i);
+
+    const visibleCopy = [
+      portfolioThesis.title,
+      portfolioThesis.lead,
+      ...portfolioThesis.tags,
+      ...portfolioThesis.loop.map((step) => step.detail),
+      portfolioThesis.honestClaim,
+      portfolioThesis.agentAuthority,
+      ...productBriefs.flatMap((brief) => [
+        brief.name,
+        brief.tagline,
+        ...brief.chips,
+        ...brief.capabilities,
+        brief.shipped,
+      ]),
+      ...defaultAiProductEntries.flatMap((entry) => [
+        entry.label,
+        entry.phase,
+        entry.summary ?? "",
+      ]),
+      softwareSchema.name,
+      softwareSchema.description,
+      ...(softwareSchema.keywords ?? []),
+      occupationSchema.description,
+      aboutFaqSchema.questions.map((item) => item.answer).join(" "),
+      readFileSync("public/llms.txt", "utf8"),
+    ].join("\n");
+
+    expect(visibleCopy).not.toMatch(/Client Toolbox/);
+    expect(visibleCopy).not.toMatch(/Service Desk Toolbox/);
+    expect(visibleCopy).not.toMatch(/Incident Buddy/);
+    expect(visibleCopy).not.toMatch(/SD Toolbox/);
+    expect(visibleCopy).not.toMatch(/\bvITM\b/);
+    expect(visibleCopy).not.toMatch(/\bIris\b/);
+    expect(visibleCopy).not.toMatch(/Iris OS|irisOS/i);
+    expect(visibleCopy).not.toMatch(/\bProxima\b/);
+    expect(visibleCopy).not.toMatch(/accessAI/);
   });
 
-  it("only briefs the five public products", () => {
+  it("only briefs the seven public categories", () => {
     const ids = productBriefs.map((brief) => brief.id);
     expect(ids).toEqual([
-      "client-toolbox",
       "service-desk-toolbox",
+      "client-toolbox",
+      "deep-research",
       "iris",
-      "proxima",
+      "iris-os",
       "accessai",
+      "proxima",
     ]);
     expect(portfolioThesis).not.toHaveProperty("namedSeams");
   });
@@ -235,7 +292,7 @@ describe("AI Products briefs", () => {
     const ordered = orderProductBriefs([
       {
         id: "x",
-        label: "Iris",
+        label: "Multimodal Enterprise Agent",
         phase: "AI",
         summary: null,
         content: null,
@@ -246,6 +303,8 @@ describe("AI Products briefs", () => {
     ]);
     expect(ordered[0].id).toBe("iris");
     expect(ordered.map((brief) => brief.id)).toContain("client-toolbox");
+    expect(ordered.map((brief) => brief.id)).toContain("deep-research");
+    expect(ordered.map((brief) => brief.id)).toContain("iris-os");
   });
 
   it("renders thesis copy and at least one product brief", async () => {
@@ -263,21 +322,30 @@ describe("AI Products briefs", () => {
     expect(screen.queryByText(/14 normalized briefs/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/readiness ledger/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/owner toby/i)).not.toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Client Toolbox" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
     expect(
-      screen.getByText("Five products I led or shipped."),
+      screen.getByRole("tab", { name: "Service Delivery" }),
+    ).toHaveAttribute("aria-selected", "true");
+    for (const title of PUBLIC_CATEGORY_TITLES) {
+      expect(screen.getByRole("tab", { name: title })).toBeInTheDocument();
+    }
+    expect(
+      screen.getByText("Product categories I've shipped in."),
     ).toBeInTheDocument();
     expect(screen.queryByText(/named seams/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/second catalog/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/also in the loop/i)).not.toBeInTheDocument();
     expect(
-      screen.getByText(/vITM workspace that turns identity/i),
+      screen.getByText(/technician workspace that routes tickets/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/What I shipped/i)).toBeInTheDocument();
+    expect(screen.queryByText("Client Toolbox")).not.toBeInTheDocument();
+    expect(screen.queryByText("Iris")).not.toBeInTheDocument();
+    expect(screen.queryByText("Proxima")).not.toBeInTheDocument();
+    expect(screen.queryByText("accessAI")).not.toBeInTheDocument();
     expect(screen.queryByText(/pre-GA/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/MSP/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Cadre")).not.toBeInTheDocument();
+    expect(screen.queryByText("Spark")).not.toBeInTheDocument();
     expect(screen.queryByText(/still coming/i)).not.toBeInTheDocument();
     expect(
       screen.queryByText(/Cadre|Vantage|AI Triage/i),

--- a/src/components/portfolio/AiProductsPanel.tsx
+++ b/src/components/portfolio/AiProductsPanel.tsx
@@ -54,17 +54,17 @@ export default function AiProductsPanel({ entries }: AiProductsPanelProps) {
         <div className="flex items-end justify-between gap-4 mb-4">
           <div>
             <span className="font-mono text-xs text-muted-foreground uppercase tracking-widest">
-              Products
+              Categories
             </span>
             <p className="text-sm text-muted-foreground mt-1">
-              Five products I led or shipped.
+              Product categories I've shipped in.
             </p>
           </div>
         </div>
 
         <div
           role="tablist"
-          aria-label="AI products"
+          aria-label="AI product categories"
           className="flex flex-wrap gap-2 mb-6"
         >
           {briefs.map((brief) => {

--- a/src/data/ai-products.ts
+++ b/src/data/ai-products.ts
@@ -71,10 +71,37 @@ export const portfolioThesis: PortfolioThesis = {
 
 export const productBriefs: ProductBrief[] = [
   {
-    id: "client-toolbox",
-    name: "Client Toolbox",
+    id: "service-desk-toolbox",
+    name: "Service Delivery",
     tagline:
-      "A vITM workspace that turns identity, endpoint, and security evidence into a client book you can explain — scores, gaps, and next conversations.",
+      "A technician workspace that routes tickets into guided automations for identity, mail, and access work. Humans review before writeback.",
+    chips: [
+      "Ticket-linked automations",
+      "Guided runbooks",
+      "Human writeback",
+    ],
+    loopStages: ["sense", "operate"],
+    capabilities: [
+      "Guided automations for common identity, mail, and access work",
+      "Ticket context stays attached to the run",
+      "Humans review before anything is written back",
+      "Built with the people who close the tickets",
+    ],
+    shipped:
+      "I shipped this with the service desk team: ticket-linked automations that do not write back until a human reviews.",
+    stack: [
+      "Rewst",
+      "Halo",
+      "Azure AI Foundry",
+      "Microsoft Teams",
+      "TypeScript",
+    ],
+  },
+  {
+    id: "client-toolbox",
+    name: "Portfolio Management",
+    tagline:
+      "A workspace that turns identity, endpoint, and security evidence into a client book you can explain — scores, gaps, and next conversations.",
     chips: [
       "Assigned client book",
       "Explainable scores",
@@ -88,7 +115,7 @@ export const productBriefs: ProductBrief[] = [
       "A governed AI teammate that drafts; source systems stay authoritative",
     ],
     shipped:
-      "Designed and shipped the evidence spine: collection, scoring, and the workspace used to review a client.",
+      "I stewarded this workspace from idea through scoping, iteration, and review to completion: collection, scoring, and the client book used to review evidence.",
     stack: [
       "React",
       "TypeScript",
@@ -101,20 +128,24 @@ export const productBriefs: ProductBrief[] = [
     ],
   },
   {
-    id: "service-desk-toolbox",
-    name: "Service Desk Toolbox + Incident Buddy",
+    id: "deep-research",
+    name: "Deep Research / Technical investigations",
     tagline:
-      "Technician app, built with the service desk team, that routes tickets into guided automations and an investigation assistant. Humans review before writeback.",
-    chips: ["Ticket-linked automations", "Incident Buddy", "Human writeback"],
+      "An investigation assistant for incidents and technical questions across identity, endpoint, mail, and operations. People review findings before anything is written back.",
+    chips: [
+      "Cross-domain investigation",
+      "Cited findings",
+      "Human writeback",
+    ],
     loopStages: ["sense", "operate"],
     capabilities: [
-      "Guided automations for common identity, mail, and access work",
-      "Ticket context stays attached to the run",
-      "Incident Buddy investigates across the usual IT operations domains",
-      "Humans review findings before anything is written back",
+      "Investigates across identity, endpoint, mail, and related operations domains",
+      "Ticket and source context stay attached to the run",
+      "Findings a person can check before they act",
+      "Nothing is written back until a human reviews",
     ],
     shipped:
-      "Shipped with the service desk team: ticket-linked automations and an investigation assistant that does not write back until a human reviews.",
+      "I shipped an investigation assistant that drafts findings across the usual operations domains and waits for a human before writeback.",
     stack: [
       "Rewst",
       "Halo",
@@ -125,10 +156,10 @@ export const productBriefs: ProductBrief[] = [
   },
   {
     id: "iris",
-    name: "Iris",
+    name: "Multimodal Enterprise Agent",
     tagline:
-      "A company-grounded assistant in Teams and Iris OS. It researches, remembers, and drafts — and only acts after someone approves.",
-    chips: ["Teams + Iris OS", "Company context", "Approval-gated action"],
+      "The assistant people talk to in Teams. It researches, remembers, and drafts — and only acts after someone approves.",
+    chips: ["Teams", "Company context", "Approval-gated action"],
     loopStages: ["sense", "operate"],
     capabilities: [
       "Answers grounded in handbook, people, tickets, and approved channels",
@@ -137,7 +168,33 @@ export const productBriefs: ProductBrief[] = [
       "Specialists sit behind the same approval gate",
     ],
     shipped:
-      "Led Iris: the Teams bot, the Iris OS shell, and the approval-gated action path.",
+      "I led the assistant people talk to: the Teams bot, company-grounded answers, and the approval-gated action path.",
+    stack: [
+      "TypeScript",
+      "Azure Functions",
+      "Azure AI Foundry",
+      "Microsoft Graph",
+      "Halo",
+      "Rewst",
+      "Bot Framework",
+      "Microsoft Teams",
+    ],
+  },
+  {
+    id: "iris-os",
+    name: "Agentic Application OS Platform",
+    tagline:
+      "The agentic application OS I stewarded from idea through to completion: the shell where governed agents and apps run, with one approval path.",
+    chips: ["Application shell", "Shared context", "Approval-gated action"],
+    loopStages: ["sense", "operate"],
+    capabilities: [
+      "Hosts assistants and specialists behind one application shell",
+      "Shared company context, memory, and skills",
+      "Approval-gated action for anything that writes or spends",
+      "One OS for the agents and apps, not a pile of disconnected chat windows",
+    ],
+    shipped:
+      "I stewarded this OS platform from idea through scoping, iteration, and review to completion — the shell the assistants run in, with a single approval-gated action path.",
     stack: [
       "React",
       "TypeScript",
@@ -146,12 +203,36 @@ export const productBriefs: ProductBrief[] = [
       "Microsoft Graph",
       "Halo",
       "Rewst",
-      "Bot Framework",
+      "Microsoft Teams",
+    ],
+  },
+  {
+    id: "accessai",
+    name: "Agent and Compute Federation Platform",
+    tagline:
+      "Control plane for which identities, models, agents, and tools may run — plus cost, audit, evaluation, and rollback. Not an end-user assistant.",
+    chips: ["Multi-model governance", "Tenant-safe execution", "Cost + audit"],
+    loopStages: ["govern"],
+    capabilities: [
+      "Routes work across Azure OpenAI, Anthropic, OpenAI, and Foundry",
+      "Fail-closed identity and tenant isolation",
+      "Records runs, cost, evals, and promotions",
+      "Governs what may run; it is not an end-user assistant",
+    ],
+    shipped:
+      "I helped define the federation model — which identities, models, agents, and tools may run, under whose authority, and how a run is audited, evaluated, and rolled back.",
+    stack: [
+      "TypeScript",
+      "Hono",
+      "React",
+      "PostgreSQL",
+      "Azure Container Apps",
+      "Key Vault",
     ],
   },
   {
     id: "proxima",
-    name: "Proxima",
+    name: "DevOps Teammate",
     tagline:
       "Takes approved engineering work and returns a reviewed branch, a draft PR, and green CI. The model never marks its own work done.",
     chips: [
@@ -167,7 +248,7 @@ export const productBriefs: ProductBrief[] = [
       "Humans keep merge, deploy, and anything that spends money",
     ],
     shipped:
-      "Helped design the draft-mode delivery loop: agents implement and verify against real CI; people still merge.",
+      "I helped design the draft-mode delivery loop: a teammate that implements and verifies against real CI; people still merge.",
     stack: [
       "TypeScript",
       "Python",
@@ -176,30 +257,6 @@ export const productBriefs: ProductBrief[] = [
       "Node",
       "Azure",
       "Supabase",
-    ],
-  },
-  {
-    id: "accessai",
-    name: "accessAI",
-    tagline:
-      "Control plane for which identities, models, agents, and tools may run — plus cost, audit, evaluation, and rollback.",
-    chips: ["Multi-model governance", "Tenant-safe execution", "Cost + audit"],
-    loopStages: ["govern"],
-    capabilities: [
-      "Routes work across Azure OpenAI, Anthropic, OpenAI, and Foundry",
-      "Fail-closed identity and tenant isolation",
-      "Records runs, cost, evals, and promotions",
-      "Governs what may run; it is not an end-user assistant",
-    ],
-    shipped:
-      "Helped define the control-plane model — what may run, under whose authority, and how it gets promoted.",
-    stack: [
-      "TypeScript",
-      "Hono",
-      "React",
-      "PostgreSQL",
-      "Azure Container Apps",
-      "Key Vault",
     ],
   },
 ];

--- a/src/data/timeline-tracks.ts
+++ b/src/data/timeline-tracks.ts
@@ -101,57 +101,81 @@ We also launched a new Inventory system with a much better UX and started stacki
 /** Lightweight AI Product pills so the DB and fallback share the same track. */
 export const defaultAiProductEntries: TimelineItem[] = [
   {
-    id: "ai-client-toolbox",
-    label: "Client Toolbox",
-    phase: "Evidence-backed client reviews",
-    summary:
-      "A vITM workspace that turns identity, endpoint, and security evidence into a client book you can explain.",
-    content: null,
-    dot_position: 72,
-    track: "ai-products",
-    entry_key: "client-toolbox",
-  },
-  {
     id: "ai-service-desk-toolbox",
-    label: "Service Desk Toolbox",
-    phase: "Technician work + Incident Buddy",
+    label: "Service Delivery",
+    phase: "Technician automations",
     summary:
-      "Ticket-linked automations and an investigation assistant, built with the service desk team.",
+      "Ticket-linked automations for identity, mail, and access; humans review before writeback.",
     content: null,
-    dot_position: 68,
+    dot_position: 70,
     track: "ai-products",
     entry_key: "service-desk-toolbox",
   },
   {
+    id: "ai-client-toolbox",
+    label: "Portfolio Management",
+    phase: "Evidence-backed client reviews",
+    summary:
+      "A workspace that turns identity, endpoint, and security evidence into a client book you can explain.",
+    content: null,
+    dot_position: 78,
+    track: "ai-products",
+    entry_key: "client-toolbox",
+  },
+  {
+    id: "ai-deep-research",
+    label: "Deep Research / Technical investigations",
+    phase: "Technical investigations",
+    summary:
+      "Investigation assistant for incidents and technical questions; people review findings before writeback.",
+    content: null,
+    dot_position: 66,
+    track: "ai-products",
+    entry_key: "deep-research",
+  },
+  {
     id: "ai-iris",
-    label: "Iris",
+    label: "Multimodal Enterprise Agent",
     phase: "Governed employee AI",
     summary:
-      "Company-grounded assistant with durable skills and approval-gated action.",
+      "The assistant people talk to, with durable skills and approval-gated action.",
     content: null,
-    dot_position: 80,
+    dot_position: 82,
     track: "ai-products",
     entry_key: "iris",
   },
   {
-    id: "ai-proxima",
-    label: "Proxima",
-    phase: "Governed agentic engineering",
-    summary: "Draft PRs and green CI for approved work; humans still merge.",
+    id: "ai-iris-os",
+    label: "Agentic Application OS Platform",
+    phase: "Application OS",
+    summary:
+      "The agentic application OS I stewarded: the shell where governed agents and apps run.",
     content: null,
-    dot_position: 64,
+    dot_position: 86,
     track: "ai-products",
-    entry_key: "proxima",
+    entry_key: "iris-os",
   },
   {
     id: "ai-accessai",
-    label: "accessAI",
+    label: "Agent and Compute Federation Platform",
     phase: "AI control plane",
-    summary: "Control plane for models, agents, policy, cost, and audit.",
+    summary:
+      "Identities, models, agents, tools, cost, audit, evaluation, and rollback. Not an end-user assistant.",
     content: null,
-    dot_position: 58,
+    dot_position: 56,
     track: "ai-products",
     entry_key: "accessai",
+  },
+  {
+    id: "ai-proxima",
+    label: "DevOps Teammate",
+    phase: "Governed agentic engineering",
+    summary:
+      "Draft branch, draft PR, and green CI for approved work; humans still merge.",
+    content: null,
+    dot_position: 62,
+    track: "ai-products",
+    entry_key: "proxima",
   },
 ];
 

--- a/src/lib/seo.tsx
+++ b/src/lib/seo.tsx
@@ -586,17 +586,19 @@ export const occupationSchema: OccupationSchema = {
 
 export const softwareSchema: CreativeWorkSchema = {
   type: "CreativeWork",
-  name: "AI products John Christensen led or shipped",
+  name: "AI product categories John Christensen has shipped in",
   description:
     "Governed AI for the Enterprise work I ship. I built an app platform, several individual apps, and an agent and compute federation platform. Two of the app platforms I stewarded from idea through scoping, iteration, and review, and saw through to completion. Substantial products; not yet one uniformly integrated platform.",
   url: "/portfolio?track=ai-products",
   creator: "Jonathan Christensen",
   keywords: [
-    "Client Toolbox",
-    "Iris",
-    "Proxima",
-    "accessAI",
-    "Service Desk Toolbox",
+    "Service Delivery",
+    "Portfolio Management",
+    "Deep Research / Technical investigations",
+    "Multimodal Enterprise Agent",
+    "Agentic Application OS Platform",
+    "Agent and Compute Federation Platform",
+    "DevOps Teammate",
     "governed agents",
   ],
 };

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -73,7 +73,7 @@ const Portfolio = () => {
       return {
         title: "AI Products",
         description:
-          "AI work John Christensen led or shipped: Client Toolbox, Iris, Proxima, accessAI, and Service Desk Toolbox. Governed agents and evidence-preserving workflows.",
+          "Governed AI for the Enterprise work I ship. Categories: Service Delivery, Portfolio Management, Deep Research / Technical investigations, Multimodal Enterprise Agent, Agentic Application OS Platform, Agent and Compute Federation Platform, and DevOps Teammate.",
         url: "/portfolio?track=ai-products",
         keywords: RECRUITING_KEYWORDS,
       };

--- a/supabase/migrations/20260822170000_ai_product_category_labels.sql
+++ b/supabase/migrations/20260822170000_ai_product_category_labels.sql
@@ -1,0 +1,112 @@
+-- Recast public AI product timeline labels to stranger-readable categories.
+-- Internal entry_key slugs stay for routing. Owner / pre-GA / MSP copy is cleared.
+
+UPDATE public.timelines
+SET
+  description = 'Two tracks: AI Products (governed enterprise work) and Endpoint Logistics (provisioning transformation).'
+WHERE slug = 'provisioning-roadmap';
+
+UPDATE public.timeline_entries AS e
+SET
+  label = v.label,
+  phase = v.phase,
+  summary = v.summary,
+  content = NULL,
+  dot_position = v.dot_position,
+  order_index = v.order_index
+FROM public.timelines AS t,
+(
+  VALUES
+    (
+      'service-desk-toolbox',
+      'Service Delivery',
+      'Technician automations',
+      'Ticket-linked automations for identity, mail, and access; humans review before writeback.',
+      70,
+      0
+    ),
+    (
+      'client-toolbox',
+      'Portfolio Management',
+      'Evidence-backed client reviews',
+      'A workspace that turns identity, endpoint, and security evidence into a client book you can explain.',
+      78,
+      1
+    ),
+    (
+      'iris',
+      'Multimodal Enterprise Agent',
+      'Governed employee AI',
+      'The assistant people talk to, with durable skills and approval-gated action.',
+      82,
+      3
+    ),
+    (
+      'proxima',
+      'DevOps Teammate',
+      'Governed agentic engineering',
+      'Draft branch, draft PR, and green CI for approved work; humans still merge.',
+      62,
+      6
+    ),
+    (
+      'accessai',
+      'Agent and Compute Federation Platform',
+      'AI control plane',
+      'Identities, models, agents, tools, cost, audit, evaluation, and rollback. Not an end-user assistant.',
+      56,
+      5
+    )
+) AS v(entry_key, label, phase, summary, dot_position, order_index)
+WHERE e.timeline_id = t.id
+  AND t.slug = 'provisioning-roadmap'
+  AND e.entry_key = v.entry_key;
+
+INSERT INTO public.timeline_entries (
+  timeline_id,
+  label,
+  phase,
+  summary,
+  content,
+  dot_position,
+  order_index,
+  track,
+  entry_key
+)
+SELECT
+  t.id,
+  v.label,
+  v.phase,
+  v.summary,
+  NULL,
+  v.dot_position,
+  v.order_index,
+  'ai-products',
+  v.entry_key
+FROM public.timelines AS t
+CROSS JOIN (
+  VALUES
+    (
+      'Deep Research / Technical investigations',
+      'Technical investigations',
+      'Investigation assistant for incidents and technical questions; people review findings before writeback.',
+      66,
+      2,
+      'deep-research'
+    ),
+    (
+      'Agentic Application OS Platform',
+      'Application OS',
+      'The agentic application OS I stewarded: the shell where governed agents and apps run.',
+      86,
+      4,
+      'iris-os'
+    )
+) AS v(label, phase, summary, dot_position, order_index, entry_key)
+WHERE t.slug = 'provisioning-roadmap'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.timeline_entries AS existing
+    WHERE existing.timeline_id = t.id
+      AND existing.entry_key = v.entry_key
+  );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Public AI Products tiles now use stranger-readable **categories**, not internal product names. Review on `/portfolio?track=ai-products`.

## Seven public category titles

1. **Service Delivery**
2. **Portfolio Management**
3. **Deep Research / Technical investigations**
4. **Multimodal Enterprise Agent**
5. **Agentic Application OS Platform**
6. **Agent and Compute Federation Platform**
7. **DevOps Teammate**

Those titles are what appear on pills, cards, timeline labels, SEO/JSON-LD, and `public/llms.txt`.

## Internal names are off the page

No tiles, footer, llms, or JSON-LD keywords for Spark, Vantage, Cadre, Spot, Navigate, Knowledge, AI Triage, Client Toolbox, Iris, Iris OS / irisOS, Proxima, accessAI, Incident Buddy, vITM, SD Toolbox, or Service Desk Toolbox. Routing slugs may stay; every user-visible `name` / heading / label / timeline entry / meta description uses the category.

Investigations are split out of Service Delivery. The assistant people talk to is split from the agentic application OS. Federation keeps the control-plane substance (identities, models, agents, tools, cost, audit, eval, rollback — not an end-user assistant). DevOps Teammate keeps draft branch / draft PR / green CI / human merge, and never marks its own work done.

## Locked copy unchanged

- Thesis heading: **Governed AI for the Enterprise work I ship**
- Thesis lead core claim (app platform, individual apps, federation; two platforms stewarded through to completion; governed AI IT leaders actually run; substantial products, not yet one uniformly integrated platform)
- No MSP identity, no pre-GA/GA, no Proven/Still coming/Later ledger
- Agents advise/draft/test; people keep merge, deploy, production authority
- Occupation headline “AI Automation Engineer”
- Results case-study cards and Endpoint Logistics year pills

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee6b46ed-f5f6-41f3-85f0-561d51901e41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee6b46ed-f5f6-41f3-85f0-561d51901e41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

